### PR TITLE
Clean up author search functionality for OAP spiders

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ For detailed development setup, including pre-commit hooks, please see
 ## Running
 
 This project includes spiders for crawling repositories using two main methods:
-a list of keywords or a CSV file of faculty names.
+a list of keywords or a CSV file of author names.
 
 ### Search by Keyword
 
@@ -109,20 +109,20 @@ For example, to search the `eric` repository:
 pixi run terms-search eric "ocean acidification,coral bleaching"
 ```
 
-### Search by Faculty
+### Search by Author
 
-To run a spider that supports searching by author against a list of faculty, use
-the `faculty-search` command. This requires a CSV file with `FirstName`,
+To run a spider that supports searching by author against a list of authors, use
+the `author-search` command. This requires a CSV file with `FirstName`,
 `LastName`, and `Email` columns.
 
 ```bash
-pixi run faculty-search <spider_name> <path_to_csv>
+pixi run author-search <spider_name> <path_to_csv>
 ```
 
-For example, to search `openalex` using a faculty file:
+For example, to search `openalex` using an author file:
 
 ```bash
-pixi run faculty-search openalex data/faculty.csv
+pixi run author-search openalex data/authors.csv
 ```
 
 ## Contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "msgraph-sdk",
+    "nameparser",
     "pandas",
     "playwright",
     "python-dateutil",
@@ -41,6 +42,7 @@ dev = [
     "pytest-xdist",
     "pytest",
     "types-python-dateutil",
+    "types-nameparser",
 ]
 docs = [
     "jupyter-book",
@@ -99,6 +101,10 @@ disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
 module = "msgraph_core.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "nameparser"
 ignore_missing_imports = true
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,9 +166,9 @@ docs = { features = ["docs"], solve-group = "default" }
 [tool.pixi.tasks.dotenv]
 cmd = "mkdir output && cp .env.example .env"
 
-[tool.pixi.tasks.faculty-search]
-args = ["spider", "faculty_csv"]
-cmd = "scrapy crawl {{ spider }} -a faculty_csv={{ faculty_csv }}"
+[tool.pixi.tasks.author-search]
+args = ["spider", "author_csv"]
+cmd = "scrapy crawl {{ spider }} -a author_csv={{ author_csv }}"
 
 [tool.pixi.tasks.spider]
 args = ["spider"]

--- a/src/open_ire/author.py
+++ b/src/open_ire/author.py
@@ -18,10 +18,12 @@ class AuthorRecord:
 
     @property
     def openalex_name(self) -> str:
+        """Return name in 'Firstname Lastname' format for OpenAlex API."""
         return f"{self.first_name.strip()} {self.last_name.strip()}".strip()
 
     @property
     def wos_name(self) -> str:
+        """Return name in 'LASTNAME FIRSTNAME' format for Web of Science API."""
         return f"{self.last_name.strip().upper()} {self.first_name.strip().upper()}".strip()
 
 
@@ -40,33 +42,20 @@ class AuthorIndex:
         self.records = self._load_records()
         self.lookups = self._build_lookups()
 
-    @staticmethod
-    def _stip_value(value: str | None) -> str:
-        return (value or "").strip()
+    # === PUBLIC INTERFACE ===
 
-    @staticmethod
-    def _normalize_text(value: str) -> str:
-        normalized = unicodedata.normalize("NFKD", value or "")
-        normalized = "".join(c for c in normalized if c.isalnum() or c.isspace())
+    def get_lookup(self, repository: str) -> dict[str, dict[str, str]]:
+        """Get lookup tables for a specific repository format."""
+        if repository not in self.lookups:
+            msg = f"Unsupported author lookup repository: {repository}"
+            raise ValueError(msg)
 
-        return " ".join(normalized.lower().split())
+        return self.lookups[repository]
 
-    def _build_record(
-        self,
-        first_name: str | None,
-        last_name: str | None,
-        email: str | None,
-    ) -> AuthorRecord | None:
-        clean_email = self._stip_value(email)
-        clean_first = self._stip_value(first_name)
-        clean_last = self._stip_value(last_name)
-
-        if not any((clean_email, clean_first, clean_last)):
-            return None
-
-        return AuthorRecord(first_name=clean_first, last_name=clean_last, email=clean_email)
+    # === DATA LOADING AND PROCESSING ===
 
     def _load_records(self) -> list[AuthorRecord]:
+        """Load and validate author records from CSV file."""
         if not self.path.exists():
             msg = f"Author file not found: {self.path}"
             raise FileNotFoundError(msg)
@@ -93,16 +82,26 @@ class AuthorIndex:
 
         return records
 
-    def _build_lookup(self, attr: str) -> dict[str, str]:
-        lookup: dict[str, str] = {}
-        for record in self.records:
-            key = getattr(record, attr)
-            if key and key not in lookup:
-                lookup[key] = record.email
+    def _build_record(
+        self,
+        first_name: str | None,
+        last_name: str | None,
+        email: str | None,
+    ) -> AuthorRecord | None:
+        """Build an AuthorRecord from CSV row data, returning None if invalid."""
+        clean_email = self._stip_value(email)
+        clean_first = self._stip_value(first_name)
+        clean_last = self._stip_value(last_name)
 
-        return lookup
+        if not any((clean_email, clean_first, clean_last)):
+            return None
+
+        return AuthorRecord(first_name=clean_first, last_name=clean_last, email=clean_email)
+
+    # === LOOKUP TABLE CONSTRUCTION ===
 
     def _build_lookups(self) -> dict[str, dict[str, dict[str, str]]]:
+        """Build lookup tables for all supported repository formats."""
         lookups: dict[str, dict[str, dict[str, str]]] = {}
         repository_attrs = {"openalex": "openalex_name", "wos": "wos_name"}
 
@@ -117,12 +116,30 @@ class AuthorIndex:
 
         return lookups
 
-    def get_lookup(self, repository: str) -> dict[str, dict[str, str]]:
-        if repository not in self.lookups:
-            msg = f"Unsupported author lookup repository: {repository}"
-            raise ValueError(msg)
+    def _build_lookup(self, attr: str) -> dict[str, str]:
+        """Build a lookup table mapping names to emails for a specific name format."""
+        lookup: dict[str, str] = {}
+        for record in self.records:
+            key = getattr(record, attr)
+            if key and key not in lookup:
+                lookup[key] = record.email
 
-        return self.lookups[repository]
+        return lookup
+
+    # === TEXT PROCESSING UTILITIES ===
+
+    @staticmethod
+    def _stip_value(value: str | None) -> str:
+        """Strip whitespace from a string value, handling None."""
+        return (value or "").strip()
+
+    @staticmethod
+    def _normalize_text(value: str) -> str:
+        """Normalize text for consistent matching by removing accents and standardizing case."""
+        normalized = unicodedata.normalize("NFKD", value or "")
+        normalized = "".join(c for c in normalized if c.isalnum() or c.isspace())
+
+        return " ".join(normalized.lower().split())
 
 
 class AuthorMatcher:
@@ -138,27 +155,42 @@ class AuthorMatcher:
         author_index = AuthorIndex(Path(author_csv_path).resolve())
         self.author_lookup = author_index.get_lookup(repository)
 
-    @staticmethod
-    def _normalize_text(value: str) -> str:
-        normalized = unicodedata.normalize("NFKD", value or "")
-        normalized = "".join(ch for ch in normalized if ch.isalnum() or ch.isspace())
-        return " ".join(normalized.lower().split())
+    # === PUBLIC MATCHING INTERFACE ===
 
-    @staticmethod
-    def _similarity(left: str, right: str) -> float:
-        if not left or not right:
-            return 0.0
-        return fuzz.token_set_ratio(left, right) / 100
+    def match_author(self, candidate: str) -> tuple[str | None, str | None]:
+        """Match a single author name, returning (matched_name, email) or (None, None)."""
+        return self._match_from_lookup(
+            candidate, self.author_lookup["raw"], self.author_lookup["normalized"]
+        )
+
+    def collect_matches(self, names: list[str]) -> tuple[list[str], list[str]]:
+        """Match multiple author names, returning sorted lists of unique matches."""
+        matched_names: set[str] = set()
+        matched_emails: set[str] = set()
+
+        for name in names:
+            matched_name, matched_email = self.match_author(name)
+            if matched_name:
+                matched_names.add(matched_name)
+            if matched_email:
+                matched_emails.add(matched_email)
+
+        return sorted(matched_names), sorted(matched_emails)
+
+    # === MATCHING IMPLEMENTATION ===
 
     def _match_from_lookup(
         self, candidate: str, lookup: dict[str, str], normalized_lookup: dict[str, str]
     ) -> tuple[str | None, str | None]:
+        """Match a candidate name against lookup tables using exact and fuzzy matching."""
         normalized_candidate = self._normalize_text(candidate)
 
+        # Try exact match first
         if normalized_candidate in normalized_lookup:
             original = normalized_lookup[normalized_candidate]
             return original, lookup[original]
 
+        # Fall back to fuzzy matching
         best_match: str | None = None
         best_score = 0.0
 
@@ -175,20 +207,18 @@ class AuthorMatcher:
 
         return None, None
 
-    def match_author(self, candidate: str) -> tuple[str | None, str | None]:
-        return self._match_from_lookup(
-            candidate, self.author_lookup["raw"], self.author_lookup["normalized"]
-        )
+    # === TEXT PROCESSING UTILITIES ===
 
-    def collect_matches(self, names: list[str]) -> tuple[list[str], list[str]]:
-        matched_names: set[str] = set()
-        matched_emails: set[str] = set()
+    @staticmethod
+    def _normalize_text(value: str) -> str:
+        """Normalize text for consistent matching by removing accents and standardizing case."""
+        normalized = unicodedata.normalize("NFKD", value or "")
+        normalized = "".join(ch for ch in normalized if ch.isalnum() or ch.isspace())
+        return " ".join(normalized.lower().split())
 
-        for name in names:
-            matched_name, matched_email = self.match_author(name)
-            if matched_name:
-                matched_names.add(matched_name)
-            if matched_email:
-                matched_emails.add(matched_email)
-
-        return sorted(matched_names), sorted(matched_emails)
+    @staticmethod
+    def _similarity(left: str, right: str) -> float:
+        """Calculate similarity score between two strings using token set ratio."""
+        if not left or not right:
+            return 0.0
+        return fuzz.token_set_ratio(left, right) / 100

--- a/src/open_ire/author.py
+++ b/src/open_ire/author.py
@@ -7,7 +7,11 @@ from rapidfuzz import fuzz
 
 
 @dataclass(frozen=True, slots=True)
-class FacultyRecord:
+class AuthorRecord:
+    """
+    Represents an author with email and name information.
+    """
+
     email: str
     first_name: str
     last_name: str
@@ -21,7 +25,14 @@ class FacultyRecord:
         return f"{self.last_name.strip().upper()} {self.first_name.strip().upper()}".strip()
 
 
-class FacultyIndex:
+class AuthorIndex:
+    """
+    Loads and indexes author data from CSV files.
+
+    Creates lookup tables for different repository formats and provides
+    normalized text matching capabilities for author name resolution.
+    """
+
     _required_fields = frozenset({"FirstName", "LastName", "Email"})
 
     def __init__(self, csv_path: Path) -> None:
@@ -45,7 +56,7 @@ class FacultyIndex:
         first_name: str | None,
         last_name: str | None,
         email: str | None,
-    ) -> FacultyRecord | None:
+    ) -> AuthorRecord | None:
         clean_email = self._stip_value(email)
         clean_first = self._stip_value(first_name)
         clean_last = self._stip_value(last_name)
@@ -53,19 +64,19 @@ class FacultyIndex:
         if not any((clean_email, clean_first, clean_last)):
             return None
 
-        return FacultyRecord(first_name=clean_first, last_name=clean_last, email=clean_email)
+        return AuthorRecord(first_name=clean_first, last_name=clean_last, email=clean_email)
 
-    def _load_records(self) -> list[FacultyRecord]:
+    def _load_records(self) -> list[AuthorRecord]:
         if not self.path.exists():
-            msg = f"Faculty file not found: {self.path}"
+            msg = f"Author file not found: {self.path}"
             raise FileNotFoundError(msg)
 
-        records: list[FacultyRecord] = []
+        records: list[AuthorRecord] = []
         with self.path.open(encoding="utf-8-sig", newline="") as handle:
             reader = csv.DictReader(handle)
             if not reader.fieldnames or not self._required_fields.issubset(reader.fieldnames):
                 msg = (
-                    f"Faculty file must include columns: {', '.join(sorted(self._required_fields))}"
+                    f"Author file must include columns: {', '.join(sorted(self._required_fields))}"
                 )
                 raise ValueError(msg)
 
@@ -77,7 +88,7 @@ class FacultyIndex:
                     records.append(record)
 
         if not records:
-            msg = f"No valid faculty records found in {self.path}"
+            msg = f"No valid author records found in {self.path}"
             raise ValueError(msg)
 
         return records
@@ -108,17 +119,24 @@ class FacultyIndex:
 
     def get_lookup(self, repository: str) -> dict[str, dict[str, str]]:
         if repository not in self.lookups:
-            msg = f"Unsupported faculty lookup repository: {repository}"
+            msg = f"Unsupported author lookup repository: {repository}"
             raise ValueError(msg)
 
         return self.lookups[repository]
 
 
 class AuthorMatcher:
-    def __init__(self, faculty_csv_path: str, repository: str, similarity_threshold: float = 0.9):
+    """
+    Matches author names against an author index using fuzzy string matching.
+
+    Provides exact and similarity-based matching for author name resolution,
+    supporting different repository name formats and configurable similarity thresholds.
+    """
+
+    def __init__(self, author_csv_path: str, repository: str, similarity_threshold: float = 0.9):
         self.similarity_threshold = similarity_threshold
-        faculty_index = FacultyIndex(Path(faculty_csv_path).resolve())
-        self.faculty_lookup = faculty_index.get_lookup(repository)
+        author_index = AuthorIndex(Path(author_csv_path).resolve())
+        self.author_lookup = author_index.get_lookup(repository)
 
     @staticmethod
     def _normalize_text(value: str) -> str:
@@ -159,7 +177,7 @@ class AuthorMatcher:
 
     def match_author(self, candidate: str) -> tuple[str | None, str | None]:
         return self._match_from_lookup(
-            candidate, self.faculty_lookup["raw"], self.faculty_lookup["normalized"]
+            candidate, self.author_lookup["raw"], self.author_lookup["normalized"]
         )
 
     def collect_matches(self, names: list[str]) -> tuple[list[str], list[str]]:

--- a/src/open_ire/author.py
+++ b/src/open_ire/author.py
@@ -1,18 +1,81 @@
 import csv
 import unicodedata
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
+from nameparser import HumanName
 
-@dataclass(frozen=True, slots=True)
+
+@dataclass(slots=True)
 class AuthorRecord:
     """
-    Represents an author with email and name information.
+    Represents an author with email and parsed name information.
+
+    The name is parsed using the nameparser library, which handles complex names
+    including titles, middle names, and suffixes. Spiders can access individual
+    name components to format names as required by their target APIs.
     """
 
+    name: str | HumanName
     email: str
-    first_name: str
-    last_name: str
+    _parsed_name: HumanName = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Parse the name if it's a string."""
+        if isinstance(self.name, str):
+            object.__setattr__(self, "_parsed_name", HumanName(self.name))
+        else:
+            object.__setattr__(self, "_parsed_name", self.name)
+
+    def __repr__(self) -> str:
+        return f"AuthorRecord(name='{self._parsed_name}', email='{self.email}')"
+
+    @property
+    def first_name(self) -> str:
+        return str(self._parsed_name.first)
+
+    @property
+    def last_name(self) -> str:
+        return str(self._parsed_name.last)
+
+    @property
+    def middle_name(self) -> str:
+        return str(self._parsed_name.middle)
+
+    @property
+    def middle_names(self) -> str:
+        """Alias for middle_name(), kept for consistency with middle_initials()."""
+        return str(self._parsed_name.middle)
+
+    @property
+    def first_initial(self) -> str:
+        """First initial (uppercase)."""
+        first = str(self._parsed_name.first)
+        return first[0].upper() if first else ""
+
+    @property
+    def middle_initial(self) -> str:
+        """Middle initial (uppercase)."""
+        middle = str(self._parsed_name.middle)
+        return middle[0].upper() if middle else ""
+
+    @property
+    def middle_initials(self) -> str:
+        """Middle initials (uppercase) joined together."""
+        middle = str(self._parsed_name.middle)
+        if not middle:
+            return ""
+        return "".join(initial[0].upper() for initial in middle.split(" ") if initial)
+
+    @property
+    def title(self) -> str:
+        """Title component (e.g., Dr., Prof.)."""
+        return str(self._parsed_name.title)
+
+    @property
+    def suffix(self) -> str:
+        """Suffix component (e.g., Jr., III)."""
+        return str(self._parsed_name.suffix)
 
 
 class AuthorIndex:
@@ -63,21 +126,18 @@ class AuthorIndex:
         email: str | None,
     ) -> AuthorRecord | None:
         """Build an AuthorRecord from CSV row data, returning None if invalid."""
-        clean_email = self._stip_value(email)
-        clean_first = self._stip_value(first_name)
-        clean_last = self._stip_value(last_name)
+        email = (email or "").strip()
+        first_name = (first_name or "").strip()
+        last_name = (last_name or "").strip()
 
-        if not any((clean_email, clean_first, clean_last)):
+        if not any((email, first_name, last_name)):
             return None
 
-        return AuthorRecord(first_name=clean_first, last_name=clean_last, email=clean_email)
+        # Construct full name from components and parse it
+        full_name = f"{first_name} {last_name}"
+        return AuthorRecord(email=email, name=HumanName(full_name))
 
     # === TEXT PROCESSING UTILITIES ===
-
-    @staticmethod
-    def _stip_value(value: str | None) -> str:
-        """Strip whitespace from a string value, handling None."""
-        return (value or "").strip()
 
     @staticmethod
     def _normalize_text(value: str) -> str:

--- a/src/open_ire/author.py
+++ b/src/open_ire/author.py
@@ -1,12 +1,11 @@
 import csv
 import unicodedata
-from dataclasses import dataclass, field
+from dataclasses import field
 from pathlib import Path
 
 from nameparser import HumanName
 
 
-@dataclass(slots=True)
 class AuthorRecord:
     """
     Represents an author with email and parsed name information.
@@ -17,15 +16,16 @@ class AuthorRecord:
     """
 
     name: str | HumanName
-    email: str
+    email: str | None
     _parsed_name: HumanName = field(init=False, repr=False)
 
-    def __post_init__(self) -> None:
-        """Parse the name if it's a string."""
-        if isinstance(self.name, str):
-            object.__setattr__(self, "_parsed_name", HumanName(self.name))
+    def __init__(self, name: str | HumanName, email: str | None = None) -> None:
+        if isinstance(name, str):
+            self._parsed_name = HumanName(name)
         else:
-            object.__setattr__(self, "_parsed_name", self.name)
+            self._parsed_name = name
+            self.name = str(name)
+        self.email = email
 
     def __repr__(self) -> str:
         return f"AuthorRecord(name='{self._parsed_name}', email='{self.email}')"

--- a/src/open_ire/author.py
+++ b/src/open_ire/author.py
@@ -132,6 +132,11 @@ class AuthorRecord:
         parts = [name.strip() for name in author_string.split(";") if name.strip()]
         return [cls(name=name, email="") for name in parts]
 
+    @classmethod
+    def encode_author_string(cls, authors: list["AuthorRecord"]) -> str:
+        """Encode a list of AuthorRecord objects back into a semicolon-separated string."""
+        return "; ".join(str(author.normalized_name) for author in authors)
+
 
 class AuthorIndex:
     """

--- a/src/open_ire/author.py
+++ b/src/open_ire/author.py
@@ -15,8 +15,7 @@ class AuthorRecord:
     name components to format names as required by their target APIs.
     """
 
-    name: str | HumanName
-    email: str | None
+    _email: str | None
     _parsed_name: HumanName = field(init=False, repr=False)
 
     def __init__(self, name: str | HumanName, email: str | None = None) -> None:
@@ -24,11 +23,22 @@ class AuthorRecord:
             self._parsed_name = HumanName(name)
         else:
             self._parsed_name = name
-            self.name = str(name)
-        self.email = email
+        self._email = email
 
     def __repr__(self) -> str:
-        return f"AuthorRecord(name='{self._parsed_name}', email='{self.email}')"
+        return f"AuthorRecord(name='{self._parsed_name}', email='{self._email}')"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, AuthorRecord):
+            return NotImplemented
+        return self.normalized_name == other.normalized_name and self.email == other.email
+
+    def __hash__(self) -> int:
+        return hash((self.normalized_name, self.email))
+
+    @property
+    def email(self) -> str | None:
+        return self._email
 
     @property
     def first_name(self) -> str:
@@ -76,6 +86,51 @@ class AuthorRecord:
     def suffix(self) -> str:
         """Suffix component (e.g., Jr., III)."""
         return str(self._parsed_name.suffix)
+
+    @property
+    def full_name(self) -> str:
+        """Return the full name as parsed by nameparser."""
+        return str(self._parsed_name)
+
+    @property
+    def normalized_name(self) -> str:
+        """Return normalized name in 'Last, First Middle' format for consistent storage."""
+        last = self.last_name.strip()
+        first = self.first_name.strip()
+        middle = self.middle_name.strip()
+
+        # Build given name (first + middle)
+        given_parts = [p for p in [first, middle] if p]
+        given_name = " ".join(given_parts) if given_parts else ""
+
+        # Return in "Last, First Middle" format
+        if last and given_name:
+            return f"{last}, {given_name}"
+        if last:
+            return last
+        if given_name:
+            return given_name
+        return str(self._parsed_name).strip() or "Unknown"
+
+    @classmethod
+    def parse_author_string(cls, author_string: str) -> list["AuthorRecord"]:
+        """Parse a semicolon-separated author string into AuthorRecord objects.
+
+        Authors are separated by semicolons. Each author name is parsed by nameparser
+        which handles both "Last, First" and "First Last" formats.
+
+        Args:
+            author_string: Semicolon-separated string of author names
+
+        Returns:
+            List of AuthorRecord objects (with empty email fields)
+        """
+        if not author_string or not author_string.strip():
+            return []
+
+        # Split by semicolon and parse each name
+        parts = [name.strip() for name in author_string.split(";") if name.strip()]
+        return [cls(name=name, email="") for name in parts]
 
 
 class AuthorIndex:

--- a/src/open_ire/author.py
+++ b/src/open_ire/author.py
@@ -3,8 +3,6 @@ import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
 
-from rapidfuzz import fuzz
-
 
 @dataclass(frozen=True, slots=True)
 class AuthorRecord:
@@ -16,23 +14,10 @@ class AuthorRecord:
     first_name: str
     last_name: str
 
-    @property
-    def openalex_name(self) -> str:
-        """Return name in 'Firstname Lastname' format for OpenAlex API."""
-        return f"{self.first_name.strip()} {self.last_name.strip()}".strip()
-
-    @property
-    def wos_name(self) -> str:
-        """Return name in 'LASTNAME FIRSTNAME' format for Web of Science API."""
-        return f"{self.last_name.strip().upper()} {self.first_name.strip().upper()}".strip()
-
 
 class AuthorIndex:
     """
     Loads and indexes author data from CSV files.
-
-    Creates lookup tables for different repository formats and provides
-    normalized text matching capabilities for author name resolution.
     """
 
     _required_fields = frozenset({"FirstName", "LastName", "Email"})
@@ -40,17 +25,6 @@ class AuthorIndex:
     def __init__(self, csv_path: Path) -> None:
         self.path = csv_path
         self.records = self._load_records()
-        self.lookups = self._build_lookups()
-
-    # === PUBLIC INTERFACE ===
-
-    def get_lookup(self, repository: str) -> dict[str, dict[str, str]]:
-        """Get lookup tables for a specific repository format."""
-        if repository not in self.lookups:
-            msg = f"Unsupported author lookup repository: {repository}"
-            raise ValueError(msg)
-
-        return self.lookups[repository]
 
     # === DATA LOADING AND PROCESSING ===
 
@@ -98,34 +72,6 @@ class AuthorIndex:
 
         return AuthorRecord(first_name=clean_first, last_name=clean_last, email=clean_email)
 
-    # === LOOKUP TABLE CONSTRUCTION ===
-
-    def _build_lookups(self) -> dict[str, dict[str, dict[str, str]]]:
-        """Build lookup tables for all supported repository formats."""
-        lookups: dict[str, dict[str, dict[str, str]]] = {}
-        repository_attrs = {"openalex": "openalex_name", "wos": "wos_name"}
-
-        for repository, attr in repository_attrs.items():
-            raw = self._build_lookup(attr)
-            normalized = {self._normalize_text(name): name for name in raw}
-
-            lookups[repository] = {
-                "raw": raw,
-                "normalized": normalized,
-            }
-
-        return lookups
-
-    def _build_lookup(self, attr: str) -> dict[str, str]:
-        """Build a lookup table mapping names to emails for a specific name format."""
-        lookup: dict[str, str] = {}
-        for record in self.records:
-            key = getattr(record, attr)
-            if key and key not in lookup:
-                lookup[key] = record.email
-
-        return lookup
-
     # === TEXT PROCESSING UTILITIES ===
 
     @staticmethod
@@ -140,85 +86,3 @@ class AuthorIndex:
         normalized = "".join(c for c in normalized if c.isalnum() or c.isspace())
 
         return " ".join(normalized.lower().split())
-
-
-class AuthorMatcher:
-    """
-    Matches author names against an author index using fuzzy string matching.
-
-    Provides exact and similarity-based matching for author name resolution,
-    supporting different repository name formats and configurable similarity thresholds.
-    """
-
-    def __init__(self, author_csv_path: str, repository: str, similarity_threshold: float = 0.9):
-        self.similarity_threshold = similarity_threshold
-        author_index = AuthorIndex(Path(author_csv_path).resolve())
-        self.author_lookup = author_index.get_lookup(repository)
-
-    # === PUBLIC MATCHING INTERFACE ===
-
-    def match_author(self, candidate: str) -> tuple[str | None, str | None]:
-        """Match a single author name, returning (matched_name, email) or (None, None)."""
-        return self._match_from_lookup(
-            candidate, self.author_lookup["raw"], self.author_lookup["normalized"]
-        )
-
-    def collect_matches(self, names: list[str]) -> tuple[list[str], list[str]]:
-        """Match multiple author names, returning sorted lists of unique matches."""
-        matched_names: set[str] = set()
-        matched_emails: set[str] = set()
-
-        for name in names:
-            matched_name, matched_email = self.match_author(name)
-            if matched_name:
-                matched_names.add(matched_name)
-            if matched_email:
-                matched_emails.add(matched_email)
-
-        return sorted(matched_names), sorted(matched_emails)
-
-    # === MATCHING IMPLEMENTATION ===
-
-    def _match_from_lookup(
-        self, candidate: str, lookup: dict[str, str], normalized_lookup: dict[str, str]
-    ) -> tuple[str | None, str | None]:
-        """Match a candidate name against lookup tables using exact and fuzzy matching."""
-        normalized_candidate = self._normalize_text(candidate)
-
-        # Try exact match first
-        if normalized_candidate in normalized_lookup:
-            original = normalized_lookup[normalized_candidate]
-            return original, lookup[original]
-
-        # Fall back to fuzzy matching
-        best_match: str | None = None
-        best_score = 0.0
-
-        for original in lookup:
-            normalized_original = self._normalize_text(original)
-            score = self._similarity(normalized_candidate, normalized_original)
-
-            if score > best_score:
-                best_match = original
-                best_score = score
-
-        if best_match and best_score >= self.similarity_threshold:
-            return best_match, lookup[best_match]
-
-        return None, None
-
-    # === TEXT PROCESSING UTILITIES ===
-
-    @staticmethod
-    def _normalize_text(value: str) -> str:
-        """Normalize text for consistent matching by removing accents and standardizing case."""
-        normalized = unicodedata.normalize("NFKD", value or "")
-        normalized = "".join(ch for ch in normalized if ch.isalnum() or ch.isspace())
-        return " ".join(normalized.lower().split())
-
-    @staticmethod
-    def _similarity(left: str, right: str) -> float:
-        """Calculate similarity score between two strings using token set ratio."""
-        if not left or not right:
-            return 0.0
-        return fuzz.token_set_ratio(left, right) / 100

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -53,10 +53,12 @@ class OpenAlexSpider(AuthorSearchSpider):
             url,
             headers=self.request_headers,
             callback=self.author_publication_requests,
+            meta={"matched_author": term},
         )
 
     def author_publication_requests(self, response: Response) -> Generator[Request, None, None]:
         """Parse author search results and generate publication requests."""
+        matched_author = response.meta["matched_author"]
         data = json.loads(response.text or "{}")
 
         for author in data.get("results", []):
@@ -66,13 +68,13 @@ class OpenAlexSpider(AuthorSearchSpider):
 
             # TODO: OpenAlex returns a relevance score; we could use it for early filtering.
 
-            yield from self._request_publications(author_id)
+            yield from self._request_publications(author_id, matched_author)
 
     # === SUPPORTING WORKFLOW METHODS ===
     # These methods support the main workflow
 
     def _request_publications(
-        self, author_id: str, cursor: str = "*"
+        self, author_id: str, matched_author: str, cursor: str = "*"
     ) -> Generator[Request, None, None]:
         """Generate a request for an author's publications with pagination support."""
         params = {
@@ -87,6 +89,7 @@ class OpenAlexSpider(AuthorSearchSpider):
             url,
             headers=self.request_headers,
             callback=self.parse_publications,
+            meta={"matched_author": matched_author},
             cb_kwargs={"author_id": author_id},
         )
 
@@ -94,6 +97,7 @@ class OpenAlexSpider(AuthorSearchSpider):
         self, response: Response, author_id: str
     ) -> Generator[Request | ArticleItem, None, None]:
         """Parse publication results and yield ArticleItems, handling pagination."""
+        matched_author = response.meta["matched_author"]
         data = json.loads(response.text or "{}")
         results = data.get("results", [])
 
@@ -101,14 +105,14 @@ class OpenAlexSpider(AuthorSearchSpider):
             if not isinstance(publication, dict):
                 continue
 
-            if item := self._build_item(publication):
+            if item := self._build_item(publication, matched_author):
                 yield item
 
         meta = data.get("meta", {})
         if next_cursor := meta.get("next_cursor"):
-            yield from self._request_publications(author_id, cursor=next_cursor)
+            yield from self._request_publications(author_id, matched_author, cursor=next_cursor)
 
-    def _build_item(self, publication: dict[str, Any]) -> ArticleItem | None:
+    def _build_item(self, publication: dict[str, Any], matched_author: str) -> ArticleItem | None:
         """Build an ArticleItem from OpenAlex publication data."""
         external_id = publication.get("id")
         if not external_id:
@@ -127,6 +131,7 @@ class OpenAlexSpider(AuthorSearchSpider):
                 "oa_status": oa_status,
                 "publication_type": publication.get("type"),
                 "publication_year": self._parse_year(publication.get("publication_year")),
+                "matched_author": matched_author,
             },
             publication_date=self._parse_date(publication.get("publication_date")),
             reference=str(external_id),

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -39,7 +39,8 @@ class OpenAlexSpider(AuthorSearchSpider):
     def build_search_request(self, term: str) -> Request:
         """Build the initial search request for a given author name."""
         params = {
-            "filter": f"display_name.search:{term},last_known_institutions.id:{self.institution_id}",
+            "search": term,
+            "filter": f"affiliations.institution.id:{self.institution_id}",
             "per_page": str(self.page_size),
         }
         url = f"{self.base_url}/authors?{urlencode(params)}"

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -7,6 +7,7 @@ from urllib.parse import urlencode
 from dateutil.parser import parse
 from scrapy.http import Request, Response
 
+from open_ire.author import AuthorRecord
 from open_ire.items import ArticleItem
 from open_ire.settings import OPENALEX_CONTACT_EMAIL, OPENALEX_INSTITUTION_ID
 from open_ire.spiders.search import AuthorSearchSpider
@@ -32,6 +33,9 @@ class OpenAlexSpider(AuthorSearchSpider):
         self.start_date = start_date
         self.institution_id = OPENALEX_INSTITUTION_ID
         self.request_headers: dict[str, str] = {"User-Agent": f"mailto:{OPENALEX_CONTACT_EMAIL}"}
+
+    def _get_author_name(self, record: AuthorRecord) -> str:
+        return f"{record.first_name} {record.last_name}"
 
     # === HIGH-LEVEL WORKFLOW METHODS ===
     # These methods define the main crawling workflow

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -118,13 +118,13 @@ class OpenAlexSpider(AuthorSearchSpider):
         is_oa = publication.get("open_access", {}).get("is_oa")
 
         return ArticleItem(
-            authors=self._join_or_none(author_names),
+            authors=self._join_authors(author_names),
             doi=publication.get("doi"),
             extra={
                 "is_open_access": is_oa,
                 "journal_name": self._extract_journal_name(publication),
-                "matched_author": self._join_or_none(matched_names),
-                "matched_email": self._join_or_none(matched_emails),
+                "matched_author": self._join_authors(matched_names),
+                "matched_email": self._join_authors(matched_emails),
                 "oa_status": oa_status,
                 "publication_type": publication.get("type"),
                 "publication_year": self._parse_year(publication.get("publication_year")),
@@ -176,11 +176,6 @@ class OpenAlexSpider(AuthorSearchSpider):
 
     # === LOW-LEVEL UTILITY FUNCTIONS ===
     # These are generic utility functions for data processing
-
-    @staticmethod
-    def _join_or_none(values: list[str]) -> str | None:
-        """Join a list of strings with commas, or return None if empty."""
-        return ", ".join(values) if values else None
 
     @staticmethod
     def _parse_date(value: Any) -> date | None:

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -7,13 +7,17 @@ from urllib.parse import urlencode
 from dateutil.parser import parse
 from scrapy.http import Request, Response
 
-from open_ire.faculty import AuthorMatcher
+from open_ire.author import AuthorMatcher
 from open_ire.items import ArticleItem
 from open_ire.settings import OPENALEX_CONTACT_EMAIL, OPENALEX_INSTITUTION_ID
-from open_ire.spiders.search import FacultySearchSpider
+from open_ire.spiders.search import AuthorSearchSpider
 
 
-class OpenAlexSpider(FacultySearchSpider):
+class OpenAlexSpider(AuthorSearchSpider):
+    """
+    OpenAlex API spider for collecting academic publications by author.
+    """
+
     name = "openalex"
     base_url = "https://api.openalex.org"
     page_size = 25
@@ -26,17 +30,10 @@ class OpenAlexSpider(FacultySearchSpider):
     ) -> None:
         super().__init__(*args, **kwargs)
 
-        # The 'faculty_csv' argument is passed to the parent class,
-        # but we need it to initialize the AuthorMatcher.
-        faculty_csv = kwargs.get("faculty_csv")
-        if not faculty_csv:
-            msg = "The 'faculty_csv' argument is required for the OpenAlex spider."
-            raise ValueError(msg)
-
         self.start_date = start_date
         self.institution_id = OPENALEX_INSTITUTION_ID
         self.request_headers: dict[str, str] = {"User-Agent": f"mailto:{OPENALEX_CONTACT_EMAIL}"}
-        self.author_matcher = AuthorMatcher(faculty_csv, "openalex")
+        self.author_matcher = AuthorMatcher(author_csv, "openalex")
 
     @staticmethod
     def _join_or_none(values: list[str]) -> str | None:

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -118,12 +118,12 @@ class OpenAlexSpider(AuthorSearchSpider):
         if not external_id:
             return None
 
-        author_names = self._extract_authors(publication)
+        authors = self._extract_authors(publication)
         oa_status = publication.get("open_access", {}).get("oa_status")
         is_oa = publication.get("open_access", {}).get("is_oa")
 
         return ArticleItem(
-            authors=self._join_authors(author_names),
+            authors=AuthorRecord.encode_author_string(authors),
             doi=publication.get("doi"),
             extra={
                 "is_open_access": is_oa,
@@ -144,9 +144,9 @@ class OpenAlexSpider(AuthorSearchSpider):
     # These methods extract specific data from OpenAlex API responses
 
     @staticmethod
-    def _extract_authors(publication: dict[str, Any]) -> list[str]:
+    def _extract_authors(publication: dict[str, Any]) -> list[AuthorRecord]:
         """Extract author names from publication authorship data."""
-        author_names: list[str] = []
+        authors: list[AuthorRecord] = []
         authorships = publication.get("authorships", [])
         for authorship in authorships:
             if not isinstance(authorship, dict):
@@ -154,9 +154,9 @@ class OpenAlexSpider(AuthorSearchSpider):
 
             display_name = authorship.get("author", {}).get("display_name")
             if display_name and isinstance(display_name, str):
-                author_names.append(display_name)
+                authors.append(AuthorRecord(display_name))
 
-        return author_names
+        return authors
 
     @staticmethod
     def _extract_journal_name(publication: dict[str, Any]) -> str | None:

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -7,7 +7,6 @@ from urllib.parse import urlencode
 from dateutil.parser import parse
 from scrapy.http import Request, Response
 
-from open_ire.author import AuthorMatcher
 from open_ire.items import ArticleItem
 from open_ire.settings import OPENALEX_CONTACT_EMAIL, OPENALEX_INSTITUTION_ID
 from open_ire.spiders.search import AuthorSearchSpider
@@ -33,7 +32,6 @@ class OpenAlexSpider(AuthorSearchSpider):
         self.start_date = start_date
         self.institution_id = OPENALEX_INSTITUTION_ID
         self.request_headers: dict[str, str] = {"User-Agent": f"mailto:{OPENALEX_CONTACT_EMAIL}"}
-        self.author_matcher = AuthorMatcher(author_csv, "openalex")
 
     # === HIGH-LEVEL WORKFLOW METHODS ===
     # These methods define the main crawling workflow
@@ -112,8 +110,6 @@ class OpenAlexSpider(AuthorSearchSpider):
             return None
 
         author_names = self._extract_authors(publication)
-        matched_names, matched_emails = self.author_matcher.collect_matches(author_names)
-
         oa_status = publication.get("open_access", {}).get("oa_status")
         is_oa = publication.get("open_access", {}).get("is_oa")
 
@@ -123,8 +119,6 @@ class OpenAlexSpider(AuthorSearchSpider):
             extra={
                 "is_open_access": is_oa,
                 "journal_name": self._extract_journal_name(publication),
-                "matched_author": self._join_authors(matched_names),
-                "matched_email": self._join_authors(matched_emails),
                 "oa_status": oa_status,
                 "publication_type": publication.get("type"),
                 "publication_year": self._parse_year(publication.get("publication_year")),

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -35,77 +35,8 @@ class OpenAlexSpider(AuthorSearchSpider):
         self.request_headers: dict[str, str] = {"User-Agent": f"mailto:{OPENALEX_CONTACT_EMAIL}"}
         self.author_matcher = AuthorMatcher(author_csv, "openalex")
 
-    @staticmethod
-    def _join_or_none(values: list[str]) -> str | None:
-        return ", ".join(values) if values else None
-
-    @staticmethod
-    def _parse_date(value: Any) -> date | None:
-        if not value:
-            return None
-        try:
-            return parse(str(value)).date()
-        except (ValueError, TypeError):
-            return None
-
-    @staticmethod
-    def _parse_year(value: Any) -> int | None:
-        if isinstance(value, int):
-            return value
-        if isinstance(value, str) and value.isdigit():
-            return int(value)
-        return None
-
-    @staticmethod
-    def _extract_journal_name(publication: dict[str, Any]) -> str | None:
-        primary_location = publication.get("primary_location") or {}
-        if isinstance(primary_location, dict):
-            source = primary_location.get("source") or {}
-            if isinstance(source, dict) and source.get("display_name"):
-                return str(source["display_name"])
-
-        for location in publication.get("locations", []) or []:
-            if not isinstance(location, dict):
-                continue
-
-            source = location.get("source") or {}
-            display_name = source.get("display_name")
-            if display_name and isinstance(display_name, str):
-                return str(display_name)
-
-        return None
-
-    @staticmethod
-    def _extract_authors(publication: dict[str, Any]) -> list[str]:
-        author_names: list[str] = []
-        authorships = publication.get("authorships", [])
-        for authorship in authorships:
-            if not isinstance(authorship, dict):
-                continue
-
-            display_name = authorship.get("author", {}).get("display_name")
-            if display_name and isinstance(display_name, str):
-                author_names.append(display_name)
-
-        return author_names
-
-    def _request_publications(
-        self, author_id: str, cursor: str = "*"
-    ) -> Generator[Request, None, None]:
-        params = {
-            "filter": f"author.id:{author_id},from_publication_date:{self.start_date}",
-            "per_page": str(self.page_size),
-            "cursor": cursor,
-            "sort": "publication_date:desc",
-        }
-        url = f"{self.base_url}/works?{urlencode(params)}"
-
-        yield Request(
-            url,
-            headers=self.request_headers,
-            callback=self.parse_publications,
-            cb_kwargs={"author_id": author_id},
-        )
+    # === HIGH-LEVEL WORKFLOW METHODS ===
+    # These methods define the main crawling workflow
 
     def build_search_request(self, term: str) -> Request:
         """Build the initial search request for a given author name."""
@@ -134,9 +65,32 @@ class OpenAlexSpider(AuthorSearchSpider):
 
             yield from self._request_publications(author_id)
 
+    # === SUPPORTING WORKFLOW METHODS ===
+    # These methods support the main workflow
+
+    def _request_publications(
+        self, author_id: str, cursor: str = "*"
+    ) -> Generator[Request, None, None]:
+        """Generate a request for an author's publications with pagination support."""
+        params = {
+            "filter": f"author.id:{author_id},from_publication_date:{self.start_date}",
+            "per_page": str(self.page_size),
+            "cursor": cursor,
+            "sort": "publication_date:desc",
+        }
+        url = f"{self.base_url}/works?{urlencode(params)}"
+
+        yield Request(
+            url,
+            headers=self.request_headers,
+            callback=self.parse_publications,
+            cb_kwargs={"author_id": author_id},
+        )
+
     def parse_publications(
         self, response: Response, author_id: str
     ) -> Generator[Request | ArticleItem, None, None]:
+        """Parse publication results and yield ArticleItems, handling pagination."""
         data = json.loads(response.text or "{}")
         results = data.get("results", [])
 
@@ -152,12 +106,12 @@ class OpenAlexSpider(AuthorSearchSpider):
             yield from self._request_publications(author_id, cursor=next_cursor)
 
     def _build_item(self, publication: dict[str, Any]) -> ArticleItem | None:
+        """Build an ArticleItem from OpenAlex publication data."""
         external_id = publication.get("id")
         if not external_id:
             return None
 
         author_names = self._extract_authors(publication)
-
         matched_names, matched_emails = self.author_matcher.collect_matches(author_names)
 
         oa_status = publication.get("open_access", {}).get("oa_status")
@@ -181,3 +135,68 @@ class OpenAlexSpider(AuthorSearchSpider):
             title=publication.get("title"),
             url=publication.get("doi"),
         )
+
+    # === DATA EXTRACTION UTILITIES ===
+    # These methods extract specific data from OpenAlex API responses
+
+    @staticmethod
+    def _extract_authors(publication: dict[str, Any]) -> list[str]:
+        """Extract author names from publication authorship data."""
+        author_names: list[str] = []
+        authorships = publication.get("authorships", [])
+        for authorship in authorships:
+            if not isinstance(authorship, dict):
+                continue
+
+            display_name = authorship.get("author", {}).get("display_name")
+            if display_name and isinstance(display_name, str):
+                author_names.append(display_name)
+
+        return author_names
+
+    @staticmethod
+    def _extract_journal_name(publication: dict[str, Any]) -> str | None:
+        """Extract journal name from publication location data."""
+        primary_location = publication.get("primary_location") or {}
+        if isinstance(primary_location, dict):
+            source = primary_location.get("source") or {}
+            if isinstance(source, dict) and source.get("display_name"):
+                return str(source["display_name"])
+
+        for location in publication.get("locations", []) or []:
+            if not isinstance(location, dict):
+                continue
+
+            source = location.get("source") or {}
+            display_name = source.get("display_name")
+            if display_name and isinstance(display_name, str):
+                return str(display_name)
+
+        return None
+
+    # === LOW-LEVEL UTILITY FUNCTIONS ===
+    # These are generic utility functions for data processing
+
+    @staticmethod
+    def _join_or_none(values: list[str]) -> str | None:
+        """Join a list of strings with commas, or return None if empty."""
+        return ", ".join(values) if values else None
+
+    @staticmethod
+    def _parse_date(value: Any) -> date | None:
+        """Parse a date value into a date object, returning None on failure."""
+        if not value:
+            return None
+        try:
+            return parse(str(value)).date()
+        except (ValueError, TypeError):
+            return None
+
+    @staticmethod
+    def _parse_year(value: Any) -> int | None:
+        """Parse a year value into an integer, returning None on failure."""
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str) and value.isdigit():
+            return int(value)
+        return None

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -1,16 +1,15 @@
 import json
 from collections.abc import Generator
-from datetime import date
 from typing import Any
 from urllib.parse import urlencode
 
-from dateutil.parser import parse
 from scrapy.http import Request, Response
 
 from open_ire.author import AuthorRecord
 from open_ire.items import ArticleItem
 from open_ire.settings import OPENALEX_CONTACT_EMAIL, OPENALEX_INSTITUTION_ID
 from open_ire.spiders.search import AuthorSearchSpider
+from open_ire.utils import parse_date
 
 
 class OpenAlexSpider(AuthorSearchSpider):
@@ -130,10 +129,9 @@ class OpenAlexSpider(AuthorSearchSpider):
                 "journal_name": self._extract_journal_name(publication),
                 "oa_status": oa_status,
                 "publication_type": publication.get("type"),
-                "publication_year": self._parse_year(publication.get("publication_year")),
                 "matched_author": matched_author,
             },
-            publication_date=self._parse_date(publication.get("publication_date")),
+            publication_date=parse_date(publication.get("publication_date")),
             reference=str(external_id),
             repository=self.name,
             title=publication.get("title"),
@@ -176,26 +174,4 @@ class OpenAlexSpider(AuthorSearchSpider):
             if display_name and isinstance(display_name, str):
                 return str(display_name)
 
-        return None
-
-    # === LOW-LEVEL UTILITY FUNCTIONS ===
-    # These are generic utility functions for data processing
-
-    @staticmethod
-    def _parse_date(value: Any) -> date | None:
-        """Parse a date value into a date object, returning None on failure."""
-        if not value:
-            return None
-        try:
-            return parse(str(value)).date()
-        except (ValueError, TypeError):
-            return None
-
-    @staticmethod
-    def _parse_year(value: Any) -> int | None:
-        """Parse a year value into an integer, returning None on failure."""
-        if isinstance(value, int):
-            return value
-        if isinstance(value, str) and value.isdigit():
-            return int(value)
         return None

--- a/src/open_ire/spiders/search.py
+++ b/src/open_ire/spiders/search.py
@@ -6,7 +6,7 @@ from typing import Any
 from scrapy import Spider
 from scrapy.http import Request
 
-from open_ire.faculty import FacultyIndex, FacultyRecord
+from open_ire.author import AuthorIndex, AuthorRecord
 from open_ire.settings import OPEN_IRE_DEFAULT_TERMS
 
 
@@ -51,27 +51,27 @@ class TermSearchSpider(SearchSpider):
         self.search_terms = [term.strip() for term in (terms or "").split(",")]
 
 
-class FacultySearchSpider(SearchSpider):
+class AuthorSearchSpider(SearchSpider):
     """
-    A specialized base spider that only searches using a faculty CSV file.
+    A specialized base spider that only searches using an author CSV file.
 
-    This spider requires the `faculty_csv` argument. Subclasses can override
+    This spider requires the `author_csv` argument. Subclasses can override
     `_get_author_name` to specify the required name format for the target API.
     """
 
-    def __init__(self, faculty_csv: str | None = None, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, author_csv: str | None = None, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        if not faculty_csv:
-            msg = f"The '{self.name}' spider requires the 'faculty_csv' argument."
+        if not author_csv:
+            msg = f"The '{self.name}' spider requires the 'author_csv' argument."
             raise ValueError(msg)
 
-        self.search_terms = self._get_search_terms(faculty_csv)
+        self.search_terms = self._get_search_terms(author_csv)
 
-    def _get_author_name(self, record: FacultyRecord) -> str:
+    def _get_author_name(self, record: AuthorRecord) -> str:
         """Return the author name in the default 'Firstname Lastname' format."""
         return f"{record.first_name} {record.last_name}"
 
-    def _get_search_terms(self, faculty_csv: str) -> list[str]:
-        faculty_path = Path(faculty_csv).resolve()
-        faculty_index = FacultyIndex(faculty_path)
-        return [self._get_author_name(record) for record in faculty_index.records]
+    def _get_search_terms(self, author_csv: str) -> list[str]:
+        author_path = Path(author_csv).resolve()
+        author_index = AuthorIndex(author_path)
+        return [self._get_author_name(record) for record in author_index.records]

--- a/src/open_ire/spiders/search.py
+++ b/src/open_ire/spiders/search.py
@@ -20,6 +20,11 @@ class SearchSpider(Spider, metaclass=abc.ABCMeta):
 
     search_terms: list[str]
 
+    @staticmethod
+    def _join_authors(values: list[str]) -> str | None:
+        """Join a list of author names with semicolons, or return None if empty."""
+        return "; ".join(values) if values else None
+
     async def start(self) -> AsyncIterator[Request]:
         for term in self.search_terms:
             if not term:

--- a/src/open_ire/spiders/search.py
+++ b/src/open_ire/spiders/search.py
@@ -20,11 +20,6 @@ class SearchSpider(Spider, metaclass=abc.ABCMeta):
 
     search_terms: list[str]
 
-    @staticmethod
-    def _join_authors(values: list[str]) -> str | None:
-        """Join a list of author names with semicolons, or return None if empty."""
-        return "; ".join(values) if values else None
-
     async def start(self) -> AsyncIterator[Request]:
         for term in self.search_terms:
             if not term:

--- a/src/open_ire/spiders/wos.py
+++ b/src/open_ire/spiders/wos.py
@@ -10,7 +10,6 @@ from urllib.parse import urlencode
 from dateutil.parser import parse
 from scrapy.http import Request, Response
 
-from open_ire.author import AuthorMatcher, AuthorRecord
 from open_ire.items import ArticleItem
 from open_ire.settings import WOS_ORGANIZATION
 from open_ire.spiders.search import AuthorSearchSpider
@@ -33,7 +32,6 @@ class WoSSpider(AuthorSearchSpider):
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
-        author_csv = kwargs["author_csv"]
 
         current_year = datetime.date.today().year
         self.organization = WOS_ORGANIZATION
@@ -54,11 +52,6 @@ class WoSSpider(AuthorSearchSpider):
             raise ValueError(msg)
 
         self.headers = {"X-ApiKey": self.api_key}
-        self.author_matcher = AuthorMatcher(author_csv, "wos")
-
-    def _get_author_name(self, record: AuthorRecord) -> str:
-        """Override to provide names in 'LASTNAME FIRSTNAME' format for WoS."""
-        return record.wos_name
 
     # === HIGH-LEVEL WORKFLOW METHODS ===
     # These methods define the main crawling workflow
@@ -81,6 +74,7 @@ class WoSSpider(AuthorSearchSpider):
     ) -> Generator[Request | ArticleItem, None, None]:
         """Parse WoS publication results and yield ArticleItems, handling pagination."""
         raw_text = response.text or ""
+
         try:
             data = json.loads(raw_text)
         except json.JSONDecodeError:
@@ -180,7 +174,6 @@ class WoSSpider(AuthorSearchSpider):
 
         names = self._as_list(summary.get("names", {}).get("name"))
         authors = self._extract_authors(names)
-        matched_names, matched_emails = self.author_matcher.collect_matches(authors)
 
         pub_info = summary.get("pub_info", {})
         cluster_related = publication.get("dynamic_data", {}).get("cluster_related", {})
@@ -199,8 +192,6 @@ class WoSSpider(AuthorSearchSpider):
             doi=doi,
             extra={
                 "journal_name": self._extract_journal_name(titles),
-                "matched_author": self._join_authors(matched_names),
-                "matched_email": self._join_authors(matched_emails),
                 "publication_type": summary.get("doctypes", {}).get("doctype"),
                 "publication_year": self._parse_year(
                     pub_info.get("pubyear") or pub_info.get("coverdate")

--- a/src/open_ire/spiders/wos.py
+++ b/src/open_ire/spiders/wos.py
@@ -228,7 +228,9 @@ class WoSSpider(AuthorSearchSpider):
             if not isinstance(author, dict):
                 continue
 
-            full_name = author.get("wos_standard") or author.get("display_name")
+            full_name = (
+                author.get("full_name") or author.get("display_name") or author.get("wos_standard")
+            )
             if full_name:
                 authors.append(str(full_name))
 

--- a/src/open_ire/spiders/wos.py
+++ b/src/open_ire/spiders/wos.py
@@ -70,6 +70,7 @@ class WoSSpider(AuthorSearchSpider):
             url,
             headers=self.headers,
             callback=self.parse_publications,
+            meta={"matched_author": term},
             cb_kwargs={"query": query, "page": 1},
         )
 
@@ -77,6 +78,7 @@ class WoSSpider(AuthorSearchSpider):
         self, response: Response, query: str, page: int
     ) -> Generator[Request | ArticleItem, None, None]:
         """Parse WoS publication results and yield ArticleItems, handling pagination."""
+        matched_author = response.meta["matched_author"]
         raw_text = response.text or ""
 
         try:
@@ -124,7 +126,7 @@ class WoSSpider(AuthorSearchSpider):
 
         emitted = 0
         for record in records:
-            if item := self._build_item(record):
+            if item := self._build_item(record, matched_author):
                 emitted += 1
                 yield item
 
@@ -137,6 +139,7 @@ class WoSSpider(AuthorSearchSpider):
                 next_url,
                 headers=self.headers,
                 callback=self.parse_publications,
+                meta={"matched_author": matched_author},
                 cb_kwargs={"query": query, "page": next_page},
             )
 
@@ -160,7 +163,7 @@ class WoSSpider(AuthorSearchSpider):
             "usrQuery": query,
         }
 
-    def _build_item(self, publication: Any) -> ArticleItem | None:
+    def _build_item(self, publication: Any, matched_author: str) -> ArticleItem | None:
         """Build an ArticleItem from WoS publication data."""
         if not isinstance(publication, dict):
             return None
@@ -200,6 +203,7 @@ class WoSSpider(AuthorSearchSpider):
                 "publication_year": self._parse_year(
                     pub_info.get("pubyear") or pub_info.get("coverdate")
                 ),
+                "matched_author": matched_author,
             },
             publication_date=self._parse_date(
                 pub_info.get("coverdate") or pub_info.get("sortdate")

--- a/src/open_ire/spiders/wos.py
+++ b/src/open_ire/spiders/wos.py
@@ -10,6 +10,7 @@ from urllib.parse import urlencode
 from dateutil.parser import parse
 from scrapy.http import Request, Response
 
+from open_ire.author import AuthorRecord
 from open_ire.items import ArticleItem
 from open_ire.settings import WOS_ORGANIZATION
 from open_ire.spiders.search import AuthorSearchSpider
@@ -52,6 +53,9 @@ class WoSSpider(AuthorSearchSpider):
             raise ValueError(msg)
 
         self.headers = {"X-ApiKey": self.api_key}
+
+    def _get_author_name(self, record: AuthorRecord) -> str:
+        return f"{record.last_name} {record.first_name}"
 
     # === HIGH-LEVEL WORKFLOW METHODS ===
     # These methods define the main crawling workflow

--- a/src/open_ire/spiders/wos.py
+++ b/src/open_ire/spiders/wos.py
@@ -1,19 +1,17 @@
 import datetime
 import json
 import os
-import re
 from collections.abc import Generator
-from datetime import date
 from typing import Any
 from urllib.parse import urlencode
 
-from dateutil.parser import parse
 from scrapy.http import Request, Response
 
 from open_ire.author import AuthorRecord
 from open_ire.items import ArticleItem
 from open_ire.settings import WOS_ORGANIZATION
 from open_ire.spiders.search import AuthorSearchSpider
+from open_ire.utils import as_list, parse_date, validate_year
 
 
 class WoSSpider(AuthorSearchSpider):
@@ -36,12 +34,12 @@ class WoSSpider(AuthorSearchSpider):
 
         current_year = datetime.date.today().year
         self.organization = WOS_ORGANIZATION
-        self.start_year = self._validate_year(start_year, "start_year")
+        self.start_year = validate_year(start_year, "start_year")
 
         if end_year is None:
             self.end_year = current_year
         else:
-            self.end_year = self._validate_year(end_year, "end_year")
+            self.end_year = validate_year(end_year, "end_year")
 
         if self.end_year < self.start_year:
             msg = "The 'end_year' must be greater than or equal to 'start_year'."
@@ -117,7 +115,7 @@ class WoSSpider(AuthorSearchSpider):
             )
             return
 
-        records = self._as_list(records_container.get("REC"))
+        records = as_list(records_container.get("REC"))
 
         try:
             total = int((data.get("QueryResult") or {}).get("RecordsFound") or 0)
@@ -173,18 +171,18 @@ class WoSSpider(AuthorSearchSpider):
             return None
 
         summary = publication.get("static_data", {}).get("summary", {})
-        titles = self._as_list(summary.get("titles", {}).get("title"))
+        titles = as_list(summary.get("titles", {}).get("title"))
         title = next(
             (t.get("content") for t in titles if isinstance(t, dict) and t.get("type") == "item"),
             None,
         )
 
-        names = self._as_list(summary.get("names", {}).get("name"))
+        names = as_list(summary.get("names", {}).get("name"))
         authors = self._extract_authors(names)
 
         pub_info = summary.get("pub_info", {})
         cluster_related = publication.get("dynamic_data", {}).get("cluster_related", {})
-        identifiers = self._as_list(cluster_related.get("identifiers", {}).get("identifier"))
+        identifiers = as_list(cluster_related.get("identifiers", {}).get("identifier"))
         doi = next(
             (
                 identifier.get("value")
@@ -200,14 +198,9 @@ class WoSSpider(AuthorSearchSpider):
             extra={
                 "journal_name": self._extract_journal_name(titles),
                 "publication_type": summary.get("doctypes", {}).get("doctype"),
-                "publication_year": self._parse_year(
-                    pub_info.get("pubyear") or pub_info.get("coverdate")
-                ),
                 "matched_author": matched_author,
             },
-            publication_date=self._parse_date(
-                pub_info.get("coverdate") or pub_info.get("sortdate")
-            ),
+            publication_date=parse_date(pub_info.get("coverdate") or pub_info.get("sortdate")),
             reference=str(external_id),
             repository=self.name,
             title=title,
@@ -245,52 +238,3 @@ class WoSSpider(AuthorSearchSpider):
                 return str(title["content"])
 
         return None
-
-    # === LOW-LEVEL UTILITY FUNCTIONS ===
-    # These are generic utility functions for data processing
-
-    @staticmethod
-    def _as_list(value: Any) -> list[Any]:
-        """Convert a value to a list, handling WoS API's inconsistent list/single item responses."""
-        if isinstance(value, list):
-            return value
-
-        if value is None:
-            return []
-
-        return [value]
-
-    @staticmethod
-    def _parse_date(value: Any) -> date | None:
-        """Parse a date value into a date object, returning None on failure."""
-        if not value:
-            return None
-        try:
-            return parse(str(value)).date()
-        except (ValueError, TypeError):
-            return None
-
-    @staticmethod
-    def _parse_year(value: Any) -> int | None:
-        """Parse a year value into an integer, with regex fallback for complex formats."""
-        if value is None:
-            return None
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            pass
-        match = re.search(r"(19|20)\d{2}", str(value))
-        if match:
-            return int(match.group())
-        return None
-
-    @staticmethod
-    def _validate_year(raw_year: str, field_name: str) -> int:
-        """Validate and convert a year string to integer, raising ValueError on failure."""
-        try:
-            value = int(raw_year)
-        except (TypeError, ValueError) as exc:
-            msg = f"Invalid value for '{field_name}': {raw_year!r}"
-            raise ValueError(msg) from exc
-
-        return value

--- a/src/open_ire/spiders/wos.py
+++ b/src/open_ire/spiders/wos.py
@@ -55,7 +55,7 @@ class WoSSpider(AuthorSearchSpider):
         self.headers = {"X-ApiKey": self.api_key}
 
     def _get_author_name(self, record: AuthorRecord) -> str:
-        return f"{record.last_name} {record.first_name}"
+        return f"{record.last_name}, {record.first_name}"
 
     # === HIGH-LEVEL WORKFLOW METHODS ===
     # These methods define the main crawling workflow
@@ -195,7 +195,7 @@ class WoSSpider(AuthorSearchSpider):
         )
 
         return ArticleItem(
-            authors=self._join_authors(authors),
+            authors=AuthorRecord.encode_author_string(authors),
             doi=doi,
             extra={
                 "journal_name": self._extract_journal_name(titles),
@@ -220,18 +220,18 @@ class WoSSpider(AuthorSearchSpider):
     # These methods extract specific data from WoS API responses
 
     @staticmethod
-    def _extract_authors(names: list[Any]) -> list[str]:
+    def _extract_authors(names: list[Any]) -> list[AuthorRecord]:
         """Extract author names from WoS names data structure."""
-        authors: list[str] = []
+        authors: list[AuthorRecord] = []
         for author in names:
             if not isinstance(author, dict):
                 continue
 
-            full_name = (
+            author_name = (
                 author.get("full_name") or author.get("display_name") or author.get("wos_standard")
             )
-            if full_name:
-                authors.append(str(full_name))
+            if author_name:
+                authors.append(AuthorRecord(author_name))
 
         return authors
 

--- a/src/open_ire/spiders/wos.py
+++ b/src/open_ire/spiders/wos.py
@@ -60,89 +60,8 @@ class WoSSpider(AuthorSearchSpider):
         """Override to provide names in 'LASTNAME FIRSTNAME' format for WoS."""
         return record.wos_name
 
-    @staticmethod
-    def _join_or_none(values: list[str]) -> str | None:
-        return ", ".join(values) if values else None
-
-    @staticmethod
-    def _parse_date(value: Any) -> date | None:
-        if not value:
-            return None
-        try:
-            return parse(str(value)).date()
-        except (ValueError, TypeError):
-            return None
-
-    @staticmethod
-    def _parse_year(value: Any) -> int | None:
-        if value is None:
-            return None
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            pass
-        match = re.search(r"(19|20)\d{2}", str(value))
-        if match:
-            return int(match.group())
-        return None
-
-    @staticmethod
-    def _validate_year(raw_year: str, field_name: str) -> int:
-        try:
-            value = int(raw_year)
-        except (TypeError, ValueError) as exc:
-            msg = f"Invalid value for '{field_name}': {raw_year!r}"
-            raise ValueError(msg) from exc
-
-        return value
-
-    @staticmethod
-    def _extract_authors(names: list[Any]) -> list[str]:
-        authors: list[str] = []
-        for author in names:
-            if not isinstance(author, dict):
-                continue
-
-            full_name = author.get("wos_standard") or author.get("display_name")
-            if full_name:
-                authors.append(str(full_name))
-
-        return authors
-
-    @staticmethod
-    def _extract_journal_name(titles: list[Any]) -> str | None:
-        for title in titles:
-            if not isinstance(title, dict):
-                continue
-            if title.get("type") == "source" and title.get("content"):
-                return str(title["content"])
-
-        return None
-
-    @staticmethod
-    def _as_list(value: Any) -> list[Any]:
-        if isinstance(value, list):
-            return value
-
-        if value is None:
-            return []
-
-        return [value]
-
-    def _build_query(self, term: str) -> str:
-        return (
-            f'AU=("{term}") AND OG=("{self.organization}") '
-            f"AND PY=({self.start_year}-{self.end_year})"
-        )
-
-    def _build_params(self, query: str, page: int) -> dict[str, Any]:
-        return {
-            "count": self.page_size,
-            "databaseId": "WOS",
-            "page": page,
-            "sortField": "PY+D",
-            "usrQuery": query,
-        }
+    # === HIGH-LEVEL WORKFLOW METHODS ===
+    # These methods define the main crawling workflow
 
     def build_search_request(self, term: str) -> Request:
         """Build a search request for a single author term."""
@@ -160,6 +79,7 @@ class WoSSpider(AuthorSearchSpider):
     def parse_publications(
         self, response: Response, query: str, page: int
     ) -> Generator[Request | ArticleItem, None, None]:
+        """Parse WoS publication results and yield ArticleItems, handling pagination."""
         raw_text = response.text or ""
         try:
             data = json.loads(raw_text)
@@ -222,7 +142,28 @@ class WoSSpider(AuthorSearchSpider):
                 cb_kwargs={"query": query, "page": next_page},
             )
 
+    # === SUPPORTING WORKFLOW METHODS ===
+    # These methods support the main workflow
+
+    def _build_query(self, term: str) -> str:
+        """Build WoS query string with author, organization, and date filters."""
+        return (
+            f'AU=("{term}") AND OG=("{self.organization}") '
+            f"AND PY=({self.start_year}-{self.end_year})"
+        )
+
+    def _build_params(self, query: str, page: int) -> dict[str, Any]:
+        """Build API request parameters for WoS search."""
+        return {
+            "count": self.page_size,
+            "databaseId": "WOS",
+            "page": page,
+            "sortField": "PY+D",
+            "usrQuery": query,
+        }
+
     def _build_item(self, publication: Any) -> ArticleItem | None:
+        """Build an ArticleItem from WoS publication data."""
         if not isinstance(publication, dict):
             return None
 
@@ -275,3 +216,85 @@ class WoSSpider(AuthorSearchSpider):
             if doi
             else f"https://www.webofscience.com/wos/woscc/full-record/{external_id}",
         )
+
+    # === DATA EXTRACTION UTILITIES ===
+    # These methods extract specific data from WoS API responses
+
+    @staticmethod
+    def _extract_authors(names: list[Any]) -> list[str]:
+        """Extract author names from WoS names data structure."""
+        authors: list[str] = []
+        for author in names:
+            if not isinstance(author, dict):
+                continue
+
+            full_name = author.get("wos_standard") or author.get("display_name")
+            if full_name:
+                authors.append(str(full_name))
+
+        return authors
+
+    @staticmethod
+    def _extract_journal_name(titles: list[Any]) -> str | None:
+        """Extract journal name from WoS titles data structure."""
+        for title in titles:
+            if not isinstance(title, dict):
+                continue
+            if title.get("type") == "source" and title.get("content"):
+                return str(title["content"])
+
+        return None
+
+    # === LOW-LEVEL UTILITY FUNCTIONS ===
+    # These are generic utility functions for data processing
+
+    @staticmethod
+    def _as_list(value: Any) -> list[Any]:
+        """Convert a value to a list, handling WoS API's inconsistent list/single item responses."""
+        if isinstance(value, list):
+            return value
+
+        if value is None:
+            return []
+
+        return [value]
+
+    @staticmethod
+    def _join_or_none(values: list[str]) -> str | None:
+        """Join a list of strings with commas, or return None if empty."""
+        return ", ".join(values) if values else None
+
+    @staticmethod
+    def _parse_date(value: Any) -> date | None:
+        """Parse a date value into a date object, returning None on failure."""
+        if not value:
+            return None
+        try:
+            return parse(str(value)).date()
+        except (ValueError, TypeError):
+            return None
+
+    @staticmethod
+    def _parse_year(value: Any) -> int | None:
+        """Parse a year value into an integer, with regex fallback for complex formats."""
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            pass
+        match = re.search(r"(19|20)\d{2}", str(value))
+        if match:
+            return int(match.group())
+        return None
+
+    @staticmethod
+    def _validate_year(raw_year: str, field_name: str) -> int:
+        """Validate and convert a year string to integer, raising ValueError on failure."""
+        try:
+            value = int(raw_year)
+        except (TypeError, ValueError) as exc:
+            msg = f"Invalid value for '{field_name}': {raw_year!r}"
+            raise ValueError(msg) from exc
+
+        return value

--- a/src/open_ire/spiders/wos.py
+++ b/src/open_ire/spiders/wos.py
@@ -10,13 +10,17 @@ from urllib.parse import urlencode
 from dateutil.parser import parse
 from scrapy.http import Request, Response
 
-from open_ire.faculty import AuthorMatcher, FacultyRecord
+from open_ire.author import AuthorMatcher, AuthorRecord
 from open_ire.items import ArticleItem
 from open_ire.settings import WOS_ORGANIZATION
-from open_ire.spiders.search import FacultySearchSpider
+from open_ire.spiders.search import AuthorSearchSpider
 
 
-class WoSSpider(FacultySearchSpider):
+class WoSSpider(AuthorSearchSpider):
+    """
+    Web of Science API spider for collecting academic publications by author.
+    """
+
     name = "wos"
     base_url = "https://api.clarivate.com/api/wos/"
     page_size = 25
@@ -29,7 +33,7 @@ class WoSSpider(FacultySearchSpider):
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
-        faculty_csv = kwargs["faculty_csv"]
+        author_csv = kwargs["author_csv"]
 
         current_year = datetime.date.today().year
         self.organization = WOS_ORGANIZATION
@@ -50,9 +54,9 @@ class WoSSpider(FacultySearchSpider):
             raise ValueError(msg)
 
         self.headers = {"X-ApiKey": self.api_key}
-        self.author_matcher = AuthorMatcher(faculty_csv, "wos")
+        self.author_matcher = AuthorMatcher(author_csv, "wos")
 
-    def _get_author_name(self, record: FacultyRecord) -> str:
+    def _get_author_name(self, record: AuthorRecord) -> str:
         """Override to provide names in 'LASTNAME FIRSTNAME' format for WoS."""
         return record.wos_name
 

--- a/src/open_ire/spiders/wos.py
+++ b/src/open_ire/spiders/wos.py
@@ -195,12 +195,12 @@ class WoSSpider(AuthorSearchSpider):
         )
 
         return ArticleItem(
-            authors=self._join_or_none(authors),
+            authors=self._join_authors(authors),
             doi=doi,
             extra={
                 "journal_name": self._extract_journal_name(titles),
-                "matched_author": self._join_or_none(matched_names),
-                "matched_email": self._join_or_none(matched_emails),
+                "matched_author": self._join_authors(matched_names),
+                "matched_email": self._join_authors(matched_emails),
                 "publication_type": summary.get("doctypes", {}).get("doctype"),
                 "publication_year": self._parse_year(
                     pub_info.get("pubyear") or pub_info.get("coverdate")
@@ -260,11 +260,6 @@ class WoSSpider(AuthorSearchSpider):
             return []
 
         return [value]
-
-    @staticmethod
-    def _join_or_none(values: list[str]) -> str | None:
-        """Join a list of strings with commas, or return None if empty."""
-        return ", ".join(values) if values else None
 
     @staticmethod
     def _parse_date(value: Any) -> date | None:

--- a/src/open_ire/utils.py
+++ b/src/open_ire/utils.py
@@ -1,0 +1,38 @@
+"""Common utility functions."""
+
+from datetime import date
+from typing import Any
+
+from dateutil.parser import parse
+
+
+def parse_date(value: Any) -> date | None:
+    """Parse a date value into a date object, returning None on failure."""
+    if not value:
+        return None
+    try:
+        return parse(str(value)).date()
+    except (ValueError, TypeError):
+        return None
+
+
+def validate_year(raw_year: str, field_name: str) -> int:
+    """Validate and convert a year string to integer, raising ValueError on failure."""
+    try:
+        year = int(raw_year)
+        if 1900 <= year <= 2100:  # Reasonable year range
+            return year
+        msg = f"Year {year} is outside reasonable range (1900-2100)"
+        raise ValueError(msg)
+    except (TypeError, ValueError) as e:
+        msg = f"Invalid {field_name}: '{raw_year}' - {e}"
+        raise ValueError(msg) from e
+
+
+def as_list(value: Any) -> list[Any]:
+    """Convert a value to a list, handling API's inconsistent list/single item responses."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]

--- a/tests/spiders/test_openalex.py
+++ b/tests/spiders/test_openalex.py
@@ -80,10 +80,11 @@ class TestOpenAlexSpider:
         ],
     )
     def test_request_publications(self, spider, author_id, cursor) -> None:
-        requests = list(spider._request_publications(author_id, cursor))
+        requests = list(spider._request_publications(author_id, "Kemi Adeyemi", cursor))
         assert len(requests) == 1
         assert requests[0].url.startswith(spider.base_url + "/works")
         assert requests[0].cb_kwargs["author_id"] == author_id
+        assert requests[0].meta['matched_author'] == "Kemi Adeyemi"
 
         parsed_url = urlparse(requests[0].url)
         query_params = parse_qs(parsed_url.query)
@@ -91,8 +92,9 @@ class TestOpenAlexSpider:
 
     def test_author_publication_requests(self, spider) -> None:
         response_data = {"results": [{"id": "A1"}, {"id": "A2"}]}
+        request = Request(url="http://dummy.url", meta={'matched_author': "Kemi Adeyemi"})
         response = HtmlResponse(
-            url="http://dummy.url", body=json.dumps(response_data), encoding="utf-8"
+            url="http://dummy.url", body=json.dumps(response_data), encoding="utf-8", request=request
         )
 
         requests = list(spider.author_publication_requests(response))
@@ -111,8 +113,9 @@ class TestOpenAlexSpider:
             ],
             "meta": {"next_cursor": "cursor123"},
         }
+        request = Request(url="http://dummy.url", meta={'matched_author': "Kemi Adeyemi"})
         response = HtmlResponse(
-            url="http://dummy.url", body=json.dumps(publication_data), encoding="utf-8"
+            url="http://dummy.url", body=json.dumps(publication_data), encoding="utf-8", request=request
         )
 
         emitted = list(spider.parse_publications(response, author_id="A1"))
@@ -120,11 +123,12 @@ class TestOpenAlexSpider:
         assert isinstance(emitted[1], Request)
 
     def test_build_item(self, spider, dummy_publication) -> None:
-        item = spider._build_item(dummy_publication)
+        item = spider._build_item(dummy_publication, "Kemi Adeyemi")
         assert isinstance(item, ArticleItem)
         assert item.doi == "https://doi.org/10.1234/test.doi"  # Spider returns original DOI, pipeline normalizes it
         assert item.title == "A Study on Testing"
         assert item.extra["journal_name"] == "Journal of Testing"
+        assert item.extra["matched_author"] == "Kemi Adeyemi"
         assert item.authors == "Alice Smith; Bob Jones"
 
     def test_build_search_request(self, spider) -> None:

--- a/tests/spiders/test_openalex.py
+++ b/tests/spiders/test_openalex.py
@@ -125,7 +125,7 @@ class TestOpenAlexSpider:
         assert item.doi == "https://doi.org/10.1234/test.doi"  # Spider returns original DOI, pipeline normalizes it
         assert item.title == "A Study on Testing"
         assert item.extra["journal_name"] == "Journal of Testing"
-        assert item.authors == "Alice Smith, Bob Jones"
+        assert item.authors == "Alice Smith; Bob Jones"
 
     def test_build_search_request(self, spider) -> None:
         request = spider.build_search_request("Kemi Adeyemi")

--- a/tests/spiders/test_openalex.py
+++ b/tests/spiders/test_openalex.py
@@ -17,7 +17,7 @@ Kemi Adeyemi,Kemi,Adeyemi,kadeyemi@uw.edu
     csv_path = tmp_path / "adeyemi.csv"
     csv_path.write_text(csv_content)
 
-    return OpenAlexSpider(faculty_csv=str(csv_path))
+    return OpenAlexSpider(author_csv=str(csv_path))
 
 
 @pytest.fixture

--- a/tests/spiders/test_openalex.py
+++ b/tests/spiders/test_openalex.py
@@ -133,7 +133,8 @@ class TestOpenAlexSpider:
         assert request.url.startswith(spider.base_url + "/authors")
         parsed_url = urlparse(request.url)
         query_params = parse_qs(parsed_url.query)
-        assert "display_name.search:Kemi Adeyemi" in query_params["filter"][0]
+        assert query_params["search"] == ["Kemi Adeyemi"]
+        assert "affiliations.institution.id:" in query_params["filter"][0]
 
     @pytest.mark.asyncio
     async def test_start(self, spider) -> None:

--- a/tests/spiders/test_openalex.py
+++ b/tests/spiders/test_openalex.py
@@ -5,14 +5,15 @@ from scrapy.http import HtmlResponse, Request
 from typing import Any
 from urllib.parse import urlparse, parse_qs
 
+from open_ire.author import AuthorRecord
 from open_ire.items import ArticleItem
 from open_ire.spiders.openalex import OpenAlexSpider
 
 
 @pytest.fixture
-def spider(tmp_path: Path) -> OpenAlexSpider:
-    csv_content = """Full Name,FirstName,LastName,Email
-Kemi Adeyemi,Kemi,Adeyemi,kadeyemi@uw.edu
+def spider(tmp_path: Path, five_authors: list[AuthorRecord]) -> OpenAlexSpider:
+    csv_content = f"""Full Name,FirstName,LastName,Email
+{five_authors[4].full_name},{five_authors[4].first_name},{five_authors[4].last_name},{five_authors[4].email}
 """
     csv_path = tmp_path / "adeyemi.csv"
     csv_path.write_text(csv_content)
@@ -21,15 +22,26 @@ Kemi Adeyemi,Kemi,Adeyemi,kadeyemi@uw.edu
 
 
 @pytest.fixture
-def dummy_publication() -> dict[str, Any]:
+def five_authors() -> list[AuthorRecord]:
+    return [
+        AuthorRecord("Luis Manuel Garcia-Mispireta"),
+        AuthorRecord("E.V.S.S.K. Babu"),
+        AuthorRecord("Ramón H. Rivera-Servera"),
+        AuthorRecord("M. Elena Alvarez-Alvarez"),
+        AuthorRecord("Kemi Adeyemi", email="kadeyemi@uw.edu"),
+    ]
+
+
+@pytest.fixture
+def dummy_publication(five_authors) -> dict[str, Any]:
     return {
         "id": "W123",
         "title": "A Study on Testing",
         "publication_date": "2022-05-15",
         "primary_location": {"source": {"display_name": "Journal of Testing"}},
         "authorships": [
-            {"author": {"display_name": "Alice Smith"}},
-            {"author": {"display_name": "Bob Jones"}},
+            {"author": {"display_name": five_authors[0].full_name}},
+            {"author": {"display_name": five_authors[1].full_name}},
         ],
         "doi": "https://doi.org/10.1234/test.doi",
     }
@@ -56,18 +68,9 @@ class TestOpenAlexSpider:
         )
         assert journal_name == None
 
-    def test_extract_authors(self) -> None:
-        publication = {
-            "authorships": [
-                {"author": {"display_name": "Alice Smith"}},
-                {"author": {"display_name": "Bob Jones"}},
-                {"author": {}},
-                "invalid authorship",
-            ]
-        }
-
-        authors = OpenAlexSpider._extract_authors(publication)
-        assert authors == ["Alice Smith", "Bob Jones"]
+    def test_extract_authors(self, five_authors, dummy_publication) -> None:
+        authors = OpenAlexSpider._extract_authors(dummy_publication)
+        assert authors == [five_authors[0], five_authors[1]]
 
         authors = OpenAlexSpider._extract_authors({})
         assert authors == []
@@ -79,22 +82,29 @@ class TestOpenAlexSpider:
             ("A2", "cursor123"),
         ],
     )
-    def test_request_publications(self, spider, author_id, cursor) -> None:
-        requests = list(spider._request_publications(author_id, "Kemi Adeyemi", cursor))
+    def test_request_publications(self, spider, five_authors, author_id, cursor) -> None:
+        requests = list(
+            spider._request_publications(author_id, five_authors[0].normalized_name, cursor)
+        )
         assert len(requests) == 1
         assert requests[0].url.startswith(spider.base_url + "/works")
         assert requests[0].cb_kwargs["author_id"] == author_id
-        assert requests[0].meta['matched_author'] == "Kemi Adeyemi"
+        assert requests[0].meta["matched_author"] == five_authors[0].normalized_name
 
         parsed_url = urlparse(requests[0].url)
         query_params = parse_qs(parsed_url.query)
         assert query_params["cursor"] == [cursor]
 
-    def test_author_publication_requests(self, spider) -> None:
+    def test_author_publication_requests(self, spider, five_authors) -> None:
         response_data = {"results": [{"id": "A1"}, {"id": "A2"}]}
-        request = Request(url="http://dummy.url", meta={'matched_author': "Kemi Adeyemi"})
+        request = Request(
+            url="http://dummy.url", meta={"matched_author": five_authors[0].normalized_name}
+        )
         response = HtmlResponse(
-            url="http://dummy.url", body=json.dumps(response_data), encoding="utf-8", request=request
+            url="http://dummy.url",
+            body=json.dumps(response_data),
+            encoding="utf-8",
+            request=request,
         )
 
         requests = list(spider.author_publication_requests(response))
@@ -103,7 +113,7 @@ class TestOpenAlexSpider:
         assert requests[0].url.startswith(spider.base_url + "/works")
         assert requests[1].url.startswith(spider.base_url + "/works")
 
-    def test_parse_publications(self, spider, dummy_publication) -> None:
+    def test_parse_publications(self, spider, five_authors, dummy_publication) -> None:
         publication_data = {
             "results": [
                 {
@@ -113,31 +123,38 @@ class TestOpenAlexSpider:
             ],
             "meta": {"next_cursor": "cursor123"},
         }
-        request = Request(url="http://dummy.url", meta={'matched_author': "Kemi Adeyemi"})
+        request = Request(
+            url="http://dummy.url", meta={"matched_author": five_authors[0].normalized_name}
+        )
         response = HtmlResponse(
-            url="http://dummy.url", body=json.dumps(publication_data), encoding="utf-8", request=request
+            url="http://dummy.url",
+            body=json.dumps(publication_data),
+            encoding="utf-8",
+            request=request,
         )
 
         emitted = list(spider.parse_publications(response, author_id="A1"))
         assert isinstance(emitted[0], ArticleItem)
         assert isinstance(emitted[1], Request)
 
-    def test_build_item(self, spider, dummy_publication) -> None:
-        item = spider._build_item(dummy_publication, "Kemi Adeyemi")
+    def test_build_item(self, spider, five_authors, dummy_publication) -> None:
+        item = spider._build_item(dummy_publication, five_authors[0].normalized_name)
         assert isinstance(item, ArticleItem)
-        assert item.doi == "https://doi.org/10.1234/test.doi"  # Spider returns original DOI, pipeline normalizes it
+        assert (
+            item.doi == "https://doi.org/10.1234/test.doi"
+        )  # Spider returns original DOI, pipeline normalizes it
         assert item.title == "A Study on Testing"
         assert item.extra["journal_name"] == "Journal of Testing"
-        assert item.extra["matched_author"] == "Kemi Adeyemi"
-        assert item.authors == "Alice Smith; Bob Jones"
+        assert item.extra["matched_author"] == five_authors[0].normalized_name
+        assert item.authors == AuthorRecord.encode_author_string([five_authors[0], five_authors[1]])
 
-    def test_build_search_request(self, spider) -> None:
-        request = spider.build_search_request("Kemi Adeyemi")
+    def test_build_search_request(self, spider, five_authors) -> None:
+        request = spider.build_search_request(five_authors[0].normalized_name)
         assert isinstance(request, Request)
         assert request.url.startswith(spider.base_url + "/authors")
         parsed_url = urlparse(request.url)
         query_params = parse_qs(parsed_url.query)
-        assert query_params["search"] == ["Kemi Adeyemi"]
+        assert query_params["search"] == [five_authors[0].normalized_name]
         assert "affiliations.institution.id:" in query_params["filter"][0]
 
     @pytest.mark.asyncio

--- a/tests/spiders/test_wos.py
+++ b/tests/spiders/test_wos.py
@@ -6,14 +6,26 @@ from scrapy.http import HtmlResponse, Request
 from typing import Any
 from urllib.parse import urlparse, parse_qs
 
+from open_ire.author import AuthorRecord
 from open_ire.items import ArticleItem
 from open_ire.spiders.wos import WoSSpider
 
 
 @pytest.fixture
-def dummy_csv(tmp_path: Path) -> Path:
-    csv_content = """Full Name,FirstName,LastName,Email
-Amina ElSayed,Amina,ElSayed,amina.elsayed@example.edu
+def five_authors() -> list[AuthorRecord]:
+    return [
+        AuthorRecord("Luis Manuel Garcia-Mispireta"),
+        AuthorRecord("E.V.S.S.K. Babu"),
+        AuthorRecord("Ramón H. Rivera-Servera"),
+        AuthorRecord("M. Elena Alvarez-Alvarez"),
+        AuthorRecord("Kemi Adeyemi", email="kadeyemi@uw.edu"),
+    ]
+
+
+@pytest.fixture
+def dummy_csv(tmp_path: Path, five_authors: list[AuthorRecord]) -> Path:
+    csv_content = f"""Full Name,FirstName,LastName,Email
+{five_authors[4].full_name},{five_authors[4].first_name},{five_authors[4].last_name},{five_authors[4].email}
 """
     csv_path = tmp_path / "dummy.csv"
     csv_path.write_text(csv_content)
@@ -21,7 +33,7 @@ Amina ElSayed,Amina,ElSayed,amina.elsayed@example.edu
 
 
 @pytest.fixture
-def dummy_record() -> dict[str, Any]:
+def dummy_record(five_authors: list[AuthorRecord]) -> dict[str, Any]:
     return {
         "UID": "WOS:000123456789",
         "static_data": {
@@ -38,8 +50,8 @@ def dummy_record() -> dict[str, Any]:
                 },
                 "names": {
                     "name": [
-                        {"display_name": "ElSayed, Amina", "wos_standard": "ElSayed, A"},
-                        {"display_name": "Doe, John", "wos_standard": "Doe, J"},
+                        {"display_name": five_authors[4].normalized_name, "wos_standard": f"{five_authors[4].last_name}, {five_authors[4].first_initial}"},
+                        {"display_name": five_authors[0].normalized_name, "wos_standard": f"{five_authors[0].last_name}, {five_authors[0].first_initial}"},
                     ]
                 },
                 "doctypes": {"doctype": "Article"},
@@ -70,43 +82,43 @@ def spider(dummy_csv: Path, monkeypatch) -> WoSSpider:
 
 
 class TestWoSSpider:
-    def test_build_item(self, spider: WoSSpider, dummy_record: dict[str, Any]) -> None:
-        item = spider._build_item(dummy_record, "ElSayed Amina")
+    def test_build_item(self, spider: WoSSpider, five_authors: list[AuthorRecord], dummy_record: dict[str, Any]) -> None:
+        item = spider._build_item(dummy_record, five_authors[4].normalized_name)
 
         assert isinstance(item, ArticleItem)
         assert item.title == "Sample Publication Title"
         assert item.extra["publication_year"] == 2020
-        assert item.extra["matched_author"] == "ElSayed Amina"
+        assert item.extra["matched_author"] == five_authors[4].normalized_name
         assert item.doi == "10.1000/sampledoi"
-        assert item.authors == "ElSayed, Amina; Doe, John"
+        assert item.authors == AuthorRecord.encode_author_string([five_authors[4], five_authors[0]])
         assert item.url == "https://doi.org/10.1000/sampledoi"
 
-    def test_build_item_without_doi(self, spider: WoSSpider, dummy_record: dict[str, Any]) -> None:
+    def test_build_item_without_doi(self, spider: WoSSpider, five_authors: list[AuthorRecord], dummy_record: dict[str, Any]) -> None:
         # Remove DOI from the record
         record_without_doi = copy.deepcopy(dummy_record)
         record_without_doi["dynamic_data"]["cluster_related"]["identifiers"] = {"identifier": []}
 
-        item = spider._build_item(record_without_doi, "ElSayed Amina")
+        item = spider._build_item(record_without_doi, five_authors[4].normalized_name)
 
         assert isinstance(item, ArticleItem)
         assert item.doi is None
         assert item.url == "https://www.webofscience.com/wos/woscc/full-record/WOS:000123456789"
 
-    def test_build_item_missing_identifiers_section(self, spider: WoSSpider, dummy_record: dict[str, Any]) -> None:
+    def test_build_item_missing_identifiers_section(self, spider: WoSSpider, five_authors: list[AuthorRecord], dummy_record: dict[str, Any]) -> None:
         # Remove entire identifiers section
         record_no_identifiers = copy.deepcopy(dummy_record)
         record_no_identifiers["dynamic_data"]["cluster_related"] = {}
 
-        item = spider._build_item(record_no_identifiers, "ElSayed Amina")
+        item = spider._build_item(record_no_identifiers, five_authors[4].normalized_name)
 
         assert isinstance(item, ArticleItem)
         assert item.doi is None
         assert item.url == "https://www.webofscience.com/wos/woscc/full-record/WOS:000123456789"
 
-    def test_parse_publications(self, spider: WoSSpider, dummy_response: HtmlResponse) -> None:
-        query = spider._build_query("Kemi Adeyemi")
+    def test_parse_publications(self, spider: WoSSpider, five_authors: list[AuthorRecord], dummy_response: HtmlResponse) -> None:
+        query = spider._build_query(five_authors[4].normalized_name)
         # Create a request with meta to tie to the response
-        request = Request(url="http://example.com/api", meta={'matched_author': "Kemi Adeyemi"})
+        request = Request(url="http://example.com/api", meta={'matched_author': five_authors[4].normalized_name})
         dummy_response = dummy_response.replace(request=request)
 
         results = list(spider.parse_publications(dummy_response, query, page=1))
@@ -120,22 +132,22 @@ class TestWoSSpider:
         assert item.reference == "WOS:000123456789"
         assert item.title == "Sample Publication Title"
         assert item.extra["publication_year"] == 2020
-        assert item.extra["matched_author"] == "Kemi Adeyemi"
+        assert item.extra["matched_author"] == five_authors[4].normalized_name
         assert item.doi == "10.1000/sampledoi"
-        assert item.authors == "ElSayed, Amina; Doe, John"
+        assert item.authors == AuthorRecord.encode_author_string([five_authors[4], five_authors[0]])
 
     def test_validate_year(self, spider: WoSSpider) -> None:
         assert spider._validate_year("2020", "Some Field") == 2020
         with pytest.raises(ValueError):
             spider._validate_year("NotAYear", "Some Field")
 
-    def test_build_search_request(self, spider: WoSSpider) -> None:
-        request = spider.build_search_request("Adeyemi Kemi")
+    def test_build_search_request(self, spider: WoSSpider, five_authors: list[AuthorRecord]) -> None:
+        request = spider.build_search_request(five_authors[4].normalized_name)
 
         assert request.url.startswith(spider.base_url + "?count=25&databaseId=WOS")
 
     def test_parse_publications_no_results_records_empty_string(
-        self, spider: WoSSpider
+        self, spider: WoSSpider, five_authors: list[AuthorRecord]
     ) -> None:
         # WoS empty results schema: records is an empty string
         json_body = {
@@ -143,10 +155,10 @@ class TestWoSSpider:
             "QueryResult": {"RecordsFound": 0},
         }
         body_str = json.dumps(json_body)
-        request = Request(url="http://example.com/api", meta={'matched_author': "Nobody Matches"})
+        request = Request(url="http://example.com/api", meta={'matched_author': five_authors[1].normalized_name})
         response = HtmlResponse(url="http://example.com/api", body=body_str, encoding="utf-8", request=request)
 
-        query = spider._build_query("Nobody Matches")
+        query = spider._build_query(five_authors[1].normalized_name)
         results = list(spider.parse_publications(response, query, page=1))
 
         items = [res for res in results if isinstance(res, ArticleItem)]
@@ -156,7 +168,7 @@ class TestWoSSpider:
         assert requests == []
 
     def test_parse_publications_records_container_string_is_ignored(
-        self, spider: WoSSpider
+        self, spider: WoSSpider, five_authors: list[AuthorRecord]
     ) -> None:
         # Sometimes WoS returns a string in `records` (e.g., error-ish message).
         json_body = {
@@ -164,10 +176,10 @@ class TestWoSSpider:
             "QueryResult": {"RecordsFound": 0},
         }
         body_str = json.dumps(json_body)
-        request = Request(url="http://example.com/api", meta={'matched_author': "Also Nobody"})
+        request = Request(url="http://example.com/api", meta={'matched_author': five_authors[2].normalized_name})
         response = HtmlResponse(url="http://example.com/api", body=body_str, encoding="utf-8", request=request)
 
-        query = spider._build_query("Also Nobody")
+        query = spider._build_query(five_authors[2].normalized_name)
         results = list(spider.parse_publications(response, query, page=1))
 
         items = [res for res in results if isinstance(res, ArticleItem)]

--- a/tests/spiders/test_wos.py
+++ b/tests/spiders/test_wos.py
@@ -66,7 +66,7 @@ def dummy_response(dummy_record: dict[str, Any]) -> HtmlResponse:
 @pytest.fixture
 def spider(dummy_csv: Path, monkeypatch) -> WoSSpider:
     monkeypatch.setenv("WOS_API_KEY", "dummy_api_key")
-    return WoSSpider(faculty_csv=str(dummy_csv), start_year="2020", end_year="2021")
+    return WoSSpider(author_csv=str(dummy_csv), start_year="2020", end_year="2021")
 
 
 class TestWoSSpider:

--- a/tests/spiders/test_wos.py
+++ b/tests/spiders/test_wos.py
@@ -77,7 +77,7 @@ class TestWoSSpider:
         assert item.title == "Sample Publication Title"
         assert item.extra["publication_year"] == 2020
         assert item.doi == "10.1000/sampledoi"
-        assert item.authors == "ElSayed, Amina, Doe, John"
+        assert item.authors == "ElSayed, Amina; Doe, John"
         assert item.url == "https://doi.org/10.1000/sampledoi"
 
     def test_build_item_without_doi(self, spider: WoSSpider, dummy_record: dict[str, Any]) -> None:
@@ -116,7 +116,7 @@ class TestWoSSpider:
         assert item.title == "Sample Publication Title"
         assert item.extra["publication_year"] == 2020
         assert item.doi == "10.1000/sampledoi"
-        assert item.authors == "ElSayed, Amina, Doe, John"
+        assert item.authors == "ElSayed, Amina; Doe, John"
 
     def test_validate_year(self, spider: WoSSpider) -> None:
         assert spider._validate_year("2020", "Some Field") == 2020

--- a/tests/spiders/test_wos.py
+++ b/tests/spiders/test_wos.py
@@ -71,11 +71,12 @@ def spider(dummy_csv: Path, monkeypatch) -> WoSSpider:
 
 class TestWoSSpider:
     def test_build_item(self, spider: WoSSpider, dummy_record: dict[str, Any]) -> None:
-        item = spider._build_item(dummy_record)
+        item = spider._build_item(dummy_record, "ElSayed Amina")
 
         assert isinstance(item, ArticleItem)
         assert item.title == "Sample Publication Title"
         assert item.extra["publication_year"] == 2020
+        assert item.extra["matched_author"] == "ElSayed Amina"
         assert item.doi == "10.1000/sampledoi"
         assert item.authors == "ElSayed, Amina; Doe, John"
         assert item.url == "https://doi.org/10.1000/sampledoi"
@@ -85,7 +86,7 @@ class TestWoSSpider:
         record_without_doi = copy.deepcopy(dummy_record)
         record_without_doi["dynamic_data"]["cluster_related"]["identifiers"] = {"identifier": []}
 
-        item = spider._build_item(record_without_doi)
+        item = spider._build_item(record_without_doi, "ElSayed Amina")
 
         assert isinstance(item, ArticleItem)
         assert item.doi is None
@@ -96,7 +97,7 @@ class TestWoSSpider:
         record_no_identifiers = copy.deepcopy(dummy_record)
         record_no_identifiers["dynamic_data"]["cluster_related"] = {}
 
-        item = spider._build_item(record_no_identifiers)
+        item = spider._build_item(record_no_identifiers, "ElSayed Amina")
 
         assert isinstance(item, ArticleItem)
         assert item.doi is None
@@ -104,6 +105,10 @@ class TestWoSSpider:
 
     def test_parse_publications(self, spider: WoSSpider, dummy_response: HtmlResponse) -> None:
         query = spider._build_query("Kemi Adeyemi")
+        # Create a request with meta to tie to the response
+        request = Request(url="http://example.com/api", meta={'matched_author': "Kemi Adeyemi"})
+        dummy_response = dummy_response.replace(request=request)
+
         results = list(spider.parse_publications(dummy_response, query, page=1))
         items = [res for res in results if isinstance(res, ArticleItem)]
         requests = [res for res in results if isinstance(res, Request)]
@@ -115,6 +120,7 @@ class TestWoSSpider:
         assert item.reference == "WOS:000123456789"
         assert item.title == "Sample Publication Title"
         assert item.extra["publication_year"] == 2020
+        assert item.extra["matched_author"] == "Kemi Adeyemi"
         assert item.doi == "10.1000/sampledoi"
         assert item.authors == "ElSayed, Amina; Doe, John"
 
@@ -137,7 +143,8 @@ class TestWoSSpider:
             "QueryResult": {"RecordsFound": 0},
         }
         body_str = json.dumps(json_body)
-        response = HtmlResponse(url="http://example.com/api", body=body_str, encoding="utf-8")
+        request = Request(url="http://example.com/api", meta={'matched_author': "Nobody Matches"})
+        response = HtmlResponse(url="http://example.com/api", body=body_str, encoding="utf-8", request=request)
 
         query = spider._build_query("Nobody Matches")
         results = list(spider.parse_publications(response, query, page=1))
@@ -157,7 +164,8 @@ class TestWoSSpider:
             "QueryResult": {"RecordsFound": 0},
         }
         body_str = json.dumps(json_body)
-        response = HtmlResponse(url="http://example.com/api", body=body_str, encoding="utf-8")
+        request = Request(url="http://example.com/api", meta={'matched_author': "Also Nobody"})
+        response = HtmlResponse(url="http://example.com/api", body=body_str, encoding="utf-8", request=request)
 
         query = spider._build_query("Also Nobody")
         results = list(spider.parse_publications(response, query, page=1))

--- a/tests/spiders/test_wos.py
+++ b/tests/spiders/test_wos.py
@@ -77,8 +77,7 @@ class TestWoSSpider:
         assert item.title == "Sample Publication Title"
         assert item.extra["publication_year"] == 2020
         assert item.doi == "10.1000/sampledoi"
-        assert item.authors == "ElSayed, A, Doe, J"
-        assert item.extra["matched_author"] is None
+        assert item.authors == "ElSayed, Amina, Doe, John"
         assert item.url == "https://doi.org/10.1000/sampledoi"
 
     def test_build_item_without_doi(self, spider: WoSSpider, dummy_record: dict[str, Any]) -> None:
@@ -117,8 +116,7 @@ class TestWoSSpider:
         assert item.title == "Sample Publication Title"
         assert item.extra["publication_year"] == 2020
         assert item.doi == "10.1000/sampledoi"
-        assert item.authors == "ElSayed, A, Doe, J"
-        assert item.extra["matched_author"] is None
+        assert item.authors == "ElSayed, Amina, Doe, John"
 
     def test_validate_year(self, spider: WoSSpider) -> None:
         assert spider._validate_year("2020", "Some Field") == 2020

--- a/tests/spiders/test_wos.py
+++ b/tests/spiders/test_wos.py
@@ -87,7 +87,6 @@ class TestWoSSpider:
 
         assert isinstance(item, ArticleItem)
         assert item.title == "Sample Publication Title"
-        assert item.extra["publication_year"] == 2020
         assert item.extra["matched_author"] == five_authors[4].normalized_name
         assert item.doi == "10.1000/sampledoi"
         assert item.authors == AuthorRecord.encode_author_string([five_authors[4], five_authors[0]])
@@ -131,15 +130,9 @@ class TestWoSSpider:
         item = items[0]
         assert item.reference == "WOS:000123456789"
         assert item.title == "Sample Publication Title"
-        assert item.extra["publication_year"] == 2020
         assert item.extra["matched_author"] == five_authors[4].normalized_name
         assert item.doi == "10.1000/sampledoi"
         assert item.authors == AuthorRecord.encode_author_string([five_authors[4], five_authors[0]])
-
-    def test_validate_year(self, spider: WoSSpider) -> None:
-        assert spider._validate_year("2020", "Some Field") == 2020
-        with pytest.raises(ValueError):
-            spider._validate_year("NotAYear", "Some Field")
 
     def test_build_search_request(self, spider: WoSSpider, five_authors: list[AuthorRecord]) -> None:
         request = spider.build_search_request(five_authors[4].normalized_name)

--- a/tests/test_author.py
+++ b/tests/test_author.py
@@ -1,0 +1,163 @@
+"""Tests for author.py module."""
+
+from pathlib import Path
+
+import pytest
+from nameparser import HumanName
+
+from open_ire.author import AuthorIndex, AuthorRecord
+
+
+class TestAuthorRecord:
+    """Tests for AuthorRecord class."""
+
+    def test_create_with_string(self) -> None:
+        """Test creating AuthorRecord with a string name."""
+        record = AuthorRecord(name="John A. Doe Jr.", email="john@example.com")
+
+        assert record.email == "john@example.com"
+        assert record.first_name == "John"
+        assert record.last_name == "Doe"
+        assert record.middle_name == "A."
+        assert record.suffix == "Jr."
+
+    def test_create_with_human_name(self) -> None:
+        """Test creating AuthorRecord with a HumanName object."""
+        human_name = HumanName("Dr. Jane Smith")
+        record = AuthorRecord(name=human_name, email="jane@example.com")
+
+        assert record.email == "jane@example.com"
+        assert record.first_name == "Jane"
+        assert record.last_name == "Smith"
+        assert record.title == "Dr."
+
+    def test_first_initial(self) -> None:
+        """Test first_initial property."""
+        record = AuthorRecord(name="John Doe", email="test@example.com")
+        assert record.first_initial == "J"
+
+    def test_middle_initial(self) -> None:
+        """Test middle_initial property."""
+        record = AuthorRecord(name="John Andrew Doe", email="test@example.com")
+        assert record.middle_initial == "A"
+
+    def test_middle_initial_empty(self) -> None:
+        """Test middle_initial when no middle name exists."""
+        record = AuthorRecord(name="John Doe", email="test@example.com")
+        assert record.middle_initial == ""
+
+    def test_complex_name_parsing(self) -> None:
+        """Test parsing of complex names with titles and suffixes."""
+        record = AuthorRecord(name="Prof. Robert James Smith III, PhD", email="rsmith@example.com")
+
+        assert record.title == "Prof."
+        assert record.first_name == "Robert"
+        assert record.middle_name == "James"
+        assert record.last_name == "Smith"
+        assert record.suffix == "III, PhD"
+
+    def test_empty_name_components(self) -> None:
+        """Test that empty name components return empty strings."""
+        record = AuthorRecord(name="", email="test@example.com")
+
+        assert record.first_name == ""
+        assert record.last_name == ""
+        assert record.middle_name == ""
+        assert record.title == ""
+        assert record.suffix == ""
+        assert record.first_initial == ""
+        assert record.middle_initial == ""
+
+
+class TestAuthorIndex:
+    """Tests for AuthorIndex class."""
+
+    def test_load_valid_csv(self, tmp_path: Path) -> None:
+        """Test loading a valid CSV file."""
+        csv_content = """FirstName,LastName,Email
+John,Doe,john@example.com
+Jane,Smith,jane@example.com
+"""
+        csv_path = tmp_path / "authors.csv"
+        csv_path.write_text(csv_content)
+
+        index = AuthorIndex(csv_path)
+
+        assert len(index.records) == 2
+        assert index.records[0].first_name == "John"
+        assert index.records[0].last_name == "Doe"
+        assert index.records[0].email == "john@example.com"
+        assert index.records[1].first_name == "Jane"
+        assert index.records[1].last_name == "Smith"
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        """Test that FileNotFoundError is raised for missing file."""
+        csv_path = tmp_path / "nonexistent.csv"
+
+        with pytest.raises(FileNotFoundError, match="Author file not found"):
+            AuthorIndex(csv_path)
+
+    def test_missing_required_columns(self, tmp_path: Path) -> None:
+        """Test that ValueError is raised when required columns are missing."""
+        csv_content = """Name,Email
+John Doe,john@example.com
+"""
+        csv_path = tmp_path / "authors.csv"
+        csv_path.write_text(csv_content)
+
+        with pytest.raises(ValueError, match="must include columns"):
+            AuthorIndex(csv_path)
+
+    def test_empty_csv(self, tmp_path: Path) -> None:
+        """Test that ValueError is raised for CSV with no valid records."""
+        csv_content = """FirstName,LastName,Email
+,,
+"""
+        csv_path = tmp_path / "authors.csv"
+        csv_path.write_text(csv_content)
+
+        with pytest.raises(ValueError, match="No valid author records found"):
+            AuthorIndex(csv_path)
+
+    def test_skip_invalid_rows(self, tmp_path: Path) -> None:
+        """Test that invalid rows are skipped."""
+        csv_content = """FirstName,LastName,Email
+John,Doe,john@example.com
+,,
+Jane,Smith,jane@example.com
+"""
+        csv_path = tmp_path / "authors.csv"
+        csv_path.write_text(csv_content)
+
+        index = AuthorIndex(csv_path)
+
+        assert len(index.records) == 2
+        assert index.records[0].first_name == "John"
+        assert index.records[1].first_name == "Jane"
+
+    def test_whitespace_handling(self, tmp_path: Path) -> None:
+        """Test that whitespace is properly stripped."""
+        csv_content = """FirstName,LastName,Email
+  John  ,  Doe  ,  john@example.com
+"""
+        csv_path = tmp_path / "authors.csv"
+        csv_path.write_text(csv_content)
+
+        index = AuthorIndex(csv_path)
+
+        assert index.records[0].first_name == "John"
+        assert index.records[0].last_name == "Doe"
+        assert index.records[0].email == "john@example.com"
+
+    def test_utf8_bom_handling(self, tmp_path: Path) -> None:
+        """Test that UTF-8 BOM is handled correctly."""
+        csv_content = """FirstName,LastName,Email
+John,Doe,john@example.com
+"""
+        csv_path = tmp_path / "authors.csv"
+        csv_path.write_text(csv_content, encoding="utf-8-sig")
+
+        index = AuthorIndex(csv_path)
+
+        assert len(index.records) == 1
+        assert index.records[0].first_name == "John"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,66 @@
+"""Tests for utils.py module."""
+
+from datetime import date
+
+import pytest
+
+from open_ire.utils import as_list, parse_date, validate_year
+
+
+class TestParseDate:
+    """Tests for parse_date function."""
+
+    def test_parse_valid_date(self):
+        """Test parsing valid date strings."""
+        assert parse_date("2023-01-15") == date(2023, 1, 15)
+        assert parse_date("January 15, 2023") == date(2023, 1, 15)
+
+    def test_parse_none_or_empty(self):
+        """Test parsing None or empty values."""
+        assert parse_date(None) is None
+        assert parse_date("") is None
+
+    def test_parse_invalid_date(self):
+        """Test parsing invalid date strings."""
+        assert parse_date("not a date") is None
+        assert parse_date("2023-13-45") is None
+
+
+class TestValidateYear:
+    """Tests for validate_year function."""
+
+    def test_valid_year(self):
+        """Test validating valid years."""
+        assert validate_year("2023", "test_field") == 2023
+        assert validate_year("1950", "test_field") == 1950
+
+    def test_invalid_year_string(self):
+        """Test validating invalid year strings."""
+        with pytest.raises(ValueError, match="Invalid test_field"):
+            validate_year("not a year", "test_field")
+
+    def test_year_out_of_range(self):
+        """Test validating years outside reasonable range."""
+        with pytest.raises(ValueError, match="outside reasonable range"):
+            validate_year("1800", "test_field")
+        with pytest.raises(ValueError, match="outside reasonable range"):
+            validate_year("2200", "test_field")
+
+
+class TestAsList:
+    """Tests for as_list function."""
+
+    def test_none_value(self):
+        """Test converting None to list."""
+        assert as_list(None) == []
+
+    def test_already_list(self):
+        """Test that lists are returned as-is."""
+        test_list = [1, 2, 3]
+        assert as_list(test_list) is test_list
+
+    def test_single_value(self):
+        """Test converting single values to list."""
+        assert as_list("single") == ["single"]
+        assert as_list(42) == [42]
+        assert as_list({"key": "value"}) == [{"key": "value"}]


### PR DESCRIPTION
Some "spring cleaning" before implementing author normalization. The only two semi-significant changes:

1) Authors string in ArticleItem is joined with semicolon, not comma
2) Authors string generated by WoS spider records full names, not just family name and first initial