### PR TITLE
fix: Auto-create dbs/ directory when missing

### DIFF
--- a/src/open_ire/pipelines.py
+++ b/src/open_ire/pipelines.py
@@ -1,3 +1,4 @@
+import logging
 import mimetypes
 from datetime import datetime
 from pathlib import Path
@@ -25,6 +26,8 @@ from open_ire.errors import (
 from open_ire.items import ArticleItem, OAPublicationItem
 from open_ire.models import Article, ArticleFile, ArticleFileReference, OAPublication
 from open_ire.sharepoint import SharePoint
+
+logger = logging.getLogger(__name__)
 
 # Remember to add your pipelines to the `settings.ITEM_PIPELINES` list
 
@@ -61,6 +64,11 @@ class SQLModelPipeline:
         if not db_path:
             conf = "OPEN_IRE_DATABASE_FILE"
             raise ConfigurationError(conf)
+
+        parent_dir = Path(db_path).parent
+        if not parent_dir.exists():
+            parent_dir.mkdir(parents=True, exist_ok=True)
+            logger.info("Created OPEN_IRE database directory at %s", parent_dir)
 
         if not (files_base_path := crawler.settings.get("FILES_STORE", "")):
             conf = "FILES_STORE"
@@ -435,6 +443,11 @@ class OAPPublicationSQLModelPipeline:
         if not db_path:
             conf = "OPEN_IRE_DATABASE_FILE"
             raise ConfigurationError(conf)
+
+        parent_dir = Path(db_path).parent
+        if not parent_dir.exists():
+            parent_dir.mkdir(parents=True, exist_ok=True)
+            logger.info("Created OPEN_IRE database directory at %s", parent_dir)
 
         return cls(db_path)
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,5 +1,6 @@
 from collections.abc import Generator
 from datetime import date
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -12,6 +13,7 @@ from open_ire.models import Article, ArticleFile, ArticleFileReference
 from open_ire.pipelines import (
     DuplicatesPipeline,
     SQLModelPipeline,
+    OAPPublicationSQLModelPipeline,
     SharePointPipeline,
 )
 
@@ -262,6 +264,24 @@ class TestSQLModelPipeline:
             file_refs = session.exec(select(ArticleFileReference)).all()
             assert len(file_refs) == 1
 
+    def test_from_crawler_creates_missing_db_parent_dir(self, tmp_path: Path):
+        from types import SimpleNamespace
+        missing_db = str(tmp_path / "missing_parent" / "open_ire.db")
+        crawler = SimpleNamespace(settings={"OPEN_IRE_DATABASE_FILE": missing_db,
+                                            "FILES_STORE": str(tmp_path)})
+        pipeline = SQLModelPipeline.from_crawler(crawler)  # type: ignore[arg-type]
+        assert Path(missing_db).parent.exists()
+
+class TestOAPPublicationSQLModelPipeline:
+    """Tests the processing and validation logic of the OAPPublicationSQLModelPipeline."""
+
+    def test_from_crawler_creates_missing_db_parent_dir(self, tmp_path: Path):
+        from types import SimpleNamespace
+        missing_db = str(tmp_path / "missing_parent" / "open_ire.db")
+        crawler = SimpleNamespace(settings={"OPEN_IRE_DATABASE_FILE": missing_db,
+                                            "FILES_STORE": str(tmp_path)})
+        pipeline = OAPPublicationSQLModelPipeline.from_crawler(crawler)  # type: ignore[arg-type]
+        assert Path(missing_db).parent.exists()
 
 class TestSharePointPipeline:
     """Tests the SharePoint pipeline for file uploads."""


### PR DESCRIPTION
Or would it be better to either 1) set `OPEN_IRE_DATABASE_FILE` in `src/open-ire/settings/base.py` to `FILES_STORE + "open_ire.db"` or 2) silently create `OPEN_IRE_DATABASE_FILE` parent directory if it doesn't exist?