### PR TITLE
Rename user tasks to resume/search-authors/search-terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,35 +94,50 @@ For detailed development setup, including pre-commit hooks, please see
 This project includes spiders for crawling repositories using two main methods:
 a list of keywords or a CSV file of author names.
 
+### Crawl and Resume
+
+To run a spider with a persistent crawl state (Scrapy `JOBDIR`) and optionally
+skip already-known files, use the `resume` command:
+
+```bash
+pixi run resume <spider_name> [--skip-existing]
+```
+
+For example:
+
+```bash
+pixi run resume eric --skip-existing
+```
+
 ### Search by Keyword
 
-To run a spider with a custom list of search terms, use the `terms-search`
+To run a spider with a custom list of search terms, use the `search-terms`
 command:
 
 ```bash
-pixi run terms-search <spider_name> "term1,term2,..." [<page>]
+pixi run search-terms <spider_name> "term1,term2,..." [<page>]
 ```
 
 For example, to search the `eric` repository:
 
 ```bash
-pixi run terms-search eric "ocean acidification,coral bleaching"
+pixi run search-terms eric "ocean acidification,coral bleaching"
 ```
 
 ### Search by Author
 
 To run a spider that supports searching by author against a list of authors, use
-the `author-search` command. This requires a CSV file with `FirstName`,
+the `search-authors` command. This requires a CSV file with `FirstName`,
 `LastName`, and `Email` columns.
 
 ```bash
-pixi run author-search <spider_name> <path_to_csv>
+pixi run search-authors <spider_name> <path_to_csv>
 ```
 
 For example, to search `openalex` using an author file:
 
 ```bash
-pixi run author-search openalex data/authors.csv
+pixi run search-authors openalex data/authors.csv
 ```
 
 ## Contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,23 +185,17 @@ test = "python -m pytest -ra --cov=open_ire"
 [tool.pixi.tasks.dotenv]
 cmd = "mkdir -p output && cp -n .env.example .env"
 
-[tool.pixi.tasks.author-search]
-args = ["spider", "author_csv"]
-cmd = "scrapy crawl {{ spider }} -a author_csv={{ author_csv }}"
-
-[tool.pixi.tasks.terms-search]
-args = ["spider", "terms", "page"]
-cmd = "scrapy crawl {{ spider }} -a page={{ page }} -a terms=\"{{ terms }}\""
-
-[tool.pixi.tasks.spider]
-args = ["spider"]
-depends-on = [
-    { task = "terms-search", args = ["{{ spider }}", "university of washington", "1"] }
-]
-
-[tool.pixi.tasks.start]
+[tool.pixi.tasks.resume]
 args = [
     "spider",
     { "arg" = "flag", "default" = "" },
 ]
 cmd = "scrapy crawl {{ spider }} -s JOBDIR=crawls/{{ spider }}{% if '--skip-existing' in flag %} -s OPEN_IRE_SKIP_EXISTING=True{% endif %}"
+
+[tool.pixi.tasks.search-authors]
+args = ["spider", "author_csv"]
+cmd = "scrapy crawl {{ spider }} -a author_csv={{ author_csv }}"
+
+[tool.pixi.tasks.search-terms]
+args = ["spider", "terms", "page"]
+cmd = "scrapy crawl {{ spider }} -a page={{ page }} -a terms=\"{{ terms }}\""


### PR DESCRIPTION
This makes command intent explicit by execution mode, replacing ambiguous/overlapping names with a consistent vocabulary.

NOTE: After #64.