### PR TITLE
Add article.type column and ArticleType enum

### DIFF
--- a/src/open_ire/enums.py
+++ b/src/open_ire/enums.py
@@ -49,3 +49,21 @@ class DepositTransitionReason(StrEnum):
     VERSION_AVAILABLE = "version_available"
     MANUAL_REVIEW = "manual_review"
     FACULTY_AUTHOR = "faculty_author"
+
+
+class ArticleType(StrEnum):
+    """Normalized classification for publication types.
+
+    Used to determine if a publication falls under the faculty Open Access Policy.
+    Per the library guide, peer-reviewed journal articles and conference papers
+    created without expectation of payment are considered scholarly articles subject
+    to the OA Policy. Books, book chapters, data sets, and creative works do not
+    fall under the policy (though deposit is still encouraged).
+
+    Values:
+    - SCHOLARLY_ARTICLE: Peer-reviewed journal articles and conference papers
+    - OTHER: Books, book chapters, editorials, reviews, and other non-scholarly works
+    """
+
+    SCHOLARLY_ARTICLE = "scholarly-article"
+    OTHER = "other"

--- a/src/open_ire/models.py
+++ b/src/open_ire/models.py
@@ -6,7 +6,7 @@ from sqlalchemy import JSON, Column, UniqueConstraint
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlmodel import Field, Relationship, SQLModel, select
 
-from open_ire.enums import DepositStatus, OAEvidenceKind
+from open_ire.enums import ArticleType, DepositStatus, OAEvidenceKind
 
 
 class ArticleBase(SQLModel):
@@ -15,6 +15,7 @@ class ArticleBase(SQLModel):
     Attributes
     ----------
     abstract: Summary or abstract of the resource, if available.
+    type: Normalized publication type (scholarly-article or other).
     authors: Names of the authors or creators of the resource.
     created_at: Datetime when the article was added to this database.
     updated_at: Datetime when the article was last updated in this database.
@@ -30,6 +31,7 @@ class ArticleBase(SQLModel):
     """
 
     abstract: str | None = None
+    type: ArticleType | None = None
     authors: str | None = None
     created_at: datetime = Field(default_factory=datetime.now, index=True)
     updated_at: datetime = Field(default_factory=datetime.now, index=True)

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -1,11 +1,12 @@
 import json
 from collections.abc import Generator
-from typing import Any
+from typing import Any, ClassVar
 from urllib.parse import urlencode
 
 from scrapy.http import Request, Response
 
 from open_ire.author import AuthorRecord
+from open_ire.enums import ArticleType
 from open_ire.items import ArticleItem
 from open_ire.settings import OPEN_IRE_CONTACT_EMAIL, OPENALEX_INSTITUTION_ID
 from open_ire.spiders.search import AuthorSearchSpider
@@ -20,6 +21,31 @@ class OpenAlexSpider(AuthorSearchSpider):
     name = "openalex"
     base_url = "https://api.openalex.org"
     page_size = 25
+
+    # OpenAlex publication type mappings
+    # See https://docs.openalex.org/api-entities/works/work-object#type
+    TYPE_MAP: ClassVar[dict[str, ArticleType]] = {
+        "article": ArticleType.SCHOLARLY_ARTICLE,
+        "preprint": ArticleType.SCHOLARLY_ARTICLE,
+        "proceedings-article": ArticleType.SCHOLARLY_ARTICLE,
+        "posted-content": ArticleType.SCHOLARLY_ARTICLE,
+        "review": ArticleType.SCHOLARLY_ARTICLE,
+        "book": ArticleType.OTHER,
+        "book-chapter": ArticleType.OTHER,
+        "editorial": ArticleType.OTHER,
+        "erratum": ArticleType.OTHER,
+        "letter": ArticleType.OTHER,
+        "libguides": ArticleType.OTHER,
+        "paratext": ArticleType.OTHER,
+        "supplementary-materials": ArticleType.OTHER,
+    }
+
+    @classmethod
+    def _normalize_type(cls, raw_type: str | None) -> ArticleType | None:
+        """Normalize OpenAlex publication type to ArticleType."""
+        if raw_type is None:
+            return None
+        return cls.TYPE_MAP.get(raw_type.lower())
 
     def __init__(
         self,
@@ -121,6 +147,7 @@ class OpenAlexSpider(AuthorSearchSpider):
         oa_status = publication.get("open_access", {}).get("oa_status")
         is_oa = publication.get("open_access", {}).get("is_oa")
 
+        raw_type = publication.get("type")
         return ArticleItem(
             authors=AuthorRecord.encode_author_string(authors),
             doi=publication.get("doi"),
@@ -128,13 +155,16 @@ class OpenAlexSpider(AuthorSearchSpider):
                 "is_open_access": is_oa,
                 "journal_name": self._extract_journal_name(publication),
                 "oa_status": oa_status,
-                "publication_type": publication.get("type"),
                 "matched_author": matched_author,
+                "openalex": {
+                    "type": raw_type,
+                },
             },
             publication_date=parse_date(publication.get("publication_date")),
             reference=str(external_id),
             repository=self.name,
             title=publication.get("title"),
+            type=self._normalize_type(raw_type),
             url=publication.get("doi"),
         )
 

--- a/src/open_ire/spiders/wos.py
+++ b/src/open_ire/spiders/wos.py
@@ -2,12 +2,13 @@ import datetime
 import json
 import os
 from collections.abc import Generator
-from typing import Any
+from typing import Any, ClassVar
 from urllib.parse import urlencode
 
 from scrapy.http import Request, Response
 
 from open_ire.author import AuthorRecord
+from open_ire.enums import ArticleType
 from open_ire.items import ArticleItem
 from open_ire.settings import WOS_ORGANIZATION
 from open_ire.spiders.search import AuthorSearchSpider
@@ -22,6 +23,23 @@ class WoSSpider(AuthorSearchSpider):
     name = "wos"
     base_url = "https://api.clarivate.com/api/wos/"
     page_size = 25
+
+    # WOS document type mappings
+    TYPE_MAP: ClassVar[dict[str, ArticleType]] = {
+        "article": ArticleType.SCHOLARLY_ARTICLE,
+        "proceedings paper": ArticleType.SCHOLARLY_ARTICLE,
+        "review": ArticleType.SCHOLARLY_ARTICLE,
+        "book review": ArticleType.SCHOLARLY_ARTICLE,
+        "editorial material": ArticleType.OTHER,
+        "letter": ArticleType.OTHER,
+    }
+
+    @classmethod
+    def _normalize_type(cls, raw_type: str | None) -> ArticleType | None:
+        """Normalize WOS document type to ArticleType."""
+        if raw_type is None:
+            return None
+        return cls.TYPE_MAP.get(raw_type.lower())
 
     def __init__(
         self,
@@ -192,18 +210,22 @@ class WoSSpider(AuthorSearchSpider):
             None,
         )
 
+        raw_type = summary.get("doctypes", {}).get("doctype")
         return ArticleItem(
             authors=AuthorRecord.encode_author_string(authors),
             doi=doi,
             extra={
                 "journal_name": self._extract_journal_name(titles),
-                "publication_type": summary.get("doctypes", {}).get("doctype"),
                 "matched_author": matched_author,
+                "wos": {
+                    "type": raw_type,
+                },
             },
             publication_date=parse_date(pub_info.get("coverdate") or pub_info.get("sortdate")),
             reference=str(external_id),
             repository=self.name,
             title=title,
+            type=self._normalize_type(raw_type),
             url=f"https://doi.org/{doi}"
             if doi
             else f"https://www.webofscience.com/wos/woscc/full-record/{external_id}",

--- a/tests/spiders/test_openalex.py
+++ b/tests/spiders/test_openalex.py
@@ -6,6 +6,7 @@ from typing import Any
 from urllib.parse import urlparse, parse_qs
 
 from open_ire.author import AuthorRecord
+from open_ire.enums import ArticleType
 from open_ire.items import ArticleItem
 from open_ire.spiders.openalex import OpenAlexSpider
 
@@ -165,3 +166,35 @@ class TestOpenAlexSpider:
         assert len(requests) == 1
         assert isinstance(requests[0], Request)
         assert "Kemi+Adeyemi" in requests[0].url
+
+    @pytest.mark.parametrize(
+        "raw_type,expected",
+        [
+            ("article", ArticleType.SCHOLARLY_ARTICLE),
+            ("preprint", ArticleType.SCHOLARLY_ARTICLE),
+            ("proceedings-article", ArticleType.SCHOLARLY_ARTICLE),
+            ("posted-content", ArticleType.SCHOLARLY_ARTICLE),
+            ("review", ArticleType.SCHOLARLY_ARTICLE),
+            ("book", ArticleType.OTHER),
+            ("book-chapter", ArticleType.OTHER),
+            ("editorial", ArticleType.OTHER),
+            ("erratum", ArticleType.OTHER),
+            ("letter", ArticleType.OTHER),
+            ("libguides", ArticleType.OTHER),
+            ("paratext", ArticleType.OTHER),
+            ("supplementary-materials", ArticleType.OTHER),
+        ],
+    )
+    def test_normalize_type_known_types(self, raw_type: str, expected: ArticleType) -> None:
+        assert OpenAlexSpider._normalize_type(raw_type) == expected
+
+    @pytest.mark.parametrize("raw_type", ["Article", "ARTICLE", "PrePrint", "BOOK"])
+    def test_normalize_type_case_insensitive(self, raw_type: str) -> None:
+        result = OpenAlexSpider._normalize_type(raw_type)
+        assert result is not None
+
+    def test_normalize_type_none(self) -> None:
+        assert OpenAlexSpider._normalize_type(None) is None
+
+    def test_normalize_type_unknown(self) -> None:
+        assert OpenAlexSpider._normalize_type("unknown-type") is None

--- a/tests/spiders/test_wos.py
+++ b/tests/spiders/test_wos.py
@@ -7,6 +7,7 @@ from typing import Any
 from urllib.parse import urlparse, parse_qs
 
 from open_ire.author import AuthorRecord
+from open_ire.enums import ArticleType
 from open_ire.items import ArticleItem
 from open_ire.spiders.wos import WoSSpider
 
@@ -180,3 +181,28 @@ class TestWoSSpider:
 
         assert items == []
         assert requests == []
+
+    @pytest.mark.parametrize(
+        "raw_type,expected",
+        [
+            ("article", ArticleType.SCHOLARLY_ARTICLE),
+            ("Article", ArticleType.SCHOLARLY_ARTICLE),
+            ("proceedings paper", ArticleType.SCHOLARLY_ARTICLE),
+            ("Proceedings Paper", ArticleType.SCHOLARLY_ARTICLE),
+            ("review", ArticleType.SCHOLARLY_ARTICLE),
+            ("book review", ArticleType.SCHOLARLY_ARTICLE),
+            ("Book Review", ArticleType.SCHOLARLY_ARTICLE),
+            ("editorial material", ArticleType.OTHER),
+            ("Editorial Material", ArticleType.OTHER),
+            ("letter", ArticleType.OTHER),
+            ("Letter", ArticleType.OTHER),
+        ],
+    )
+    def test_normalize_type_known_types(self, spider: WoSSpider, raw_type: str, expected: ArticleType) -> None:
+        assert spider._normalize_type(raw_type) == expected
+
+    def test_normalize_type_none(self, spider: WoSSpider) -> None:
+        assert spider._normalize_type(None) is None
+
+    def test_normalize_type_unknown(self, spider: WoSSpider) -> None:
+        assert spider._normalize_type("unknown-type") is None


### PR DESCRIPTION
OpenAlex and WoS spiders gather works of different types, but OAP only applies to scholarly articles. Having the column makes it possible to easily limit queries to just to scholarly articles. Other spiders can either leave the column as NULL or default to SCHOLARLY_ARTICLE.