### PR TITLE
Add DOINormalizationPipeline to ensure consistency

### DIFF
--- a/src/open_ire/pipelines.py
+++ b/src/open_ire/pipelines.py
@@ -34,6 +34,32 @@ logger = logging.getLogger(__name__)
 # Remember to add your pipelines to the `settings.ITEM_PIPELINES` list
 
 
+class DOINormalizationPipeline:
+    """
+    Normalizes DOI field format across all spiders for consistency.
+
+    Strips 'https://doi.org/' prefix from DOI field to store just the identifier,
+    while preserving the full URL format in the url field when appropriate.
+    """
+
+    @staticmethod
+    def _normalize_doi(doi: str | None) -> str | None:
+        """Extract just the DOI identifier from various formats."""
+        if not doi or not isinstance(doi, str) or not doi.strip():  # type: ignore[redundant-expr]
+            return None
+        doi = doi.strip()
+
+        # Strip https://doi.org/ prefix if present
+        if doi.startswith("https://doi.org/"):
+            return doi[16:]  # Remove "https://doi.org/" prefix
+
+        return doi
+
+    def process_item(self, item: ArticleItem, spider: Spider) -> ArticleItem:  # noqa: ARG002
+        item.doi = self._normalize_doi(item.doi)
+        return item
+
+
 class DuplicatesPipeline:
     """
     Drops duplicate items for a given spider session using the `reference` field.

--- a/src/open_ire/settings/base.py
+++ b/src/open_ire/settings/base.py
@@ -25,6 +25,8 @@ ITEM_PIPELINES = {
     # Filtering pipelines:
     "open_ire.pipelines.DuplicatesPipeline": 1,
     "open_ire.pipelines.SkipExistingPipeline": 2,
+    # Data normalization pipelines:
+    "open_ire.pipelines.DOINormalizationPipeline": 10,
     # Processing pipelines:
     "open_ire.pipelines.LocalFilePipeline": 100,
     "open_ire.pipelines.FileReferencePipeline": 200,

--- a/tests/spiders/test_openalex.py
+++ b/tests/spiders/test_openalex.py
@@ -122,7 +122,7 @@ class TestOpenAlexSpider:
     def test_build_item(self, spider, dummy_publication) -> None:
         item = spider._build_item(dummy_publication)
         assert isinstance(item, ArticleItem)
-        assert item.doi == "https://doi.org/10.1234/test.doi"
+        assert item.doi == "https://doi.org/10.1234/test.doi"  # Spider returns original DOI, pipeline normalizes it
         assert item.title == "A Study on Testing"
         assert item.extra["journal_name"] == "Journal of Testing"
         assert item.authors == "Alice Smith, Bob Jones"

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -13,6 +13,7 @@ from sqlmodel import Session, select
 from open_ire.items import ArticleItem
 from open_ire.models import Article, ArticleFile, ArticleFileReference
 from open_ire.pipelines import (
+    DOINormalizationPipeline,
     DuplicatesPipeline,
     SQLModelPipeline,
     SharePointPipeline,
@@ -76,6 +77,63 @@ def spider() -> Spider:
     mock_spider.crawler = mock_crawler
 
     return mock_spider
+
+
+class TestDOINormalizationPipeline:
+    """Tests the DOI normalization pipeline."""
+
+    @pytest.fixture
+    def pipeline(self):
+        """Create a pipeline instance for testing."""
+        return DOINormalizationPipeline()
+
+    def test_normalize_full_doi_url(self, pipeline, spider, item):
+        """Test normalizing a full DOI URL."""
+        item.doi = " https://doi.org/10.1234/test.doi"
+
+        result = pipeline.process_item(item, spider)
+
+        assert result.doi == "10.1234/test.doi"
+
+    def test_normalize_already_normalized_doi(self, pipeline, spider, item):
+        """Test that already normalized DOIs are unchanged."""
+        item.doi = "10.1234/test.doi "
+
+        result = pipeline.process_item(item, spider)
+
+        assert result.doi == "10.1234/test.doi"
+
+    def test_normalize_none_doi(self, pipeline, spider, item):
+        """Test that None DOI values are handled correctly."""
+        item.doi = None
+
+        result = pipeline.process_item(item, spider)
+
+        assert result.doi is None
+
+    def test_normalize_empty_string_doi(self, pipeline, spider, item):
+        """Test that empty string DOI values are normalized to None."""
+        item.doi = ""
+
+        result = pipeline.process_item(item, spider)
+
+        assert result.doi is None
+
+    def test_normalize_whitespace_only_doi(self, pipeline, spider, item):
+        """Test that whitespace-only DOI values are normalized to None."""
+        item.doi = "   "
+
+        result = pipeline.process_item(item, spider)
+
+        assert result.doi is None
+
+    def test_normalize_non_string_doi(self, pipeline, spider, item):
+        """Test that non-string DOI values are normalized to None."""
+        item.doi = 12345
+
+        result = pipeline.process_item(item, spider)
+
+        assert result.doi is None
 
 
 class TestDuplicatesPipeline:


### PR DESCRIPTION
- Add DOINormalizationPipeline to centrally normalize DOI formats across all spiders
- Strip "https://doi.org/" prefix from DOI field to store just the identifier
- Handle edge cases: None values, empty strings, and whitespace-only strings
- Configure pipeline at priority 10 in processing chain after filtering