### PR TITLE
Create foundation for persistent fixtures and pytest-snapshot

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 exclude: |
   (?x)^(
     docs/conf.py|
+    tests/fixtures/|
     pixi.lock
   )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "pytest-asyncio",
     "pytest-cov",
     "pytest-mock",
+    "pytest-snapshot",
     "pytest-xdist",
     "pytest",
     "types-python-dateutil",

--- a/src/open_ire/middlewares.py
+++ b/src/open_ire/middlewares.py
@@ -1,0 +1,67 @@
+import hashlib
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Self
+
+from scrapy import Spider
+from scrapy.crawler import Crawler
+from scrapy.http import HtmlResponse, Response
+
+from open_ire.errors import ConfigurationError
+
+
+class SaveResponsesMiddleware:
+    """
+    A spider middleware to save all responses and their request metadata to files
+    for offline testing.
+    """
+
+    def __init__(self, save_dir: Path):
+        self.save_dir = save_dir
+        self.save_dir.mkdir(parents=True, exist_ok=True)
+
+    @classmethod
+    def from_crawler(cls, crawler: Crawler) -> Self:
+        """Create an instance of the middleware from crawler settings."""
+        config = "SAVE_RESPONSES_DIR"
+        save_dir_str = crawler.settings.get(config)
+        if not save_dir_str:
+            raise ConfigurationError(config)
+
+        return cls(save_dir=Path(save_dir_str))
+
+    def process_spider_input(self, response: Response, spider: Spider) -> None:
+        """Save the response body and request metadata to files."""
+        # Create a stable filename from the response URL
+        url_hash = hashlib.sha1(response.url.encode("utf-8")).hexdigest()
+        timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")
+        base_path = self.save_dir / f"{spider.name}_{timestamp}_{url_hash}"
+
+        # 1. Save the response content
+        if isinstance(response, HtmlResponse):
+            response_path = base_path.with_suffix(".html")
+        else:
+            response_path = base_path.with_suffix(".txt")
+        response_path.write_bytes(response.body)
+
+        # 2. Save the request metadata
+        metadata = {
+            "url": response.url,
+            "method": response.request.method if response.request else "GET",
+            "status": response.status,
+            "headers": dict(response.request.headers.to_unicode_dict()) if response.request else {},
+            "cb_kwargs": response.request.cb_kwargs if response.request else {},
+        }
+        meta_path = base_path.with_suffix(".json")
+        meta_path.write_text(json.dumps(metadata, indent=2))
+
+        spider.logger.info(
+            "Saved response for URL %s to %s and %s",
+            response.url,
+            response_path,
+            meta_path,
+        )
+
+        # Let the response continue through the processing chain
+        return  # noqa: PLR1711

--- a/src/open_ire/settings/base.py
+++ b/src/open_ire/settings/base.py
@@ -17,7 +17,19 @@ USER_AGENT = requests_utils.default_user_agent()
 # Obey robots.txt rules
 ROBOTSTXT_OBEY = True
 
-# Configure item pipelines
+# ============================================================================
+# MIDDLEWARES
+# ============================================================================
+# See https://docs.scrapy.org/en/latest/topics/spider-middleware.html
+SPIDER_MIDDLEWARES = {
+    "open_ire.middlewares.SaveResponsesMiddleware": None,  # disabled
+}
+
+SAVE_RESPONSES_DIR = "tests/fixtures/responses"
+
+# =============================================================================
+# ITEM PIPELINES
+# =============================================================================
 # See https://docs.scrapy.org/en/latest/topics/item-pipeline.html
 ITEM_PIPELINES = {
     "open_ire.pipelines.DuplicatesPipeline": 100,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import pytest
+from scrapy.http import Request, TextResponse
+
+
+@pytest.fixture(scope="session")
+def fixtures_dir(pytestconfig) -> Path:
+    # pytestconfig.rootpath is the project root (where pytest was invoked)
+    return Path(pytestconfig.rootpath) / "tests" / "fixtures"
+
+
+@pytest.fixture
+def response_from_file(fixtures_dir: Path):
+    """A fixture that returns a function to create Scrapy responses from a file."""
+
+    def _create_response_from_file(file_path: Path, url: str) -> TextResponse:
+        return TextResponse(
+            url=url,
+            request=Request(url=url),
+            body=(fixtures_dir / file_path).read_text(),
+            encoding="utf-8",
+        )
+
+    return _create_response_from_file

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+import pytest
+from scrapy.crawler import Crawler
+from scrapy.http import HtmlResponse, Request
+from scrapy.spiders import Spider
+from scrapy.settings import Settings
+
+from open_ire.errors import ConfigurationError
+from open_ire.middlewares import SaveResponsesMiddleware
+
+
+class TestMiddlewares:
+    def test_from_crawler_raises_not_configured_if_setting_is_missing(self):
+        crawler = Crawler(Spider, settings=Settings())
+        with pytest.raises(ConfigurationError):
+            SaveResponsesMiddleware.from_crawler(crawler)
+
+    def test_middleware_saves_response_correctly(self, tmp_path: Path):
+        save_dir = tmp_path / "responses"
+        middleware = SaveResponsesMiddleware(save_dir=save_dir)
+
+        # Create a dummy spider and response for the test
+        spider = Spider(name="test_spider")
+        url = "http://example.com/test-page"
+        body = b"<html><body>Test content</body></html>"
+        request = Request(url)
+        response = HtmlResponse(url, request=request, body=body)
+
+        # The middleware should return None and not stop the response
+        assert middleware.process_spider_input(response, spider) is None  # type: ignore[func-returns-value]
+
+        # Check that the directory was created
+        assert save_dir.exists()
+        assert save_dir.is_dir()
+
+        # Check that both request and response files were created
+        files = list(save_dir.iterdir())
+        assert files and all(f.name.endswith((".txt", ".html", ".json")) for f in files)
+
+        # Check that the file content is correct
+        html_file = next((f for f in files if f.name.endswith(".html")), None)
+        assert html_file is not None
+        assert html_file.read_bytes() == body
+
+        json_file = next((f for f in files if f.name.endswith(".json")), None)
+        assert json_file is not None
+        import json
+        parsed = json.loads(json_file.read_text())
+        assert parsed.get("url") == request.url


### PR DESCRIPTION
The `SaveResponsesMiddleware` allows saving actual responses from the API calls, which could then be made into persistent fixtures (in `tests/fixtures`) to use for testing. That way we are not just creating quick mockups, but using real world data.

Adding `pytest-snapshot` makes it possible to save serialized representation of objects like `ArticleItem` to use in regression tests. That way when working on large-scale refactoring (like with #28), we have a safety net.[*]

[*]: The code in this PR was part of my workflow for doing #28 refactor, but I thought it would make more sense to split things into two separate PRs.