### PR TITLE
build: Cleaner default/dev environment separation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,18 +151,20 @@ platforms = ["osx-arm64", "osx-64", "win-64"]
 [tool.pixi.pypi-dependencies]
 open_ire = { path = ".", editable = true }
 
+[tool.pixi.feature.dev.pypi-dependencies]
+open_ire = { path = ".", editable = true, extras = ["dev"] }
+
+[tool.pixi.feature.docs.pypi-dependencies]
+open_ire = { path = ".", editable = true, extras = ["docs"] }
+
 [tool.pixi.environments]
 default = { solve-group = "default" }
-all = { features = ["all", "dev", "docs"], solve-group = "default" }
+all = { features = ["dev", "docs"], solve-group = "default" }
 dev = { features = ["dev"], solve-group = "default" }
 docs = { features = ["docs"], solve-group = "default" }
 
 [tool.pixi.tasks]
 dotenv = "mkdir output && cp .env.example .env"
-pre-commit = "pre-commit run"
-pre-commit-all = "pre-commit run --all-files"
-pre-commit-install = "pre-commit install"
-test = "python -m pytest -ra --cov=open_ire"
 
 [tool.pixi.tasks.start]
 args = ["spider"]
@@ -180,6 +182,14 @@ cmd = "scrapy crawl {{ spider }} -a page={{ page }} -a terms=\"{{ terms }}\""
 args = ["spider", "faculty_file"]
 cmd = "scrapy crawl oap_{{ spider }} -a faculty_csv={{ faculty_file }}"
 
+[tool.pixi.feature.dev.tasks]
+pre-commit = "pre-commit run"
+pre-commit-all = "pre-commit run --all-files"
+pre-commit-install = "pre-commit install"
+test = "python -m pytest -ra --cov=open_ire"
+
 [tool.pixi.dependencies]
 pixi-pycharm = ">=0.0.8,<0.0.9"
+
+[tool.pixi.feature.dev.dependencies]
 pre-commit = ">=4.2.0,<5"


### PR DESCRIPTION
1. `pixi install -e dev` now installs the optional pypi dependencies
2. `pre-commit` is only installed for `dev` environment
3. Development-specific pixi commands are limited to `dev` environment
