### PR TITLE
Update SearchSpider to use start() in lieu of deprecated start_requests()

### DIFF
--- a/src/open_ire/spiders/search.py
+++ b/src/open_ire/spiders/search.py
@@ -1,5 +1,5 @@
 import abc
-from collections.abc import Generator
+from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
 
@@ -20,7 +20,7 @@ class SearchSpider(Spider, metaclass=abc.ABCMeta):
 
     search_terms: list[str]
 
-    def start_requests(self) -> Generator[Request, None, None]:
+    async def start(self) -> AsyncIterator[Request]:
         for term in self.search_terms:
             if not term:
                 continue

--- a/tests/spiders/test_openalex.py
+++ b/tests/spiders/test_openalex.py
@@ -134,3 +134,12 @@ class TestOpenAlexSpider:
         parsed_url = urlparse(request.url)
         query_params = parse_qs(parsed_url.query)
         assert "display_name.search:Kemi Adeyemi" in query_params["filter"][0]
+
+    @pytest.mark.asyncio
+    async def test_start(self, spider) -> None:
+        requests = []
+        async for req in spider.start():
+            requests.append(req)
+        assert len(requests) == 1
+        assert isinstance(requests[0], Request)
+        assert "Kemi+Adeyemi" in requests[0].url


### PR DESCRIPTION
Resolves issue #50 

Reintroduces behavior removed in commit f6f4ac6 after identifying a regression.