### PR TITLE
Clean up, reorganize, remove inconsistencies in pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,11 +61,13 @@ repos:
         args: []
         additional_dependencies:
           - msgraph-sdk
+          - nameparser
           - pytest
           - python-dotenv
           - rapidfuzz
           - scrapy
           - sqlmodel
+          - types-nameparser
           - types-python-dateutil
           - types-requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,6 @@ pixi run pre-commit-all
 - `default`: Basic execution environment.
 - `dev`: Development environment with testing tools.
 - `docs`: Documentation building environment.
-- `all`: All features combined.
 
 To activate one of these environments, run the following command:
 
@@ -130,7 +129,7 @@ Run a specific test function:
 python -m pytest tests/test_sharepoint.py::TestSharePoint::test_init_with_env
 ```
 
-Make sure to activate the `dev` or `all` environment before running tests.
+Make sure to activate the `dev` environment before running tests.
 
 ### Project Architecture
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,13 +92,18 @@ warn_unreachable = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 
+# msgraph is huge and auto-generated; slows mypy significantly
 [[tool.mypy.overrides]]
-module = "msgraph_core.*"
+module = ["msgraph_core.*", "msgraph.*"]
+follow_imports = "skip"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module = "nameparser"
-ignore_missing_imports = true
+module = "tests.*"
+check_untyped_defs = false
+disallow_incomplete_defs = false
+disallow_untyped_defs = false
+warn_return_any = false
 
 [tool.pytest.ini_options]
 minversion = "6.0"
@@ -142,7 +147,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["T20"]
+"tests/**" = ["ARG001", "ARG002", "ARG003", "T20"]
 "noxfile.py" = ["T20"]
 
 # ===

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+# ===
+# Build and packaging
+# ===
 [build-system]
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
@@ -32,8 +35,19 @@ dependencies = [
     "sqlmodel",
 ]
 
+[project.license]
+file = "LICENSE"
+
+[project.urls]
+Homepage = "https://github.com/uw-ssec/open-ire"
+Documentation = "https://github.com/uw-ssec/open-ire/blob/main/README.md"
+Repository = "https://github.com/uw-ssec/open-ire.git"
+Issues = "https://github.com/uw-ssec/open-ire/issues"
+
 [project.optional-dependencies]
 dev = [
+    "mypy",
+    "ipython",
     "nox",
     "pre-commit",
     "pytest-asyncio",
@@ -41,8 +55,10 @@ dev = [
     "pytest-mock",
     "pytest-xdist",
     "pytest",
+    "ruff",
     "types-python-dateutil",
     "types-nameparser",
+    "types-requests",
 ]
 docs = [
     "jupyter-book",
@@ -52,52 +68,29 @@ docs = [
     "sphinx_rtd_theme",
     "sphinxcontrib-mermaid",
 ]
-all = ["open_ire[dev,docs]"]
-
-[project.license]
-file = "LICENSE"
-
-[project.urls]
-Homepage = "https://github.com/uw-ssec/python-project-template"
-Documentation = "https://ssec-python-project-template.readthedocs.io"
-Repository = "https://github.com/uw-ssec/python-project-template.git"
-Issues = "https://github.com/uw-ssec/python-project-template/issues"
 
 [tool.hatch.version]
 source = "vcs"
 
-[tool.hatch.build.hooks.vcs]
-version-file = "src/open_ire/version.py"
-
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
 
-[tool.hatch.build.targets.sdist]
-exclude = ["/tests"]
+[tool.hatch.build.hooks.vcs]
+version-file = "src/open_ire/version.py"
 
-[tool.pytest.ini_options]
-minversion = "6.0"
-addopts = ["-vvv", "-ra", "--showlocals", "--strict-markers", "--strict-config"]
-xfail_strict = false
-filterwarnings = ["error"]
-log_cli_level = "INFO"
-testpaths = ["tests"]
-
+# ===
+# Developer tooling
+# ===
 [tool.mypy]
 files = ["src", "tests"]
 mypy_path = ["src"]
-python_version = "3.11"
+python_version = "3.12"
 warn_unused_configs = true
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unreachable = true
-disallow_untyped_defs = false
-disallow_incomplete_defs = false
-
-[[tool.mypy.overrides]]
-module = "open_ire.*"
-disallow_incomplete_defs = true
 disallow_untyped_defs = true
+disallow_incomplete_defs = true
 
 [[tool.mypy.overrides]]
 module = "msgraph_core.*"
@@ -107,8 +100,15 @@ ignore_missing_imports = true
 module = "nameparser"
 ignore_missing_imports = true
 
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = ["-vvv", "-ra", "--showlocals", "--strict-markers", "--strict-config"]
+xfail_strict = false
+filterwarnings = ["error"]
+log_cli_level = "INFO"
+testpaths = ["tests"]
+
 [tool.ruff]
-exclude = ["tests/**", "testing.py"]
 line-length = 100
 
 [tool.ruff.lint]
@@ -145,14 +145,20 @@ ignore = [
 "tests/**" = ["T20"]
 "noxfile.py" = ["T20"]
 
-[dependency-groups]
-dev = [
-    "ruff",
-]
-
+# ===
+# Pixi environments, dependencies, and tasks
+# ===
 [tool.pixi.workspace]
 channels = ["conda-forge"]
 platforms = ["osx-arm64", "osx-64", "win-64"]
+
+[tool.pixi.environments]
+default = { solve-group = "default" }
+dev = { features = ["dev"], solve-group = "default" }
+docs = { features = ["docs"], solve-group = "default" }
+
+[tool.pixi.dependencies]
+pixi-pycharm = ">=0.0.10,<0.0.11"
 
 [tool.pixi.pypi-dependencies]
 open_ire = { path = ".", editable = true }
@@ -163,18 +169,24 @@ open_ire = { path = ".", editable = true, extras = ["dev"] }
 [tool.pixi.feature.docs.pypi-dependencies]
 open_ire = { path = ".", editable = true, extras = ["docs"] }
 
-[tool.pixi.environments]
-default = { solve-group = "default" }
-all = { features = ["dev", "docs"], solve-group = "default" }
-dev = { features = ["dev"], solve-group = "default" }
-docs = { features = ["docs"], solve-group = "default" }
+[tool.pixi.feature.dev.tasks]
+pre-commit = "pre-commit run"
+pre-commit-all = "pre-commit run --all-files"
+pre-commit-install = "pre-commit install"
+test = "python -m pytest -ra --cov=open_ire"
+
+# User-facing tasks
 
 [tool.pixi.tasks.dotenv]
-cmd = "mkdir output && cp .env.example .env"
+cmd = "mkdir -p output && cp -n .env.example .env"
 
 [tool.pixi.tasks.author-search]
 args = ["spider", "author_csv"]
 cmd = "scrapy crawl {{ spider }} -a author_csv={{ author_csv }}"
+
+[tool.pixi.tasks.terms-search]
+args = ["spider", "terms", "page"]
+cmd = "scrapy crawl {{ spider }} -a page={{ page }} -a terms=\"{{ terms }}\""
 
 [tool.pixi.tasks.spider]
 args = ["spider"]
@@ -188,20 +200,3 @@ args = [
     { "arg" = "flag", "default" = "" },
 ]
 cmd = "scrapy crawl {{ spider }} -s JOBDIR=crawls/{{ spider }}{% if '--skip-existing' in flag %} -s OPEN_IRE_SKIP_EXISTING=True{% endif %}"
-
-[tool.pixi.tasks.terms-search]
-args = ["spider", "terms", "page"]
-cmd = "scrapy crawl {{ spider }} -a page={{ page }} -a terms=\"{{ terms }}\""
-
-[tool.pixi.feature.dev.tasks]
-pre-commit = "pre-commit run"
-pre-commit-all = "pre-commit run --all-files"
-pre-commit-install = "pre-commit install"
-test = "python -m pytest -ra --cov=open_ire"
-
-[tool.pixi.dependencies]
-pixi-pycharm = ">=0.0.10,<0.0.11"
-
-[tool.pixi.feature.dev.dependencies]
-pre-commit = ">=4.2.0,<5"
-python = "<=3.13.0"

--- a/tests/pipelines/conftest.py
+++ b/tests/pipelines/conftest.py
@@ -1,4 +1,5 @@
 from datetime import date
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -64,4 +65,4 @@ def spider() -> Spider:
     mock_spider.logger.error = MagicMock()
     mock_spider.crawler = mock_crawler
 
-    return mock_spider
+    return cast(Spider, mock_spider)

--- a/tests/pipelines/test_doi_normalization_pipeline.py
+++ b/tests/pipelines/test_doi_normalization_pipeline.py
@@ -1,5 +1,9 @@
-import pytest
+from typing import Any, cast
 
+import pytest
+from scrapy import Spider
+
+from open_ire.items import ArticleItem
 from open_ire.pipelines import DOINormalizationPipeline
 
 
@@ -7,11 +11,13 @@ class TestDOINormalizationPipeline:
     """Tests the DOI normalization pipeline."""
 
     @pytest.fixture
-    def pipeline(self):
+    def pipeline(self) -> DOINormalizationPipeline:
         """Create a pipeline instance for testing."""
         return DOINormalizationPipeline()
 
-    def test_normalize_full_doi_url(self, pipeline, spider, item):
+    def test_normalize_full_doi_url(
+        self, pipeline: DOINormalizationPipeline, spider: Spider, item: ArticleItem
+    ) -> None:
         """Test normalizing a full DOI URL."""
         item.doi = " https://doi.org/10.1234/test.doi"
 
@@ -19,7 +25,9 @@ class TestDOINormalizationPipeline:
 
         assert result.doi == "10.1234/test.doi"
 
-    def test_normalize_already_normalized_doi(self, pipeline, spider, item):
+    def test_normalize_already_normalized_doi(
+        self, pipeline: DOINormalizationPipeline, spider: Spider, item: ArticleItem
+    ) -> None:
         """Test that already normalized DOIs are unchanged."""
         item.doi = "10.1234/test.doi "
 
@@ -27,7 +35,9 @@ class TestDOINormalizationPipeline:
 
         assert result.doi == "10.1234/test.doi"
 
-    def test_normalize_none_doi(self, pipeline, spider, item):
+    def test_normalize_none_doi(
+        self, pipeline: DOINormalizationPipeline, spider: Spider, item: ArticleItem
+    ) -> None:
         """Test that None DOI values are handled correctly."""
         item.doi = None
 
@@ -35,7 +45,9 @@ class TestDOINormalizationPipeline:
 
         assert result.doi is None
 
-    def test_normalize_empty_string_doi(self, pipeline, spider, item):
+    def test_normalize_empty_string_doi(
+        self, pipeline: DOINormalizationPipeline, spider: Spider, item: ArticleItem
+    ) -> None:
         """Test that empty string DOI values are normalized to None."""
         item.doi = ""
 
@@ -43,7 +55,9 @@ class TestDOINormalizationPipeline:
 
         assert result.doi is None
 
-    def test_normalize_whitespace_only_doi(self, pipeline, spider, item):
+    def test_normalize_whitespace_only_doi(
+        self, pipeline: DOINormalizationPipeline, spider: Spider, item: ArticleItem
+    ) -> None:
         """Test that whitespace-only DOI values are normalized to None."""
         item.doi = "   "
 
@@ -51,9 +65,11 @@ class TestDOINormalizationPipeline:
 
         assert result.doi is None
 
-    def test_normalize_non_string_doi(self, pipeline, spider, item):
+    def test_normalize_non_string_doi(
+        self, pipeline: DOINormalizationPipeline, spider: Spider, item: ArticleItem
+    ) -> None:
         """Test that non-string DOI values are normalized to None."""
-        item.doi = 12345
+        item.doi = cast(Any, 12345)
 
         result = pipeline.process_item(item, spider)
 

--- a/tests/pipelines/test_duplicates_pipeline.py
+++ b/tests/pipelines/test_duplicates_pipeline.py
@@ -1,23 +1,29 @@
 import pytest
+from scrapy import Spider
 from scrapy.exceptions import DropItem
 
+from open_ire.items import ArticleItem
 from open_ire.pipelines import DuplicatesPipeline
 
 
 class TestDuplicatesPipeline:
     @pytest.fixture
-    def pipeline(self):
+    def pipeline(self) -> DuplicatesPipeline:
         """Create a pipeline instance for testing."""
         return DuplicatesPipeline()
 
-    def test_process_unique_item(self, pipeline, spider, item):
+    def test_process_unique_item(
+        self, pipeline: DuplicatesPipeline, spider: Spider, item: ArticleItem
+    ) -> None:
         """Test processing a unique item."""
         result = pipeline.process_item(item, spider)
 
         assert result == item
         assert item.reference in pipeline.seen
 
-    def test_process_duplicate_item(self, pipeline, spider, item):
+    def test_process_duplicate_item(
+        self, pipeline: DuplicatesPipeline, spider: Spider, item: ArticleItem
+    ) -> None:
         """Test processing a duplicate item."""
         pipeline.seen.add(item.reference)
         with pytest.raises(DropItem) as e:

--- a/tests/pipelines/test_sharepoint_pipeline.py
+++ b/tests/pipelines/test_sharepoint_pipeline.py
@@ -1,7 +1,11 @@
+from pathlib import Path
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from scrapy import Spider
 
+from open_ire.items import ArticleItem
 from open_ire.pipelines import SharePointPipeline
 
 
@@ -9,7 +13,7 @@ class TestSharePointPipeline:
     """Tests the SharePoint pipeline for file uploads."""
 
     @pytest.fixture
-    def pipeline(self, tmp_path):
+    def pipeline(self, tmp_path: Path) -> SharePointPipeline:
         sharepoint_base_path = "test_sharepoint"
         local_base_path = str(tmp_path)
 
@@ -23,7 +27,9 @@ class TestSharePointPipeline:
             return pipeline
 
     @pytest.mark.asyncio
-    async def test_item_with_files(self, pipeline, spider, item, tmp_path):
+    async def test_item_with_files(
+        self, pipeline: SharePointPipeline, spider: Spider, item: ArticleItem, tmp_path: Path
+    ) -> None:
         """An item with files should trigger a SharePoint upload."""
         file1 = tmp_path / "file1.pdf"
         file2 = tmp_path / "file2.pdf"
@@ -37,11 +43,12 @@ class TestSharePointPipeline:
 
         mock_upload_result = MagicMock()
         mock_upload_result.location = "https://sharepoint.com/uploaded"
-        pipeline.sharepoint.upload_file = AsyncMock(return_value=mock_upload_result)
+        sharepoint = cast(Any, pipeline.sharepoint)
+        sharepoint.upload_file = AsyncMock(return_value=mock_upload_result)
 
         mock_drive_item = MagicMock()
         mock_drive_item.web_url = "https://sharepoint.com/web-url"
-        pipeline.sharepoint.get_item = AsyncMock(return_value=mock_drive_item)
+        sharepoint.get_item = AsyncMock(return_value=mock_drive_item)
 
         result = await pipeline.process_item(item, spider)
 
@@ -50,10 +57,12 @@ class TestSharePointPipeline:
             "https://sharepoint.com/web-url",
             "https://sharepoint.com/web-url",
         ]
-        assert pipeline.sharepoint.upload_file.call_count == 2
+        assert sharepoint.upload_file.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_process_item_no_files(self, pipeline, spider, item):
+    async def test_process_item_no_files(
+        self, pipeline: SharePointPipeline, spider: Spider, item: ArticleItem
+    ) -> None:
         """An item without files should have an empty store_urls list."""
         item.files = []
 
@@ -61,21 +70,26 @@ class TestSharePointPipeline:
 
         assert result == item
         assert result.store_urls == []
-        spider.logger.warning.assert_called_once()
+        cast(Any, spider.logger).warning.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_item_upload_error(self, pipeline, spider, item):
+    async def test_item_upload_error(
+        self, pipeline: SharePointPipeline, spider: Spider, item: ArticleItem
+    ) -> None:
         """Upload errors should be logged."""
-        pipeline.sharepoint.upload_file = AsyncMock(side_effect=Exception("Upload failed"))
+        sharepoint = cast(Any, pipeline.sharepoint)
+        sharepoint.upload_file = AsyncMock(side_effect=Exception("Upload failed"))
 
         result = await pipeline.process_item(item, spider)
 
         assert result == item
         assert result.store_urls == [""]
-        spider.logger.error.assert_called()
+        cast(Any, spider.logger).error.assert_called()
 
     @pytest.mark.asyncio
-    async def test_deletes_local_file(self, pipeline, spider, item, tmp_path):
+    async def test_deletes_local_file(
+        self, pipeline: SharePointPipeline, spider: Spider, item: ArticleItem, tmp_path: Path
+    ) -> None:
         """Local file should be deleted when remote size matches"""
         local_file = tmp_path / "file.pdf"
         local_file.write_text("A" * 1000)
@@ -85,8 +99,9 @@ class TestSharePointPipeline:
         mock_drive_item = MagicMock()
         mock_drive_item.web_url = "https://sharepoint.com/uploaded"
         mock_drive_item.size = 1000
-        pipeline.sharepoint.upload_file = AsyncMock(return_value=MagicMock())
-        pipeline.sharepoint.get_item = AsyncMock(return_value=mock_drive_item)
+        sharepoint = cast(Any, pipeline.sharepoint)
+        sharepoint.upload_file = AsyncMock(return_value=MagicMock())
+        sharepoint.get_item = AsyncMock(return_value=mock_drive_item)
 
         await pipeline.process_item(item, spider)
         assert not local_file.exists()  # delete local copy
@@ -96,4 +111,4 @@ class TestSharePointPipeline:
         mock_drive_item.size = 5000
         await pipeline.process_item(item, spider)
         assert local_file.exists()  # preserve local copy
-        spider.logger.error.assert_called()
+        cast(Any, spider.logger).error.assert_called()

--- a/tests/pipelines/test_skip_existing_pipeline.py
+++ b/tests/pipelines/test_skip_existing_pipeline.py
@@ -5,6 +5,7 @@ from scrapy import Spider
 from scrapy.exceptions import DropItem
 from sqlmodel import Session
 
+from open_ire.items import ArticleItem
 from open_ire.models import Article
 from open_ire.pipelines import SkipExistingPipeline
 
@@ -13,7 +14,7 @@ class TestSkipExistingPipeline:
     """Tests the SkipExistingPipeline for skipping existing articles."""
 
     @pytest.fixture
-    def pipeline_enabled(self, spider) -> Generator[SkipExistingPipeline]:
+    def pipeline_enabled(self, spider: Spider) -> Generator[SkipExistingPipeline, None, None]:
         spider.crawler.settings.set("OPEN_IRE_SKIP_EXISTING", True)
 
         instance = SkipExistingPipeline(":memory:", "output")
@@ -23,31 +24,31 @@ class TestSkipExistingPipeline:
         instance.engine.dispose()
 
     @pytest.fixture
-    def pipeline_disabled(self, spider) -> Generator[SkipExistingPipeline]:
+    def pipeline_disabled(self, spider: Spider) -> SkipExistingPipeline:
         spider.crawler.settings.set("OPEN_IRE_SKIP_EXISTING", False)
 
         instance = SkipExistingPipeline(":memory:", "output")
         instance.open_spider(spider)
         assert instance.engine is None
-        yield instance
+        return instance
 
     def test_process_item_with_skip_existing_disabled(
-        self, pipeline_disabled: SkipExistingPipeline, spider: Spider, item
-    ):
+        self, pipeline_disabled: SkipExistingPipeline, spider: Spider, item: ArticleItem
+    ) -> None:
         result = pipeline_disabled.process_item(item, spider)
 
         assert result is item
 
     def test_process_item_with_new_article(
-        self, pipeline_enabled: SkipExistingPipeline, spider: Spider, item
-    ):
+        self, pipeline_enabled: SkipExistingPipeline, spider: Spider, item: ArticleItem
+    ) -> None:
         result = pipeline_enabled.process_item(item, spider)
 
         assert result is item
 
     def test_process_item_with_existing_article(
-        self, pipeline_enabled: SkipExistingPipeline, spider: Spider, item
-    ):
+        self, pipeline_enabled: SkipExistingPipeline, spider: Spider, item: ArticleItem
+    ) -> None:
         with Session(pipeline_enabled.engine) as session:
             article = Article(
                 title=item.title,

--- a/tests/pipelines/test_sql_model_pipeline.py
+++ b/tests/pipelines/test_sql_model_pipeline.py
@@ -1,5 +1,4 @@
 from collections.abc import Generator
-from datetime import date
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -16,7 +15,7 @@ class TestSQLModelPipeline:
     """Tests the processing and validation logic of the SQLModelPipeline."""
 
     @pytest.fixture
-    def pipeline(self, spider) -> Generator[SQLModelPipeline]:
+    def pipeline(self, spider: Spider) -> Generator[SQLModelPipeline, None, None]:
         """
         Create a pipeline instance with an in-memory SQLite DB for each test.
         """
@@ -26,7 +25,9 @@ class TestSQLModelPipeline:
         yield instance
         instance.engine.dispose()
 
-    def test_process_valid_item(self, pipeline: SQLModelPipeline, spider: Spider, item):
+    def test_process_valid_item(
+        self, pipeline: SQLModelPipeline, spider: Spider, item: ArticleItem
+    ) -> None:
         """A valid item is processed successfully."""
         result = pipeline.process_item(item, spider)
         assert result is item
@@ -39,9 +40,9 @@ class TestSQLModelPipeline:
         self,
         pipeline: SQLModelPipeline,
         spider: Spider,
-        item,
-        item_with_file_references,
-    ):
+        item: ArticleItem,
+        item_with_file_references: ArticleItem,
+    ) -> None:
         """Test updating an existing article."""
 
         pipeline.process_item(item, spider)
@@ -90,8 +91,8 @@ class TestSQLModelPipeline:
             assert len(file_refs) == 1
 
     def test_update_existing_article_with_new_files(
-        self, pipeline: SQLModelPipeline, spider: Spider, item
-    ):
+        self, pipeline: SQLModelPipeline, spider: Spider, item: ArticleItem
+    ) -> None:
         """Test updating an existing article with new files."""
 
         pipeline.process_item(item, spider)
@@ -125,7 +126,9 @@ class TestSQLModelPipeline:
             checksums = {f.checksum for f in files}
             assert checksums == {"abcde12345", "xyz789"}
 
-    def test_file_deduplication(self, pipeline: SQLModelPipeline, spider: Spider, item):
+    def test_file_deduplication(
+        self, pipeline: SQLModelPipeline, spider: Spider, item: ArticleItem
+    ) -> None:
         """Test that files with the same URL and same checksum are not duplicated."""
         pipeline.process_item(item, spider)
 
@@ -153,8 +156,8 @@ class TestSQLModelPipeline:
         self,
         pipeline: SQLModelPipeline,
         spider: Spider,
-        item_with_file_references,
-    ):
+        item_with_file_references: ArticleItem,
+    ) -> None:
         """Test that file references with the same URL are not duplicated."""
 
         pipeline.process_item(item_with_file_references, spider)
@@ -184,7 +187,7 @@ class TestSQLModelPipeline:
             file_refs = session.exec(select(ArticleFileReference)).all()
             assert len(file_refs) == 1
 
-    def test_from_crawler_creates_missing_db_parent_dir(self, tmp_path: Path):
+    def test_from_crawler_creates_missing_db_parent_dir(self, tmp_path: Path) -> None:
         missing_db = str(tmp_path / "missing_parent" / "open_ire.db")
         crawler = SimpleNamespace(
             settings={"OPEN_IRE_DATABASE_FILE": missing_db, "FILES_STORE": str(tmp_path)}

--- a/tests/spiders/test_cdc_stacks.py
+++ b/tests/spiders/test_cdc_stacks.py
@@ -5,7 +5,7 @@ from open_ire.spiders.cdc_stacks import CDCStacksSpider
 
 
 class TestCDCStacksSpider:
-    def test_default_params(self):
+    def test_default_params(self) -> None:
         """Test spider initialization with default parameters."""
         spider = CDCStacksSpider()
         assert spider.name == "cdc_stacks"
@@ -14,7 +14,7 @@ class TestCDCStacksSpider:
         assert "gsearch?terms=" in spider.start_urls[0]
         assert "start=" not in spider.start_urls[0]
 
-    def test_custom_params(self):
+    def test_custom_params(self) -> None:
         """Test spider initialization with custom parameters."""
         terms = "unittest,sample"
         page = "2"
@@ -26,7 +26,7 @@ class TestCDCStacksSpider:
         assert "terms=sample" in spider.start_urls[1]
         assert "start=100" in spider.start_urls[0]
 
-    def test_parse_next(self):
+    def test_parse_next(self) -> None:
         """Test the parse method yields the next requests."""
         html = """
         <html>
@@ -45,9 +45,7 @@ class TestCDCStacksSpider:
             </body>
         </html>
         """
-        response = HtmlResponse(
-            url="https://stacks.cdc.gov/gsearch", body=html.encode("utf-8")
-        )
+        response = HtmlResponse(url="https://stacks.cdc.gov/gsearch", body=html.encode("utf-8"))
         spider = CDCStacksSpider()
 
         requests = list(spider.parse(response))
@@ -58,7 +56,7 @@ class TestCDCStacksSpider:
         assert requests[1].url == "https://stacks.cdc.gov/view/cdc/456"
         assert requests[-1].url == "https://stacks.cdc.gov/gsearch?start=100"
 
-    def test_parse_detail(self):
+    def test_parse_detail(self) -> None:
         """Test the parse_detail method extracts article metadata correctly."""
         html = """
         <html>
@@ -104,7 +102,7 @@ class TestCDCStacksSpider:
         assert item.extra["publisher"] == "CDC Publications"
         assert set(item.extra["keywords"]) == {"health", "public health"}
 
-    def test_extract_reference(self):
+    def test_extract_reference(self) -> None:
         """Test _extract_reference falls back to full URL when CDC ID is not in path."""
         html = "<html><head></head><body></body></html>"
         url = "https://stacks.cdc.gov/some/other/path/123"

--- a/tests/spiders/test_epa.py
+++ b/tests/spiders/test_epa.py
@@ -1,7 +1,6 @@
 from datetime import date
 
-from scrapy.http import HtmlResponse
-from scrapy.http import Request
+from scrapy.http import HtmlResponse, Request
 
 from open_ire.items import ArticleItem
 from open_ire.settings import OPEN_IRE_SEARCH_TERMS
@@ -9,7 +8,7 @@ from open_ire.spiders.epa import EPASpider
 
 
 class TestEPASpider:
-    def test_default_params(self):
+    def test_default_params(self) -> None:
         """Test spider initialization with default parameters."""
         spider = EPASpider()
         assert spider.name == "epa"
@@ -18,7 +17,7 @@ class TestEPASpider:
         assert "count=25" in spider.start_urls[0]
         assert "startIndex" not in spider.start_urls[0]
 
-    def test_custom_params(self):
+    def test_custom_params(self) -> None:
         """Test spider initialization with custom parameters."""
         terms = "education,research"
         page = "3"
@@ -31,7 +30,7 @@ class TestEPASpider:
         assert "count=25" in spider.start_urls[0]
         assert "startIndex=51" in spider.start_urls[0]
 
-    def test_extract_file_urls(self):
+    def test_extract_file_urls(self) -> None:
         """Test the extract_file_urls method."""
         html = """
         <div>
@@ -49,7 +48,7 @@ class TestEPASpider:
         assert "https://cfpub.epa.gov/si/si_public_file_download.cfm?p_download_id=1" in urls
         assert "https://cfpub.epa.gov/si/si_public_file_download.cfm?p_download_id=2" in urls
 
-    def test_extract_authors(self):
+    def test_extract_authors(self) -> None:
         """Test the extract_authors method."""
         expected_title = "Sample Title"
         expected_author = "Author, A. B."
@@ -64,7 +63,7 @@ class TestEPASpider:
         author = EPASpider.extract_authors(response, expected_title)
         assert author == expected_author
 
-    def test_parse_datagov_detail(self):
+    def test_parse_datagov_detail(self) -> None:
         """Test parsing dataset file reference URLs from data.gov."""
 
         item = ArticleItem(
@@ -76,11 +75,7 @@ class TestEPASpider:
         )
         request = Request(
             url="https://catalog.data.gov/dataset/sample-dataset",
-            meta={
-                "item": item,
-                "dataset_urls": [],
-                "file_reference_urls": []
-            }
+            meta={"item": item, "dataset_urls": [], "file_reference_urls": []},
         )
 
         html = """
@@ -91,11 +86,7 @@ class TestEPASpider:
             </ul>
         </div>
         """
-        response = HtmlResponse(
-            url=request.url,
-            body=html.encode("utf-8"),
-            request=request
-        )
+        response = HtmlResponse(url=request.url, body=html.encode("utf-8"), request=request)
 
         spider = EPASpider()
         results = list(spider.parse_datagov_detail(response))
@@ -106,9 +97,9 @@ class TestEPASpider:
         assert len(result_item.file_reference_urls) == 2
         assert result_item.file_reference_urls[0] == (
             "https://catalog.data.gov/dataset/sample-dataset",
-            "https://catalog.data.gov/download/file1.csv"
+            "https://catalog.data.gov/download/file1.csv",
         )
         assert result_item.file_reference_urls[1] == (
             "https://catalog.data.gov/dataset/sample-dataset",
-            "https://catalog.data.gov/download/file2.json"
+            "https://catalog.data.gov/download/file2.json",
         )

--- a/tests/spiders/test_eric.py
+++ b/tests/spiders/test_eric.py
@@ -5,7 +5,7 @@ from open_ire.spiders.eric import EricSpider
 
 
 class TestEricSpider:
-    def test_default_params(self):
+    def test_default_params(self) -> None:
         """Test spider initialization with default parameters."""
         spider = EricSpider()
         assert spider.name == "eric"
@@ -13,7 +13,7 @@ class TestEricSpider:
         assert "eric.ed.gov" in spider.start_urls[0]
         assert "pg=1" in spider.start_urls[0]
 
-    def test_custom_params(self):
+    def test_custom_params(self) -> None:
         """Test spider initialization with custom parameters."""
         terms = "education,research"
         page = "2"
@@ -24,7 +24,7 @@ class TestEricSpider:
         assert "q=education" in spider.start_urls[0]
         assert "q=research" in spider.start_urls[1]
 
-    def test_extract_article_attribute(self):
+    def test_extract_article_attribute(self) -> None:
         """Test the extract_article_attribute method."""
         html = """
         <div><strong>ERIC Number:</strong> EJ1234567</div>

--- a/tests/spiders/test_noaa.py
+++ b/tests/spiders/test_noaa.py
@@ -5,7 +5,7 @@ from open_ire.spiders.noaa import NOAASpider
 
 
 class TestNOAASpider:
-    def test_default_params(self):
+    def test_default_params(self) -> None:
         """Test spider initialization with default parameters."""
         spider = NOAASpider()
         assert spider.name == "noaa"
@@ -14,7 +14,7 @@ class TestNOAASpider:
         assert "maxResults=100" in spider.start_urls[0]
         assert "start=" not in spider.start_urls[0]
 
-    def test_custom_params(self):
+    def test_custom_params(self) -> None:
         """Test spider initialization with custom parameters."""
         terms = "climate,ocean"
         page = "2"
@@ -27,7 +27,7 @@ class TestNOAASpider:
         assert "maxResults=100" in spider.start_urls[0]
         assert "start=100" in spider.start_urls[0]
 
-    def test_parse(self):
+    def test_parse(self) -> None:
         """Test the parse method extracts article links and next page."""
         html = """
         <html>
@@ -57,11 +57,9 @@ class TestNOAASpider:
         assert requests[0].callback == spider.parse_detail
         assert requests[0].url == "https://repository.library.noaa.gov/view/noaa/123"
         assert requests[1].url == "https://repository.library.noaa.gov/view/noaa/456"
-        assert (
-            requests[2].url == "https://repository.library.noaa.gov/gsearch?start=100"
-        )
+        assert requests[2].url == "https://repository.library.noaa.gov/gsearch?start=100"
 
-    def test_parse_detail(self):
+    def test_parse_detail(self) -> None:
         """Test the parse_detail method extracts article metadata correctly."""
         html = """
         <html>
@@ -101,7 +99,7 @@ class TestNOAASpider:
         assert len(item.file_urls) == 1
         assert hasattr(item, "extra")
 
-    def test_extract_file_urls(self):
+    def test_extract_file_urls(self) -> None:
         """Test the extract_file_urls method."""
         html = """
         <html>
@@ -122,7 +120,7 @@ class TestNOAASpider:
         assert urls[0] == "https://repository.library.noaa.gov/documents/file1.pdf"
         assert urls[1] == "https://repository.library.noaa.gov/documents/file2.pdf"
 
-    def test_extract_extra_details(self):
+    def test_extract_extra_details(self) -> None:
         """Test the extract_extra_details method."""
         html = """
         <html>
@@ -158,7 +156,7 @@ class TestNOAASpider:
         assert "ocean" in extra["keywords"]
         assert len(extra["keywords"]) == 2
 
-    def test_extract_extra_details_empty(self):
+    def test_extract_extra_details_empty(self) -> None:
         """Test the extract_extra_details method with an empty response."""
         html = "<html><head></head><body></body></html>"
         response = HtmlResponse(

--- a/tests/spiders/test_noaa_meta.py
+++ b/tests/spiders/test_noaa_meta.py
@@ -8,19 +8,19 @@ from open_ire.spiders.noaa_meta import NOAAMetaSpider
 
 
 class TestNOAAMetaSpider:
-    def test_default_params(self):
+    def test_default_params(self) -> None:
         """Test spider initialization with default parameters."""
         spider = NOAAMetaSpider()
         assert spider.name == "noaa_meta"
         assert spider.terms == OPEN_IRE_DEFAULT_TERMS.lower().split(",")
 
-    def test_custom_params(self):
+    def test_custom_params(self) -> None:
         """Test spider initialization with custom parameters."""
         terms = "unittest,test,sample"
         spider = NOAAMetaSpider(terms=terms)
         assert spider.terms == ["unittest", "test", "sample"]
 
-    def test_page_param_not_supported(self):
+    def test_page_param_not_supported(self) -> None:
         """Test that page parameter raises ValueError."""
         with pytest.raises(SpiderParameterError) as e:
             NOAAMetaSpider(page="2")
@@ -28,14 +28,13 @@ class TestNOAAMetaSpider:
         assert e.value.parameter == "page"
         assert e.value.spider_name == NOAAMetaSpider.name
 
-
-    def test_normalize_terms(self):
+    def test_normalize_terms(self) -> None:
         """Test term normalization."""
         terms = "Unittest, Test , Sample,  "
         normalized = NOAAMetaSpider._normalize_terms(terms)
         assert normalized == ["unittest", "test", "sample"]
 
-    def test_get_field_value(self):
+    def test_get_field_value(self) -> None:
         """Test field value extraction."""
         doc = {
             "field1": "value1",
@@ -44,10 +43,10 @@ class TestNOAAMetaSpider:
         }
 
         assert NOAAMetaSpider._get_field_value(doc, ["missing", "field1"]) == "value1"
-        assert NOAAMetaSpider._get_field_value(doc, ["field2"]) == ['value2a', 'value2b']
+        assert NOAAMetaSpider._get_field_value(doc, ["field2"]) == ["value2a", "value2b"]
         assert NOAAMetaSpider._get_field_value(doc, ["missing"]) is None
 
-    def test_normalize_field_value(self):
+    def test_normalize_field_value(self) -> None:
         """Test field value normalization."""
         assert NOAAMetaSpider._normalize_field_value("unittest") == "unittest"
         assert NOAAMetaSpider._normalize_field_value(["first", "second"]) == "first"
@@ -55,7 +54,7 @@ class TestNOAAMetaSpider:
         assert NOAAMetaSpider._normalize_field_value(None) is None
         assert NOAAMetaSpider._normalize_field_value("  spaced  ") == "spaced"
 
-    def test_extract_authors(self):
+    def test_extract_authors(self) -> None:
         """Test author extraction."""
         spider = NOAAMetaSpider()
 
@@ -71,7 +70,7 @@ class TestNOAAMetaSpider:
         doc = {}
         assert spider._extract_authors(doc) is None
 
-    def test_extract_publication_date(self):
+    def test_extract_publication_date(self) -> None:
         """Test publication date extraction."""
         spider = NOAAMetaSpider()
 
@@ -89,7 +88,7 @@ class TestNOAAMetaSpider:
         doc = {}
         assert spider._extract_publication_date(doc) is None
 
-    def test_extract_keywords(self):
+    def test_extract_keywords(self) -> None:
         """Test keyword extraction."""
 
         keywords = NOAAMetaSpider._extract_keywords(["unittest", "test", "unittest"])
@@ -105,7 +104,7 @@ class TestNOAAMetaSpider:
         keywords = NOAAMetaSpider._extract_keywords("")
         assert keywords == []
 
-    def test_extract_extra_details(self):
+    def test_extract_extra_details(self) -> None:
         """Test extra details extraction."""
         spider = NOAAMetaSpider()
         doc = {
@@ -120,7 +119,7 @@ class TestNOAAMetaSpider:
         assert "unittest" in extra["keywords"]
         assert "test" in extra["keywords"]
 
-    def test_document_matches_terms(self):
+    def test_document_matches_terms(self) -> None:
         """Test document term matching."""
         spider = NOAAMetaSpider(terms="unittest,test")
 
@@ -142,7 +141,7 @@ class TestNOAAMetaSpider:
         spider_no_terms = NOAAMetaSpider(terms="")
         assert spider_no_terms._document_matches_terms(doc)
 
-    def test_build_searchable_text(self):
+    def test_build_searchable_text(self) -> None:
         """Test searchable text building."""
         spider = NOAAMetaSpider()
         doc = {
@@ -156,7 +155,7 @@ class TestNOAAMetaSpider:
         assert "test sample analysis" in searchable
         assert "unittest author" in searchable
 
-    def test_create_article_item(self):
+    def test_create_article_item(self) -> None:
         """Test article item creation."""
         spider = NOAAMetaSpider()
         doc = {

--- a/tests/spiders/test_oa_license.py
+++ b/tests/spiders/test_oa_license.py
@@ -9,8 +9,8 @@ import pytest
 from scrapy.http import HtmlResponse, Request
 from sqlmodel import Session, SQLModel, create_engine, select
 
-from open_ire.enums import OAEvidenceKind, DepositStatus, DepositTransitionReason
-from open_ire.models import Article, ArticleOAEvidence, ArticleDepositStatusTransition
+from open_ire.enums import DepositStatus, DepositTransitionReason, OAEvidenceKind
+from open_ire.models import Article, ArticleDepositStatusTransition, ArticleOAEvidence
 from open_ire.spiders.oa_license import OALicenseSpider
 
 
@@ -89,7 +89,7 @@ def datacite_oa_response() -> dict[str, Any]:
 
 class TestIsOALicense:
     @pytest.mark.parametrize(
-        "license_url,expected",
+        ("license_url", "expected"),
         [
             ("https://creativecommons.org/licenses/by/4.0/", True),
             ("https://creativecommons.org/publicdomain/zero/1.0/", True),
@@ -146,7 +146,9 @@ class TestExtractDataciteLicense:
         result = OALicenseSpider.extract_datacite_license(rights_list)
 
         assert result["supports_oa"] is True
-        assert result["license_details"][0]["name"] == "Creative Commons Attribution 4.0 International"
+        assert (
+            result["license_details"][0]["name"] == "Creative Commons Attribution 4.0 International"
+        )
         assert result["license_details"][0]["identifier"] == "cc-by-4.0"
 
     def test_extract_non_oa_license(self) -> None:
@@ -269,9 +271,7 @@ class TestSaveLicenseEvidence:
         with Session(spider_with_db.engine) as session:
             # Check evidence was saved
             evidence = session.exec(
-                select(ArticleOAEvidence).where(
-                    ArticleOAEvidence.article_id == sample_article.id
-                )
+                select(ArticleOAEvidence).where(ArticleOAEvidence.article_id == sample_article.id)
             ).first()
             assert evidence is not None
             assert evidence.kind == OAEvidenceKind.LICENSE
@@ -305,9 +305,7 @@ class TestSaveLicenseEvidence:
         with Session(spider_with_db.engine) as session:
             # Check evidence was saved
             evidence = session.exec(
-                select(ArticleOAEvidence).where(
-                    ArticleOAEvidence.article_id == sample_article.id
-                )
+                select(ArticleOAEvidence).where(ArticleOAEvidence.article_id == sample_article.id)
             ).first()
             assert evidence is not None
             assert evidence.supports_oa is False

--- a/tests/spiders/test_openalex.py
+++ b/tests/spiders/test_openalex.py
@@ -1,9 +1,10 @@
 import json
-import pytest
 from pathlib import Path
-from scrapy.http import HtmlResponse, Request
 from typing import Any
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from scrapy.http import HtmlResponse, Request
 
 from open_ire.author import AuthorRecord
 from open_ire.enums import ArticleType
@@ -34,7 +35,7 @@ def five_authors() -> list[AuthorRecord]:
 
 
 @pytest.fixture
-def dummy_publication(five_authors) -> dict[str, Any]:
+def dummy_publication(five_authors: list[AuthorRecord]) -> dict[str, Any]:
     return {
         "id": "W123",
         "title": "A Study on Testing",
@@ -62,14 +63,16 @@ class TestOpenAlexSpider:
         assert journal_name == "Alternate Journal Name"
 
         journal_name = OpenAlexSpider._extract_journal_name({})
-        assert journal_name == None
+        assert journal_name is None
 
         journal_name = OpenAlexSpider._extract_journal_name(
             {"primary_location": "invalid data", "locations": ["invalid location"]}
         )
-        assert journal_name == None
+        assert journal_name is None
 
-    def test_extract_authors(self, five_authors, dummy_publication) -> None:
+    def test_extract_authors(
+        self, five_authors: list[AuthorRecord], dummy_publication: dict[str, Any]
+    ) -> None:
         authors = OpenAlexSpider._extract_authors(dummy_publication)
         assert authors == [five_authors[0], five_authors[1]]
 
@@ -77,13 +80,19 @@ class TestOpenAlexSpider:
         assert authors == []
 
     @pytest.mark.parametrize(
-        "author_id,cursor",
+        ("author_id", "cursor"),
         [
             ("A1", "*"),
             ("A2", "cursor123"),
         ],
     )
-    def test_request_publications(self, spider, five_authors, author_id, cursor) -> None:
+    def test_request_publications(
+        self,
+        spider: OpenAlexSpider,
+        five_authors: list[AuthorRecord],
+        author_id: str,
+        cursor: str,
+    ) -> None:
         requests = list(
             spider._request_publications(author_id, five_authors[0].normalized_name, cursor)
         )
@@ -96,7 +105,9 @@ class TestOpenAlexSpider:
         query_params = parse_qs(parsed_url.query)
         assert query_params["cursor"] == [cursor]
 
-    def test_author_publication_requests(self, spider, five_authors) -> None:
+    def test_author_publication_requests(
+        self, spider: OpenAlexSpider, five_authors: list[AuthorRecord]
+    ) -> None:
         response_data = {"results": [{"id": "A1"}, {"id": "A2"}]}
         request = Request(
             url="http://dummy.url", meta={"matched_author": five_authors[0].normalized_name}
@@ -114,7 +125,12 @@ class TestOpenAlexSpider:
         assert requests[0].url.startswith(spider.base_url + "/works")
         assert requests[1].url.startswith(spider.base_url + "/works")
 
-    def test_parse_publications(self, spider, five_authors, dummy_publication) -> None:
+    def test_parse_publications(
+        self,
+        spider: OpenAlexSpider,
+        five_authors: list[AuthorRecord],
+        dummy_publication: dict[str, Any],
+    ) -> None:
         publication_data = {
             "results": [
                 {
@@ -138,7 +154,12 @@ class TestOpenAlexSpider:
         assert isinstance(emitted[0], ArticleItem)
         assert isinstance(emitted[1], Request)
 
-    def test_build_item(self, spider, five_authors, dummy_publication) -> None:
+    def test_build_item(
+        self,
+        spider: OpenAlexSpider,
+        five_authors: list[AuthorRecord],
+        dummy_publication: dict[str, Any],
+    ) -> None:
         item = spider._build_item(dummy_publication, five_authors[0].normalized_name)
         assert isinstance(item, ArticleItem)
         assert (
@@ -149,7 +170,9 @@ class TestOpenAlexSpider:
         assert item.extra["matched_author"] == five_authors[0].normalized_name
         assert item.authors == AuthorRecord.encode_author_string([five_authors[0], five_authors[1]])
 
-    def test_build_search_request(self, spider, five_authors) -> None:
+    def test_build_search_request(
+        self, spider: OpenAlexSpider, five_authors: list[AuthorRecord]
+    ) -> None:
         request = spider.build_search_request(five_authors[0].normalized_name)
         assert isinstance(request, Request)
         assert request.url.startswith(spider.base_url + "/authors")
@@ -159,7 +182,7 @@ class TestOpenAlexSpider:
         assert "affiliations.institution.id:" in query_params["filter"][0]
 
     @pytest.mark.asyncio
-    async def test_start(self, spider) -> None:
+    async def test_start(self, spider: OpenAlexSpider) -> None:
         requests = []
         async for req in spider.start():
             requests.append(req)
@@ -168,7 +191,7 @@ class TestOpenAlexSpider:
         assert "Kemi+Adeyemi" in requests[0].url
 
     @pytest.mark.parametrize(
-        "raw_type,expected",
+        ("raw_type", "expected"),
         [
             ("article", ArticleType.SCHOLARLY_ARTICLE),
             ("preprint", ArticleType.SCHOLARLY_ARTICLE),

--- a/tests/spiders/test_wos.py
+++ b/tests/spiders/test_wos.py
@@ -1,10 +1,10 @@
 import copy
 import json
-import pytest
 from pathlib import Path
-from scrapy.http import HtmlResponse, Request
 from typing import Any
-from urllib.parse import urlparse, parse_qs
+
+import pytest
+from scrapy.http import HtmlResponse, Request
 
 from open_ire.author import AuthorRecord
 from open_ire.enums import ArticleType
@@ -51,8 +51,14 @@ def dummy_record(five_authors: list[AuthorRecord]) -> dict[str, Any]:
                 },
                 "names": {
                     "name": [
-                        {"display_name": five_authors[4].normalized_name, "wos_standard": f"{five_authors[4].last_name}, {five_authors[4].first_initial}"},
-                        {"display_name": five_authors[0].normalized_name, "wos_standard": f"{five_authors[0].last_name}, {five_authors[0].first_initial}"},
+                        {
+                            "display_name": five_authors[4].normalized_name,
+                            "wos_standard": f"{five_authors[4].last_name}, {five_authors[4].first_initial}",
+                        },
+                        {
+                            "display_name": five_authors[0].normalized_name,
+                            "wos_standard": f"{five_authors[0].last_name}, {five_authors[0].first_initial}",
+                        },
                     ]
                 },
                 "doctypes": {"doctype": "Article"},
@@ -77,13 +83,15 @@ def dummy_response(dummy_record: dict[str, Any]) -> HtmlResponse:
 
 
 @pytest.fixture
-def spider(dummy_csv: Path, monkeypatch) -> WoSSpider:
+def spider(dummy_csv: Path, monkeypatch: pytest.MonkeyPatch) -> WoSSpider:
     monkeypatch.setenv("WOS_API_KEY", "dummy_api_key")
     return WoSSpider(author_csv=str(dummy_csv), start_year="2020", end_year="2021")
 
 
 class TestWoSSpider:
-    def test_build_item(self, spider: WoSSpider, five_authors: list[AuthorRecord], dummy_record: dict[str, Any]) -> None:
+    def test_build_item(
+        self, spider: WoSSpider, five_authors: list[AuthorRecord], dummy_record: dict[str, Any]
+    ) -> None:
         item = spider._build_item(dummy_record, five_authors[4].normalized_name)
 
         assert isinstance(item, ArticleItem)
@@ -93,7 +101,9 @@ class TestWoSSpider:
         assert item.authors == AuthorRecord.encode_author_string([five_authors[4], five_authors[0]])
         assert item.url == "https://doi.org/10.1000/sampledoi"
 
-    def test_build_item_without_doi(self, spider: WoSSpider, five_authors: list[AuthorRecord], dummy_record: dict[str, Any]) -> None:
+    def test_build_item_without_doi(
+        self, spider: WoSSpider, five_authors: list[AuthorRecord], dummy_record: dict[str, Any]
+    ) -> None:
         # Remove DOI from the record
         record_without_doi = copy.deepcopy(dummy_record)
         record_without_doi["dynamic_data"]["cluster_related"]["identifiers"] = {"identifier": []}
@@ -104,7 +114,9 @@ class TestWoSSpider:
         assert item.doi is None
         assert item.url == "https://www.webofscience.com/wos/woscc/full-record/WOS:000123456789"
 
-    def test_build_item_missing_identifiers_section(self, spider: WoSSpider, five_authors: list[AuthorRecord], dummy_record: dict[str, Any]) -> None:
+    def test_build_item_missing_identifiers_section(
+        self, spider: WoSSpider, five_authors: list[AuthorRecord], dummy_record: dict[str, Any]
+    ) -> None:
         # Remove entire identifiers section
         record_no_identifiers = copy.deepcopy(dummy_record)
         record_no_identifiers["dynamic_data"]["cluster_related"] = {}
@@ -115,10 +127,14 @@ class TestWoSSpider:
         assert item.doi is None
         assert item.url == "https://www.webofscience.com/wos/woscc/full-record/WOS:000123456789"
 
-    def test_parse_publications(self, spider: WoSSpider, five_authors: list[AuthorRecord], dummy_response: HtmlResponse) -> None:
+    def test_parse_publications(
+        self, spider: WoSSpider, five_authors: list[AuthorRecord], dummy_response: HtmlResponse
+    ) -> None:
         query = spider._build_query(five_authors[4].normalized_name)
         # Create a request with meta to tie to the response
-        request = Request(url="http://example.com/api", meta={'matched_author': five_authors[4].normalized_name})
+        request = Request(
+            url="http://example.com/api", meta={"matched_author": five_authors[4].normalized_name}
+        )
         dummy_response = dummy_response.replace(request=request)
 
         results = list(spider.parse_publications(dummy_response, query, page=1))
@@ -135,7 +151,9 @@ class TestWoSSpider:
         assert item.doi == "10.1000/sampledoi"
         assert item.authors == AuthorRecord.encode_author_string([five_authors[4], five_authors[0]])
 
-    def test_build_search_request(self, spider: WoSSpider, five_authors: list[AuthorRecord]) -> None:
+    def test_build_search_request(
+        self, spider: WoSSpider, five_authors: list[AuthorRecord]
+    ) -> None:
         request = spider.build_search_request(five_authors[4].normalized_name)
 
         assert request.url.startswith(spider.base_url + "?count=25&databaseId=WOS")
@@ -149,8 +167,12 @@ class TestWoSSpider:
             "QueryResult": {"RecordsFound": 0},
         }
         body_str = json.dumps(json_body)
-        request = Request(url="http://example.com/api", meta={'matched_author': five_authors[1].normalized_name})
-        response = HtmlResponse(url="http://example.com/api", body=body_str, encoding="utf-8", request=request)
+        request = Request(
+            url="http://example.com/api", meta={"matched_author": five_authors[1].normalized_name}
+        )
+        response = HtmlResponse(
+            url="http://example.com/api", body=body_str, encoding="utf-8", request=request
+        )
 
         query = spider._build_query(five_authors[1].normalized_name)
         results = list(spider.parse_publications(response, query, page=1))
@@ -170,8 +192,12 @@ class TestWoSSpider:
             "QueryResult": {"RecordsFound": 0},
         }
         body_str = json.dumps(json_body)
-        request = Request(url="http://example.com/api", meta={'matched_author': five_authors[2].normalized_name})
-        response = HtmlResponse(url="http://example.com/api", body=body_str, encoding="utf-8", request=request)
+        request = Request(
+            url="http://example.com/api", meta={"matched_author": five_authors[2].normalized_name}
+        )
+        response = HtmlResponse(
+            url="http://example.com/api", body=body_str, encoding="utf-8", request=request
+        )
 
         query = spider._build_query(five_authors[2].normalized_name)
         results = list(spider.parse_publications(response, query, page=1))
@@ -183,7 +209,7 @@ class TestWoSSpider:
         assert requests == []
 
     @pytest.mark.parametrize(
-        "raw_type,expected",
+        ("raw_type", "expected"),
         [
             ("article", ArticleType.SCHOLARLY_ARTICLE),
             ("Article", ArticleType.SCHOLARLY_ARTICLE),
@@ -198,7 +224,9 @@ class TestWoSSpider:
             ("Letter", ArticleType.OTHER),
         ],
     )
-    def test_normalize_type_known_types(self, spider: WoSSpider, raw_type: str, expected: ArticleType) -> None:
+    def test_normalize_type_known_types(
+        self, spider: WoSSpider, raw_type: str, expected: ArticleType
+    ) -> None:
         assert spider._normalize_type(raw_type) == expected
 
     def test_normalize_type_none(self, spider: WoSSpider) -> None:

--- a/tests/test_sharepoint.py
+++ b/tests/test_sharepoint.py
@@ -1,7 +1,7 @@
 import os
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -51,14 +51,15 @@ class TestSharePoint:
 
     @staticmethod
     def _mock_client_drive_id(
-        sharepoint_client, drive_id: str = DefaultValues.DRIVE_ID.value
-    ):
-        sharepoint_client._get_drive_id = AsyncMock(return_value=drive_id)
+        sharepoint_client: SharePoint, drive_id: str = DefaultValues.DRIVE_ID.value
+    ) -> None:
+        sharepoint_client.__setattr__("_get_drive_id", AsyncMock(return_value=drive_id))
 
     @staticmethod
-    def _mock_client_drive_item(sharepoint_client) -> Any:
-        return (
-            sharepoint_client._client.drives.by_drive_id.return_value.items.by_drive_item_id.return_value
+    def _mock_client_drive_item(sharepoint_client: SharePoint) -> MagicMock:
+        client = cast(MagicMock, sharepoint_client._client)
+        return cast(
+            MagicMock, client.drives.by_drive_id.return_value.items.by_drive_item_id.return_value
         )
 
     @staticmethod
@@ -72,7 +73,7 @@ class TestSharePoint:
         return test_file
 
     @staticmethod
-    def _assert_client_attributes(client: SharePoint, expected_values: dict[str, str]):
+    def _assert_client_attributes(client: SharePoint, expected_values: dict[str, str]) -> None:
         for attr, expected_value in expected_values.items():
             assert getattr(client, attr) == expected_value
 
@@ -106,13 +107,19 @@ class TestSharePoint:
     @pytest.fixture
     @patch("open_ire.sharepoint.GraphServiceClient")
     @patch("open_ire.sharepoint.ClientSecretCredential")
-    def sharepoint_client(self, mock_credential, mock_graph_client, mock_env_vars):
+    def sharepoint_client(
+        self,
+        _mock_credential: MagicMock,  # needed for @patch decorator
+        mock_graph_client: MagicMock,  # needed for @patch decorator
+        mock_env_vars: dict[str, str],
+    ) -> SharePoint:
         with patch.dict(os.environ, mock_env_vars):
             mock_graph_client.return_value = MagicMock()
-            client = SharePoint(base_path=DefaultValues.BASE_PATH.value)
-            return client
+            return SharePoint(base_path=DefaultValues.BASE_PATH.value)
 
-    def test_init_with_args(self, mock_client_args, expected_client_attributes):
+    def test_init_with_args(
+        self, mock_client_args: dict[str, str], expected_client_attributes: dict[str, str]
+    ) -> None:
         with (
             patch("open_ire.sharepoint.GraphServiceClient"),
             patch("open_ire.sharepoint.ClientSecretCredential"),
@@ -124,7 +131,9 @@ class TestSharePoint:
 
         self._assert_client_attributes(client, expected_client_attributes)
 
-    def test_init_with_env(self, mock_env_vars, expected_client_attributes):
+    def test_init_with_env(
+        self, mock_env_vars: dict[str, str], expected_client_attributes: dict[str, str]
+    ) -> None:
         with (
             patch.dict(os.environ, mock_env_vars),
             patch("open_ire.sharepoint.GraphServiceClient"),
@@ -144,13 +153,15 @@ class TestSharePoint:
             },
         ],
     )
-    def test_init_missing_params(self, env_vars):
-        with patch.dict(os.environ, env_vars, clear=True):
-            with pytest.raises(ValueError):
-                SharePoint(base_path=DefaultValues.BASE_PATH.value)
+    def test_init_missing_params(self, env_vars: dict[str, str]) -> None:
+        with (
+            patch.dict(os.environ, env_vars, clear=True),
+            pytest.raises(ValueError, match="Missing required parameters for SharePoint client"),
+        ):
+            SharePoint(base_path=DefaultValues.BASE_PATH.value)
 
     @pytest.mark.parametrize(
-        "path,expected",
+        ("path", "expected"),
         [
             (
                 "folder/file.txt",
@@ -170,13 +181,20 @@ class TestSharePoint:
             ),
         ],
     )
-    def test_item_id_from_path(self, sharepoint_client, path: str, expected: str):
+    def test_item_id_from_path(
+        self, sharepoint_client: SharePoint, path: str, expected: str
+    ) -> None:
         result = sharepoint_client._item_id_from_path(path)
         assert result == expected
 
     @patch("open_ire.sharepoint.GraphServiceClient")
     @patch("open_ire.sharepoint.ClientSecretCredential")
-    def test_authenticate(self, mock_credential, mock_graph_client, sharepoint_client):
+    def test_authenticate(
+        self,
+        mock_credential: MagicMock,
+        mock_graph_client: MagicMock,
+        sharepoint_client: SharePoint,
+    ) -> None:
         mock_cred_instance = MagicMock()
         mock_credential.return_value = mock_cred_instance
         mock_graph_instance = MagicMock()
@@ -195,45 +213,47 @@ class TestSharePoint:
         assert result == mock_graph_instance
 
     @pytest.mark.asyncio
-    async def test_get_drive_id(self, sharepoint_client):
+    async def test_get_drive_id(self, sharepoint_client: SharePoint) -> None:
         mock_drive = self._mock_drive()
-        sharepoint_client._client.sites.by_site_id.return_value.drive.get = AsyncMock(
-            return_value=mock_drive
-        )
+        client = cast(MagicMock, sharepoint_client._client)
+        client.sites.by_site_id.return_value.drive.get = AsyncMock(return_value=mock_drive)
         result = await sharepoint_client._get_drive_id()
 
         assert result == DefaultValues.DRIVE_ID.value
         assert sharepoint_client._drive_id == DefaultValues.DRIVE_ID.value
 
     @pytest.mark.asyncio
-    async def test_get_drive_id_failure(self, sharepoint_client):
-        sharepoint_client._client.sites.by_site_id.return_value.drive.get = AsyncMock(
-            return_value=None
-        )
+    async def test_get_drive_id_failure(self, sharepoint_client: SharePoint) -> None:
+        client = cast(MagicMock, sharepoint_client._client)
+        client.sites.by_site_id.return_value.drive.get = AsyncMock(return_value=None)
 
         with pytest.raises(RuntimeError):
             await sharepoint_client._get_drive_id()
 
     @pytest.mark.asyncio
-    async def test_get_drive_id_cached(self, sharepoint_client):
+    async def test_get_drive_id_cached(self, sharepoint_client: SharePoint) -> None:
         sharepoint_client._drive_id = DefaultValues.DRIVE_ID.value
         result = await sharepoint_client._get_drive_id()
 
         assert result == DefaultValues.DRIVE_ID.value
-        sharepoint_client._client.sites.by_site_id.assert_not_called()
+        client = cast(MagicMock, sharepoint_client._client)
+        client.sites.by_site_id.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("open_ire.sharepoint.LargeFileUploadTask")
-    async def test_upload_file(self, mock_task_class, sharepoint_client, tmp_path):
+    async def test_upload_file(
+        self,
+        mock_task_class: MagicMock,
+        sharepoint_client: SharePoint,
+        tmp_path: Path,
+    ) -> None:
         test_file = self._create_test_file(tmp_path)
         mock_upload_result = MagicMock(spec=UploadResult)
         mock_upload_session = self._mock_upload_session()
 
         self._mock_client_drive_id(sharepoint_client)
         chain_mock = self._mock_client_drive_item(sharepoint_client)
-        chain_mock.create_upload_session.post = AsyncMock(
-            return_value=mock_upload_session
-        )
+        chain_mock.create_upload_session.post = AsyncMock(return_value=mock_upload_session)
 
         mock_task = MagicMock()
         mock_task.upload = AsyncMock(return_value=mock_upload_result)
@@ -245,14 +265,14 @@ class TestSharePoint:
         mock_task.upload.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_upload_missing_file(self, sharepoint_client):
+    async def test_upload_missing_file(self, sharepoint_client: SharePoint) -> None:
         non_existent_file = Path("/non/existent/file.txt")
 
         with pytest.raises(FileNotFoundError):
             await sharepoint_client.upload_file(non_existent_file, "uploads/test.txt")
 
     @pytest.mark.asyncio
-    async def test_delete_item(self, sharepoint_client):
+    async def test_delete_item(self, sharepoint_client: SharePoint) -> None:
         self._mock_client_drive_id(sharepoint_client)
         chain_mock = self._mock_client_drive_item(sharepoint_client)
         chain_mock.delete = AsyncMock()
@@ -263,7 +283,7 @@ class TestSharePoint:
         chain_mock.delete.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_get_item(self, sharepoint_client):
+    async def test_get_item(self, sharepoint_client: SharePoint) -> None:
         mock_drive_item = self._mock_drive_item()
 
         self._mock_client_drive_id(sharepoint_client)
@@ -273,11 +293,10 @@ class TestSharePoint:
         result = await sharepoint_client.get_item("folder/test.txt")
 
         assert result == mock_drive_item
-        sharepoint_client._client.drives.by_drive_id.assert_called_once_with(
-            DefaultValues.DRIVE_ID.value
-        )
+        client = cast(MagicMock, sharepoint_client._client)
+        client.drives.by_drive_id.assert_called_once_with(DefaultValues.DRIVE_ID.value)
 
-    def test_base_path_id(self, sharepoint_client):
+    def test_base_path_id(self, sharepoint_client: SharePoint) -> None:
         custom_base_path = "unittest/base/path"
         sharepoint_client.base_path = custom_base_path
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,17 +10,17 @@ from open_ire.utils import as_list, parse_date, validate_year
 class TestParseDate:
     """Tests for parse_date function."""
 
-    def test_parse_valid_date(self):
+    def test_parse_valid_date(self) -> None:
         """Test parsing valid date strings."""
         assert parse_date("2023-01-15") == date(2023, 1, 15)
         assert parse_date("January 15, 2023") == date(2023, 1, 15)
 
-    def test_parse_none_or_empty(self):
+    def test_parse_none_or_empty(self) -> None:
         """Test parsing None or empty values."""
         assert parse_date(None) is None
         assert parse_date("") is None
 
-    def test_parse_invalid_date(self):
+    def test_parse_invalid_date(self) -> None:
         """Test parsing invalid date strings."""
         assert parse_date("not a date") is None
         assert parse_date("2023-13-45") is None
@@ -29,17 +29,17 @@ class TestParseDate:
 class TestValidateYear:
     """Tests for validate_year function."""
 
-    def test_valid_year(self):
+    def test_valid_year(self) -> None:
         """Test validating valid years."""
         assert validate_year("2023", "test_field") == 2023
         assert validate_year("1950", "test_field") == 1950
 
-    def test_invalid_year_string(self):
+    def test_invalid_year_string(self) -> None:
         """Test validating invalid year strings."""
         with pytest.raises(ValueError, match="Invalid test_field"):
             validate_year("not a year", "test_field")
 
-    def test_year_out_of_range(self):
+    def test_year_out_of_range(self) -> None:
         """Test validating years outside reasonable range."""
         with pytest.raises(ValueError, match="outside reasonable range"):
             validate_year("1800", "test_field")
@@ -50,16 +50,16 @@ class TestValidateYear:
 class TestAsList:
     """Tests for as_list function."""
 
-    def test_none_value(self):
+    def test_none_value(self) -> None:
         """Test converting None to list."""
         assert as_list(None) == []
 
-    def test_already_list(self):
+    def test_already_list(self) -> None:
         """Test that lists are returned as-is."""
         test_list = [1, 2, 3]
         assert as_list(test_list) is test_list
 
-    def test_single_value(self):
+    def test_single_value(self) -> None:
         """Test converting single values to list."""
         assert as_list("single") == ["single"]
         assert as_list(42) == [42]


### PR DESCRIPTION
Substantive changes:

1. Updated project metadata URLs from template repo to real open-ire links (Homepage, Documentation, Repository, Issues) in pyproject.toml.
2. Expanded dev extras to include missing tooling/type stubs (mypy, ipython, ruff, types-requests) and removed self-referential all extra.
3. Tightened mypy config to `python_version = "3.12"` and enabled stricter checks globally (disallow_untyped_defs, disallow_incomplete_defs).
4. Stopped excluding tests from Ruff globally by removing `exclude = ["tests/**", ...]`, while keeping targeted per-file ignores.
5. Made dotenv task safer/idempotent: `mkdir -p output && cp -n .env.example .env`.
6. Removed duplicate/legacy Pixi dev dependency block in favor of consistent feature-based dependency/task setup.
7. Updated tests to pass Ruff/Mypy.
8. Added some overrides for Mypy/Ruff for tests.
9. Added override for Mypy to skip msgraph.* altogether, which makes `mypy` run much, much faster.