### PR TITLE
Remove local file copies after SharePoint upload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 ENVIRONMENT=<development|production>
+SHAREPOINT_BASE_PATH=<sharepoint_base_path>
 SHAREPOINT_CLIENT_ID=<application_id>
 SHAREPOINT_CLIENT_SECRET=<application_client_secret>
 SHAREPOINT_SITE_ID=<sharepoint_site_id>

--- a/src/open_ire/pipelines.py
+++ b/src/open_ire/pipelines.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import mimetypes
 from pathlib import Path
 from typing import Any, Self
@@ -435,6 +436,14 @@ class SharePointPipeline:
 
         return cls(sharepoint_base_path, local_base_path)
 
+    @staticmethod
+    def _remove_local_file(local_file_path: Path) -> None:
+        try:
+            local_file_path.unlink()
+        except OSError as e:
+            msg = f"Failed to remove local file {local_file_path}: {e}"
+            logger.warning(msg)
+
     def open_spider(self, spider: Spider) -> None:
         pass
 
@@ -454,12 +463,25 @@ class SharePointPipeline:
         try:
             msg = f"Uploading file to SharePoint: {local_file_path} -> {sharepoint_path}"
             spider.logger.info(msg)
+
             upload_result = await self.sharepoint.upload_file(local_file_path, sharepoint_path)
             if upload_result.location:
                 drive_item = await self.sharepoint.get_item(sharepoint_path)
 
-                if drive_item and drive_item.web_url:
+                if not drive_item:
+                    msg = f"Failed to confirm SharePoint upload: {local_file_path}"
+                    raise RuntimeError(msg)
+
+                if drive_item.web_url:
                     store_url = drive_item.web_url
+
+                local_size = local_file_path.stat().st_size
+                remote_size = drive_item.size or 0.0
+                if math.isclose(local_size, remote_size, rel_tol=0.01, abs_tol=1024.0):
+                    local_file_path.unlink()
+                else:
+                    msg = f"Local file size ({local_file_path}) does not match remote ({store_url})"
+                    spider.logger.error(msg)
 
         except Exception as e:
             msg = f"Error uploading file {local_file_path}: {e}"

--- a/src/open_ire/settings/base.py
+++ b/src/open_ire/settings/base.py
@@ -1,3 +1,5 @@
+import os
+
 from requests import utils as requests_utils
 
 # Scrapy settings for open_ire project
@@ -70,7 +72,7 @@ OPEN_IRE_SEARCH_TERMS = [
     "washington sea grant",
     "washington.edu",
 ]
-SHAREPOINT_BASE_PATH = "open_ire"
+SHAREPOINT_BASE_PATH = os.getenv("SHAREPOINT_BASE_PATH", "open_ire")
 OPEN_IRE_DATABASE_FILE = "dbs/open_ire.db"
 OPEN_IRE_DEFAULT_TERMS = ",".join(OPEN_IRE_SEARCH_TERMS)
 OPEN_IRE_SKIP_EXISTING = False

--- a/src/open_ire/spiders/epa.py
+++ b/src/open_ire/spiders/epa.py
@@ -33,7 +33,7 @@ class EPASpider(Spider):
         self.start_urls = [
             (
                 "https://cfpub.epa.gov/si/si_public_search_results.cfm?"
-                f"{urlencode({'keyword': term.strip(), **search_params})}"
+                f"{urlencode({'searchall': term.strip(), **search_params})}"
             )
             for term in terms.split(",")
         ]

--- a/tests/spiders/test_epa.py
+++ b/tests/spiders/test_epa.py
@@ -26,8 +26,8 @@ class TestEPASpider:
 
         assert spider.target_page == 3
         assert len(spider.start_urls) == 2
-        assert "keyword=education" in spider.start_urls[0]
-        assert "keyword=research" in spider.start_urls[1]
+        assert "searchall=education" in spider.start_urls[0]
+        assert "searchall=research" in spider.start_urls[1]
         assert "count=25" in spider.start_urls[0]
         assert "startIndex=51" in spider.start_urls[0]
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -413,3 +413,27 @@ class TestSharePointPipeline:
         assert result == item
         assert result.store_urls == [""]
         spider.logger.error.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_deletes_local_file(self, pipeline, spider, item, tmp_path):
+        """Local file should be deleted when remote size matches"""
+        local_file = tmp_path / "file.pdf"
+        local_file.write_text("A" * 1000)
+        item.files = [{"path": "file.pdf", "url": "https://example.com/file.pdf"}]
+
+        # Match
+        mock_drive_item = MagicMock()
+        mock_drive_item.web_url = "https://sharepoint.com/uploaded"
+        mock_drive_item.size = 1000
+        pipeline.sharepoint.upload_file = AsyncMock(return_value=MagicMock())
+        pipeline.sharepoint.get_item = AsyncMock(return_value=mock_drive_item)
+
+        await pipeline.process_item(item, spider)
+        assert not local_file.exists()  # delete local copy
+
+        # Mismatch
+        local_file.write_text("B" * 2000)
+        mock_drive_item.size = 5000
+        await pipeline.process_item(item, spider)
+        assert local_file.exists()  # preserve local copy
+        spider.logger.error.assert_called()


### PR DESCRIPTION
This PR resolves issue #41 and updates the EPA spider to align with a potentially recent change in their search engine. Before removing the local copy, we verify that the upload file size matches the local file size.