### PR TITLE
fix: Drop spider argument from (open|close)_spider(), process_item()

### DIFF
--- a/src/open_ire/pipelines/base_sql_model_pipeline.py
+++ b/src/open_ire/pipelines/base_sql_model_pipeline.py
@@ -2,7 +2,6 @@ import logging
 from pathlib import Path
 from typing import Self
 
-from scrapy import Spider
 from scrapy.crawler import Crawler
 from sqlalchemy import Engine, event
 from sqlmodel import Session, SQLModel, create_engine, select
@@ -21,6 +20,7 @@ class BaseSQLModelPipeline:
         self.engine: Engine | None = None
         self.db_path = db_path
         self.files_base_path = files_base_path
+        self.crawler: Crawler | None = None
 
     @staticmethod
     def find_existing_article(session: Session, item: ArticleItem) -> Article | None:
@@ -47,9 +47,11 @@ class BaseSQLModelPipeline:
             conf = "FILES_STORE"
             raise ConfigurationError(conf)
 
-        return cls(db_path, files_base_path)
+        pipeline = cls(db_path, files_base_path)
+        pipeline.crawler = crawler
+        return pipeline
 
-    def open_spider(self, spider: Spider) -> None:  # noqa: ARG002
+    def open_spider(self) -> None:
         if self.engine:
             return
 
@@ -66,6 +68,6 @@ class BaseSQLModelPipeline:
 
         SQLModel.metadata.create_all(self.engine)
 
-    def close_spider(self, spider: Spider) -> None:  # noqa: ARG002
+    def close_spider(self) -> None:
         if self.engine:
             self.engine.dispose()

--- a/src/open_ire/pipelines/doi_normalization_pipeline.py
+++ b/src/open_ire/pipelines/doi_normalization_pipeline.py
@@ -1,5 +1,3 @@
-from scrapy import Spider
-
 from open_ire.items import ArticleItem
 
 
@@ -38,6 +36,6 @@ class DOINormalizationPipeline:
 
         return doi
 
-    def process_item(self, item: ArticleItem, spider: Spider) -> ArticleItem:  # noqa: ARG002
+    def process_item(self, item: ArticleItem) -> ArticleItem:
         item.doi = self.normalize(item.doi)
         return item

--- a/src/open_ire/pipelines/duplicates_pipeline.py
+++ b/src/open_ire/pipelines/duplicates_pipeline.py
@@ -1,4 +1,4 @@
-from scrapy import Spider
+from scrapy.crawler import Crawler
 
 from open_ire.errors import DuplicateItemError
 from open_ire.items import ArticleItem
@@ -11,10 +11,25 @@ class DuplicatesPipeline:
 
     def __init__(self) -> None:
         self.seen: set[str] = set()
+        self.crawler: Crawler | None = None
 
-    def process_item(self, item: ArticleItem, spider: Spider) -> ArticleItem:
+    @classmethod
+    def from_crawler(cls, crawler: Crawler) -> "DuplicatesPipeline":
+        pipeline = cls()
+        pipeline.crawler = crawler
+        return pipeline
+
+    def open_spider(self) -> None:
+        pass
+
+    def process_item(self, item: ArticleItem) -> ArticleItem:
         if item.reference in self.seen:
-            raise DuplicateItemError(item.reference, spider.name)
+            spider_name = (
+                self.crawler.spider.name
+                if self.crawler is not None and self.crawler.spider
+                else "unknown"
+            )
+            raise DuplicateItemError(item.reference, spider_name)
 
         self.seen.add(item.reference)
         return item

--- a/src/open_ire/pipelines/file_reference_pipeline.py
+++ b/src/open_ire/pipelines/file_reference_pipeline.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from urllib.parse import urlparse
 
-from scrapy import Spider
+from scrapy.crawler import Crawler
 from scrapy.http import Request, Response
 from scrapy.http.request import NO_CALLBACK
 from scrapy.utils.defer import maybe_deferred_to_future
@@ -13,6 +13,13 @@ class FileReferencePipeline:
     """
     Populates the `file_references` field of `ArticleItem` entities with metadata for external files.
     """
+
+    def __init__(self, crawler: Crawler | None = None) -> None:
+        self.crawler = crawler
+
+    @classmethod
+    def from_crawler(cls, crawler: Crawler) -> "FileReferencePipeline":
+        return cls(crawler)
 
     @staticmethod
     def _extract_file_size(response: Response) -> int | None:
@@ -35,7 +42,7 @@ class FileReferencePipeline:
         return None
 
     async def _get_file_reference(
-        self, spider: Spider, source_url: str, reference_url: str
+        self, source_url: str, reference_url: str
     ) -> dict[str, str | int | None]:
         file_reference: dict[str, str | int | None] = {
             "extension": self._extract_extension(reference_url),
@@ -45,10 +52,10 @@ class FileReferencePipeline:
         }
 
         request = Request(reference_url, method="HEAD", callback=NO_CALLBACK)
-        if not spider.crawler.engine:
+        if self.crawler is None or not self.crawler.engine:
             return file_reference
 
-        response = await maybe_deferred_to_future(spider.crawler.engine.download(request))
+        response = await maybe_deferred_to_future(self.crawler.engine.download(request))
 
         if response.status != 200:
             return file_reference
@@ -57,13 +64,17 @@ class FileReferencePipeline:
 
         return file_reference
 
-    async def process_item(self, item: ArticleItem, spider: Spider) -> ArticleItem:
+    async def process_item(self, item: ArticleItem) -> ArticleItem:
+        if self.crawler is None:
+            msg = "Crawler context unavailable in FileReferencePipeline.process_item()."
+            raise RuntimeError(msg)
+
         if not item.file_reference_urls:
             return item
 
         file_references = []
         for source_url, ref_url in item.file_reference_urls:
-            file_reference = await self._get_file_reference(spider, source_url, ref_url)
+            file_reference = await self._get_file_reference(source_url, ref_url)
             file_references.append(file_reference)
 
         item.file_references = file_references

--- a/src/open_ire/pipelines/sharepoint_pipeline.py
+++ b/src/open_ire/pipelines/sharepoint_pipeline.py
@@ -3,7 +3,6 @@ import math
 from pathlib import Path
 from typing import Self
 
-from scrapy import Spider
 from scrapy.crawler import Crawler
 
 from open_ire.errors import ConfigurationError
@@ -18,9 +17,12 @@ class SharePointPipeline:
     Uploads files to a SharePoint drive, if configured.
     """
 
-    def __init__(self, sharepoint_base_path: str, local_base_path: str) -> None:
+    def __init__(
+        self, sharepoint_base_path: str, local_base_path: str, crawler: Crawler | None = None
+    ) -> None:
         self.sharepoint = SharePoint(base_path=sharepoint_base_path)
         self.base_path = Path(local_base_path)
+        self.crawler = crawler
 
     @classmethod
     def from_crawler(cls, crawler: Crawler) -> Self:
@@ -30,7 +32,7 @@ class SharePointPipeline:
 
         sharepoint_base_path = crawler.settings.get("SHAREPOINT_BASE_PATH", "open_ire")
 
-        return cls(sharepoint_base_path, local_base_path)
+        return cls(sharepoint_base_path, local_base_path, crawler)
 
     @staticmethod
     def _remove_local_file(local_file_path: Path) -> None:
@@ -40,25 +42,25 @@ class SharePointPipeline:
             msg = f"Failed to remove local file {local_file_path}: {e}"
             logger.warning(msg)
 
-    def open_spider(self, spider: Spider) -> None:
+    def open_spider(self) -> None:
         pass
 
-    def close_spider(self, spider: Spider) -> None:
+    def close_spider(self) -> None:
         pass
 
-    async def _save_file(self, file_data: dict[str, str | int | None], spider: Spider) -> str:
+    async def _save_file(self, file_data: dict[str, str | int | None]) -> str:
         sharepoint_path = str(file_data.get("path") or "")
         local_file_path = self.base_path / sharepoint_path
 
         if not local_file_path.exists():
             msg = f"Local file not found: {local_file_path}"
-            spider.logger.error(msg)
+            logger.error(msg)
             return ""
 
         store_url = ""
         try:
             msg = f"Uploading file to SharePoint: {local_file_path} -> {sharepoint_path}"
-            spider.logger.info(msg)
+            logger.info(msg)
 
             upload_result = await self.sharepoint.upload_file(local_file_path, sharepoint_path)
             if upload_result.location:
@@ -77,23 +79,23 @@ class SharePointPipeline:
                     local_file_path.unlink()
                 else:
                     msg = f"Local file size ({local_file_path}) does not match remote ({store_url})"
-                    spider.logger.error(msg)
+                    logger.error(msg)
 
         except Exception as e:
             msg = f"Error uploading file {local_file_path}: {e}"
-            spider.logger.error(msg)
+            logger.error(msg)
 
         return store_url
 
-    async def process_item(self, item: ArticleItem, spider: Spider) -> ArticleItem:
+    async def process_item(self, item: ArticleItem) -> ArticleItem:
         if not item.files:
             msg = f"No files found for article '{item.reference}'."
-            spider.logger.warning(msg)
+            logger.warning(msg)
             return item
 
         store_urls = []
         for file_data in item.files:
-            store_urls.append(await self._save_file(file_data, spider))
+            store_urls.append(await self._save_file(file_data))
 
         item.store_urls = store_urls
 

--- a/src/open_ire/pipelines/skip_existing_pipeline.py
+++ b/src/open_ire/pipelines/skip_existing_pipeline.py
@@ -1,10 +1,13 @@
-from scrapy import Spider
+import logging
+
 from scrapy.crawler import Crawler
 from scrapy.exceptions import DropItem
 from sqlmodel import Session
 
 from open_ire.items import ArticleItem
 from open_ire.pipelines.base_sql_model_pipeline import BaseSQLModelPipeline
+
+logger = logging.getLogger(__name__)
 
 
 class SkipExistingPipeline(BaseSQLModelPipeline):
@@ -18,23 +21,30 @@ class SkipExistingPipeline(BaseSQLModelPipeline):
     def _should_skip_existing(crawler: Crawler) -> bool:
         return bool(crawler.settings.getbool("OPEN_IRE_SKIP_EXISTING", False))
 
-    def open_spider(self, spider: Spider) -> None:
-        if not self._should_skip_existing(spider.crawler):
+    def open_spider(self) -> None:
+        if self.crawler is None or not self._should_skip_existing(self.crawler):
             return
 
-        super().open_spider(spider)
+        super().open_spider()
 
-    def process_item(self, item: ArticleItem, spider: Spider) -> ArticleItem:
-        if not self._should_skip_existing(spider.crawler):
+    def process_item(self, item: ArticleItem) -> ArticleItem:
+        if self.crawler is None or not self._should_skip_existing(self.crawler):
             return item
 
         with Session(self.engine) as session:
             if self.find_existing_article(session, item) is not None:
-                spider.logger.info(
-                    "Skipping existing article '%s' from repository '%s'.",
-                    item.reference,
-                    item.repository,
-                )
+                if self.crawler.spider:
+                    self.crawler.spider.logger.info(
+                        "Skipping existing article '%s' from repository '%s'.",
+                        item.reference,
+                        item.repository,
+                    )
+                else:
+                    logger.info(
+                        "Skipping existing article '%s' from repository '%s'.",
+                        item.reference,
+                        item.repository,
+                    )
                 msg = "Article already exists in database."
                 raise DropItem(msg)
 

--- a/src/open_ire/pipelines/sql_model_pipeline.py
+++ b/src/open_ire/pipelines/sql_model_pipeline.py
@@ -1,8 +1,8 @@
+import logging
 from pathlib import Path
 from typing import Any
 
 from pydantic import ValidationError
-from scrapy import Spider
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session
 
@@ -11,6 +11,8 @@ from open_ire.items import ArticleItem
 from open_ire.models import Article, ArticleFile, ArticleFileReference
 from open_ire.pipelines.base_sql_model_pipeline import BaseSQLModelPipeline
 
+logger = logging.getLogger(__name__)
+
 
 class SQLModelPipeline(BaseSQLModelPipeline):
     """
@@ -18,9 +20,7 @@ class SQLModelPipeline(BaseSQLModelPipeline):
     """
 
     @staticmethod
-    def _get_article_file_references(
-        item: ArticleItem, spider: Spider
-    ) -> list[ArticleFileReference]:
+    def _get_article_file_references(item: ArticleItem) -> list[ArticleFileReference]:
         article_file_refs = []
         file_references = item.file_references or []
 
@@ -28,13 +28,12 @@ class SQLModelPipeline(BaseSQLModelPipeline):
             try:
                 article_file_refs.append(ArticleFileReference(**file_ref))
             except ValidationError:
-                spider.logger.warning("Skipping file reference due to validation error.")
+                logger.warning("Skipping file reference due to validation error.")
 
         return article_file_refs
 
     @staticmethod
     def _save_article_files(
-        spider: Spider,
         session: Session,
         article_id: Any,
         article_files: list[ArticleFile] | list[ArticleFileReference],
@@ -47,7 +46,7 @@ class SQLModelPipeline(BaseSQLModelPipeline):
             except IntegrityError as e:
                 msg = f"Integrity error while saving file for article '{article_id}: {e}"
                 session.rollback()
-                spider.logger.warning(msg)
+                logger.warning(msg)
 
     def _get_file_size(self, file_path: Path) -> int | None:
         full_path = Path(self.files_base_path or "") / file_path
@@ -59,7 +58,7 @@ class SQLModelPipeline(BaseSQLModelPipeline):
 
         return None
 
-    def _get_article_files(self, item: ArticleItem, spider: Spider) -> list[ArticleFile]:
+    def _get_article_files(self, item: ArticleItem) -> list[ArticleFile]:
         article_files = []
         files = item.files or []
 
@@ -74,19 +73,12 @@ class SQLModelPipeline(BaseSQLModelPipeline):
                 file_row = ArticleFile(**file_data)
                 article_files.append(file_row)
             except ValidationError:
-                spider.logger.warning("Skipping file due to validation error.")
+                logger.warning("Skipping file due to validation error.")
 
         return article_files
 
-    def open_spider(self, spider: Spider) -> None:
-        super().open_spider(spider)
-
-    def close_spider(self, spider: Spider) -> None:
-        super().close_spider(spider)
-
     def _update_existing_article(
         self,
-        spider: Spider,
         session: Session,
         existing_article: Article,
         item_data: dict[str, Any],
@@ -100,14 +92,13 @@ class SQLModelPipeline(BaseSQLModelPipeline):
         session.commit()
         session.refresh(existing_article)
 
-        self._save_article_files(spider, session, existing_article.id, article_files)
-        self._save_article_files(spider, session, existing_article.id, file_references)
+        self._save_article_files(session, existing_article.id, article_files)
+        self._save_article_files(session, existing_article.id, file_references)
 
         session.commit()
 
     def _create_new_article(
         self,
-        spider: Spider,
         session: Session,
         item_data: dict[str, Any],
         article_files: list[ArticleFile],
@@ -120,8 +111,8 @@ class SQLModelPipeline(BaseSQLModelPipeline):
             session.commit()
             session.refresh(article)
 
-            self._save_article_files(spider, session, article.id, article_files)
-            self._save_article_files(spider, session, article.id, file_references)
+            self._save_article_files(session, article.id, article_files)
+            self._save_article_files(session, article.id, file_references)
 
             session.commit()
 
@@ -129,9 +120,9 @@ class SQLModelPipeline(BaseSQLModelPipeline):
             session.rollback()
             raise DatabaseDuplicateItemError() from e
 
-    def process_item(self, item: ArticleItem, spider: Spider) -> ArticleItem:
-        article_files = self._get_article_files(item, spider)
-        file_references = self._get_article_file_references(item, spider)
+    def process_item(self, item: ArticleItem) -> ArticleItem:
+        article_files = self._get_article_files(item)
+        file_references = self._get_article_file_references(item)
         item_data = item.model_dump(
             exclude={
                 "file_reference_urls",
@@ -145,7 +136,6 @@ class SQLModelPipeline(BaseSQLModelPipeline):
         with Session(self.engine) as session:
             if existing_article := self.find_existing_article(session, item):
                 self._update_existing_article(
-                    spider,
                     session,
                     existing_article,
                     item_data,
@@ -153,6 +143,6 @@ class SQLModelPipeline(BaseSQLModelPipeline):
                     file_references,
                 )
             else:
-                self._create_new_article(spider, session, item_data, article_files, file_references)
+                self._create_new_article(session, item_data, article_files, file_references)
 
         return item

--- a/tests/pipelines/conftest.py
+++ b/tests/pipelines/conftest.py
@@ -54,16 +54,17 @@ def item_with_file_references() -> ArticleItem:
 
 
 @pytest.fixture
-def spider() -> Spider:
-    """Create a mock spider for testing."""
+def crawler() -> Crawler:
+    """Create a mock crawler for testing."""
     mock_crawler = MagicMock(spec=Crawler)
-    mock_crawler.settings = Settings({"OPEN_IRE_SKIP_EXISTING": True})
 
     mock_spider = MagicMock(spec=Spider)
     mock_spider.name = "test_spider"
     mock_spider.logger.warning = MagicMock()
     mock_spider.logger.error = MagicMock()
     mock_spider.crawler = mock_crawler
-    mock_crawler.spider = mock_spider
 
-    return cast(Spider, mock_spider)
+    mock_crawler.spider = mock_spider
+    mock_crawler.settings = Settings()
+
+    return cast(Crawler, mock_crawler)

--- a/tests/pipelines/conftest.py
+++ b/tests/pipelines/conftest.py
@@ -64,5 +64,6 @@ def spider() -> Spider:
     mock_spider.logger.warning = MagicMock()
     mock_spider.logger.error = MagicMock()
     mock_spider.crawler = mock_crawler
+    mock_crawler.spider = mock_spider
 
     return cast(Spider, mock_spider)

--- a/tests/pipelines/test_doi_normalization_pipeline.py
+++ b/tests/pipelines/test_doi_normalization_pipeline.py
@@ -1,7 +1,6 @@
 from typing import Any, cast
 
 import pytest
-from scrapy import Spider
 
 from open_ire.items import ArticleItem
 from open_ire.pipelines import DOINormalizationPipeline
@@ -16,61 +15,61 @@ class TestDOINormalizationPipeline:
         return DOINormalizationPipeline()
 
     def test_normalize_full_doi_url(
-        self, pipeline: DOINormalizationPipeline, spider: Spider, item: ArticleItem
+        self, pipeline: DOINormalizationPipeline, item: ArticleItem
     ) -> None:
         """Test normalizing a full DOI URL."""
         item.doi = " https://doi.org/10.1234/test.doi"
 
-        result = pipeline.process_item(item, spider)
+        result = pipeline.process_item(item)
 
         assert result.doi == "10.1234/test.doi"
 
     def test_normalize_already_normalized_doi(
-        self, pipeline: DOINormalizationPipeline, spider: Spider, item: ArticleItem
+        self, pipeline: DOINormalizationPipeline, item: ArticleItem
     ) -> None:
         """Test that already normalized DOIs are unchanged."""
         item.doi = "10.1234/test.doi "
 
-        result = pipeline.process_item(item, spider)
+        result = pipeline.process_item(item)
 
         assert result.doi == "10.1234/test.doi"
 
     def test_normalize_none_doi(
-        self, pipeline: DOINormalizationPipeline, spider: Spider, item: ArticleItem
+        self, pipeline: DOINormalizationPipeline, item: ArticleItem
     ) -> None:
         """Test that None DOI values are handled correctly."""
         item.doi = None
 
-        result = pipeline.process_item(item, spider)
+        result = pipeline.process_item(item)
 
         assert result.doi is None
 
     def test_normalize_empty_string_doi(
-        self, pipeline: DOINormalizationPipeline, spider: Spider, item: ArticleItem
+        self, pipeline: DOINormalizationPipeline, item: ArticleItem
     ) -> None:
         """Test that empty string DOI values are normalized to None."""
         item.doi = ""
 
-        result = pipeline.process_item(item, spider)
+        result = pipeline.process_item(item)
 
         assert result.doi is None
 
     def test_normalize_whitespace_only_doi(
-        self, pipeline: DOINormalizationPipeline, spider: Spider, item: ArticleItem
+        self, pipeline: DOINormalizationPipeline, item: ArticleItem
     ) -> None:
         """Test that whitespace-only DOI values are normalized to None."""
         item.doi = "   "
 
-        result = pipeline.process_item(item, spider)
+        result = pipeline.process_item(item)
 
         assert result.doi is None
 
     def test_normalize_non_string_doi(
-        self, pipeline: DOINormalizationPipeline, spider: Spider, item: ArticleItem
+        self, pipeline: DOINormalizationPipeline, item: ArticleItem
     ) -> None:
         """Test that non-string DOI values are normalized to None."""
         item.doi = cast(Any, 12345)
 
-        result = pipeline.process_item(item, spider)
+        result = pipeline.process_item(item)
 
         assert result.doi is None

--- a/tests/pipelines/test_duplicates_pipeline.py
+++ b/tests/pipelines/test_duplicates_pipeline.py
@@ -8,15 +8,18 @@ from open_ire.pipelines import DuplicatesPipeline
 
 class TestDuplicatesPipeline:
     @pytest.fixture
-    def pipeline(self) -> DuplicatesPipeline:
+    def pipeline(self, spider: Spider) -> DuplicatesPipeline:
         """Create a pipeline instance for testing."""
-        return DuplicatesPipeline()
+        pipeline = DuplicatesPipeline()
+        pipeline.crawler = spider.crawler
+        pipeline.open_spider()
+        return pipeline
 
     def test_process_unique_item(
         self, pipeline: DuplicatesPipeline, spider: Spider, item: ArticleItem
     ) -> None:
         """Test processing a unique item."""
-        result = pipeline.process_item(item, spider)
+        result = pipeline.process_item(item)
 
         assert result == item
         assert item.reference in pipeline.seen
@@ -27,7 +30,7 @@ class TestDuplicatesPipeline:
         """Test processing a duplicate item."""
         pipeline.seen.add(item.reference)
         with pytest.raises(DropItem) as e:
-            pipeline.process_item(item, spider)
+            pipeline.process_item(item)
 
         assert item.reference in str(e.value)
         assert spider.name in str(e.value)

--- a/tests/pipelines/test_duplicates_pipeline.py
+++ b/tests/pipelines/test_duplicates_pipeline.py
@@ -1,5 +1,5 @@
 import pytest
-from scrapy import Spider
+from scrapy.crawler import Crawler
 from scrapy.exceptions import DropItem
 
 from open_ire.items import ArticleItem
@@ -8,29 +8,29 @@ from open_ire.pipelines import DuplicatesPipeline
 
 class TestDuplicatesPipeline:
     @pytest.fixture
-    def pipeline(self, spider: Spider) -> DuplicatesPipeline:
+    def pipeline(self, crawler: Crawler) -> DuplicatesPipeline:
         """Create a pipeline instance for testing."""
         pipeline = DuplicatesPipeline()
-        pipeline.crawler = spider.crawler
+        pipeline.crawler = crawler
         pipeline.open_spider()
+        assert pipeline.crawler is not None
+        assert pipeline.crawler.spider is not None
         return pipeline
 
-    def test_process_unique_item(
-        self, pipeline: DuplicatesPipeline, spider: Spider, item: ArticleItem
-    ) -> None:
+    def test_process_unique_item(self, pipeline: DuplicatesPipeline, item: ArticleItem) -> None:
         """Test processing a unique item."""
         result = pipeline.process_item(item)
 
         assert result == item
         assert item.reference in pipeline.seen
 
-    def test_process_duplicate_item(
-        self, pipeline: DuplicatesPipeline, spider: Spider, item: ArticleItem
-    ) -> None:
+    def test_process_duplicate_item(self, pipeline: DuplicatesPipeline, item: ArticleItem) -> None:
         """Test processing a duplicate item."""
         pipeline.seen.add(item.reference)
         with pytest.raises(DropItem) as e:
             pipeline.process_item(item)
 
         assert item.reference in str(e.value)
-        assert spider.name in str(e.value)
+        assert pipeline.crawler is not None
+        assert pipeline.crawler.spider is not None
+        assert pipeline.crawler.spider.name in str(e.value)

--- a/tests/pipelines/test_sharepoint_pipeline.py
+++ b/tests/pipelines/test_sharepoint_pipeline.py
@@ -3,7 +3,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from scrapy import Spider
+from scrapy.crawler import Crawler
 
 from open_ire.items import ArticleItem
 from open_ire.pipelines import SharePointPipeline
@@ -13,7 +13,7 @@ class TestSharePointPipeline:
     """Tests the SharePoint pipeline for file uploads."""
 
     @pytest.fixture
-    def pipeline(self, spider: Spider, tmp_path: Path) -> SharePointPipeline:
+    def pipeline(self, crawler: Crawler, tmp_path: Path) -> SharePointPipeline:
         sharepoint_base_path = "test_sharepoint"
         local_base_path = str(tmp_path)
 
@@ -23,14 +23,16 @@ class TestSharePointPipeline:
 
             pipeline = SharePointPipeline(sharepoint_base_path, local_base_path)
             pipeline.sharepoint = mock_sharepoint
-            pipeline.crawler = spider.crawler
+            pipeline.crawler = crawler
             pipeline.open_spider()
+            assert pipeline.crawler is not None
+            assert pipeline.crawler.spider is not None
 
             return pipeline
 
     @pytest.mark.asyncio
     async def test_item_with_files(
-        self, pipeline: SharePointPipeline, spider: Spider, item: ArticleItem, tmp_path: Path
+        self, pipeline: SharePointPipeline, item: ArticleItem, tmp_path: Path
     ) -> None:
         """An item with files should trigger a SharePoint upload."""
         file1 = tmp_path / "file1.pdf"

--- a/tests/pipelines/test_sharepoint_pipeline.py
+++ b/tests/pipelines/test_sharepoint_pipeline.py
@@ -13,7 +13,7 @@ class TestSharePointPipeline:
     """Tests the SharePoint pipeline for file uploads."""
 
     @pytest.fixture
-    def pipeline(self, tmp_path: Path) -> SharePointPipeline:
+    def pipeline(self, spider: Spider, tmp_path: Path) -> SharePointPipeline:
         sharepoint_base_path = "test_sharepoint"
         local_base_path = str(tmp_path)
 
@@ -23,6 +23,8 @@ class TestSharePointPipeline:
 
             pipeline = SharePointPipeline(sharepoint_base_path, local_base_path)
             pipeline.sharepoint = mock_sharepoint
+            pipeline.crawler = spider.crawler
+            pipeline.open_spider()
 
             return pipeline
 
@@ -50,7 +52,7 @@ class TestSharePointPipeline:
         mock_drive_item.web_url = "https://sharepoint.com/web-url"
         sharepoint.get_item = AsyncMock(return_value=mock_drive_item)
 
-        result = await pipeline.process_item(item, spider)
+        result = await pipeline.process_item(item)
 
         assert result == item
         assert result.store_urls == [
@@ -61,34 +63,30 @@ class TestSharePointPipeline:
 
     @pytest.mark.asyncio
     async def test_process_item_no_files(
-        self, pipeline: SharePointPipeline, spider: Spider, item: ArticleItem
+        self, pipeline: SharePointPipeline, item: ArticleItem
     ) -> None:
         """An item without files should have an empty store_urls list."""
         item.files = []
 
-        result = await pipeline.process_item(item, spider)
+        result = await pipeline.process_item(item)
 
         assert result == item
         assert result.store_urls == []
-        cast(Any, spider.logger).warning.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_item_upload_error(
-        self, pipeline: SharePointPipeline, spider: Spider, item: ArticleItem
-    ) -> None:
+    async def test_item_upload_error(self, pipeline: SharePointPipeline, item: ArticleItem) -> None:
         """Upload errors should be logged."""
         sharepoint = cast(Any, pipeline.sharepoint)
         sharepoint.upload_file = AsyncMock(side_effect=Exception("Upload failed"))
 
-        result = await pipeline.process_item(item, spider)
+        result = await pipeline.process_item(item)
 
         assert result == item
         assert result.store_urls == [""]
-        cast(Any, spider.logger).error.assert_called()
 
     @pytest.mark.asyncio
     async def test_deletes_local_file(
-        self, pipeline: SharePointPipeline, spider: Spider, item: ArticleItem, tmp_path: Path
+        self, pipeline: SharePointPipeline, item: ArticleItem, tmp_path: Path
     ) -> None:
         """Local file should be deleted when remote size matches"""
         local_file = tmp_path / "file.pdf"
@@ -103,12 +101,11 @@ class TestSharePointPipeline:
         sharepoint.upload_file = AsyncMock(return_value=MagicMock())
         sharepoint.get_item = AsyncMock(return_value=mock_drive_item)
 
-        await pipeline.process_item(item, spider)
+        await pipeline.process_item(item)
         assert not local_file.exists()  # delete local copy
 
         # Mismatch
         local_file.write_text("B" * 2000)
         mock_drive_item.size = 5000
-        await pipeline.process_item(item, spider)
+        await pipeline.process_item(item)
         assert local_file.exists()  # preserve local copy
-        cast(Any, spider.logger).error.assert_called()

--- a/tests/pipelines/test_skip_existing_pipeline.py
+++ b/tests/pipelines/test_skip_existing_pipeline.py
@@ -18,7 +18,8 @@ class TestSkipExistingPipeline:
         spider.crawler.settings.set("OPEN_IRE_SKIP_EXISTING", True)
 
         instance = SkipExistingPipeline(":memory:", "output")
-        instance.open_spider(spider)
+        instance.crawler = spider.crawler
+        instance.open_spider()
         assert instance.engine is not None
         yield instance
         instance.engine.dispose()
@@ -28,21 +29,22 @@ class TestSkipExistingPipeline:
         spider.crawler.settings.set("OPEN_IRE_SKIP_EXISTING", False)
 
         instance = SkipExistingPipeline(":memory:", "output")
-        instance.open_spider(spider)
+        instance.crawler = spider.crawler
+        instance.open_spider()
         assert instance.engine is None
         return instance
 
     def test_process_item_with_skip_existing_disabled(
         self, pipeline_disabled: SkipExistingPipeline, spider: Spider, item: ArticleItem
     ) -> None:
-        result = pipeline_disabled.process_item(item, spider)
+        result = pipeline_disabled.process_item(item)
 
         assert result is item
 
     def test_process_item_with_new_article(
         self, pipeline_enabled: SkipExistingPipeline, spider: Spider, item: ArticleItem
     ) -> None:
-        result = pipeline_enabled.process_item(item, spider)
+        result = pipeline_enabled.process_item(item)
 
         assert result is item
 
@@ -62,4 +64,4 @@ class TestSkipExistingPipeline:
             session.commit()
 
         with pytest.raises(DropItem):
-            pipeline_enabled.process_item(item, spider)
+            pipeline_enabled.process_item(item)

--- a/tests/pipelines/test_skip_existing_pipeline.py
+++ b/tests/pipelines/test_skip_existing_pipeline.py
@@ -1,7 +1,7 @@
 from collections.abc import Generator
 
 import pytest
-from scrapy import Spider
+from scrapy.crawler import Crawler
 from scrapy.exceptions import DropItem
 from sqlmodel import Session
 
@@ -14,43 +14,47 @@ class TestSkipExistingPipeline:
     """Tests the SkipExistingPipeline for skipping existing articles."""
 
     @pytest.fixture
-    def pipeline_enabled(self, spider: Spider) -> Generator[SkipExistingPipeline, None, None]:
-        spider.crawler.settings.set("OPEN_IRE_SKIP_EXISTING", True)
+    def pipeline_enabled(self, crawler: Crawler) -> Generator[SkipExistingPipeline, None, None]:
+        crawler.settings.set("OPEN_IRE_SKIP_EXISTING", True)
 
         instance = SkipExistingPipeline(":memory:", "output")
-        instance.crawler = spider.crawler
+        instance.crawler = crawler
         instance.open_spider()
         assert instance.engine is not None
         yield instance
         instance.engine.dispose()
 
     @pytest.fixture
-    def pipeline_disabled(self, spider: Spider) -> SkipExistingPipeline:
-        spider.crawler.settings.set("OPEN_IRE_SKIP_EXISTING", False)
+    def pipeline_disabled(self, crawler: Crawler) -> Generator[SkipExistingPipeline, None, None]:
+        crawler.settings.set("OPEN_IRE_SKIP_EXISTING", False)
 
         instance = SkipExistingPipeline(":memory:", "output")
-        instance.crawler = spider.crawler
-        instance.open_spider()
-        assert instance.engine is None
-        return instance
+        instance.crawler = crawler
+        try:
+            instance.open_spider()
+            assert instance.engine is None
+            yield instance
+        finally:
+            instance.close_spider()
 
     def test_process_item_with_skip_existing_disabled(
-        self, pipeline_disabled: SkipExistingPipeline, spider: Spider, item: ArticleItem
+        self, pipeline_disabled: SkipExistingPipeline, item: ArticleItem
     ) -> None:
         result = pipeline_disabled.process_item(item)
 
         assert result is item
 
     def test_process_item_with_new_article(
-        self, pipeline_enabled: SkipExistingPipeline, spider: Spider, item: ArticleItem
+        self, pipeline_enabled: SkipExistingPipeline, item: ArticleItem
     ) -> None:
         result = pipeline_enabled.process_item(item)
 
         assert result is item
 
     def test_process_item_with_existing_article(
-        self, pipeline_enabled: SkipExistingPipeline, spider: Spider, item: ArticleItem
+        self, pipeline_enabled: SkipExistingPipeline, item: ArticleItem
     ) -> None:
+        assert pipeline_enabled.engine is not None
         with Session(pipeline_enabled.engine) as session:
             article = Article(
                 title=item.title,

--- a/tests/pipelines/test_sql_model_pipeline.py
+++ b/tests/pipelines/test_sql_model_pipeline.py
@@ -20,7 +20,8 @@ class TestSQLModelPipeline:
         Create a pipeline instance with an in-memory SQLite DB for each test.
         """
         instance = SQLModelPipeline(":memory:", "output")
-        instance.open_spider(spider)
+        instance.crawler = spider.crawler
+        instance.open_spider()
         assert instance.engine is not None
         yield instance
         instance.engine.dispose()
@@ -29,7 +30,7 @@ class TestSQLModelPipeline:
         self, pipeline: SQLModelPipeline, spider: Spider, item: ArticleItem
     ) -> None:
         """A valid item is processed successfully."""
-        result = pipeline.process_item(item, spider)
+        result = pipeline.process_item(item)
         assert result is item
 
         with Session(pipeline.engine) as session:
@@ -45,8 +46,8 @@ class TestSQLModelPipeline:
     ) -> None:
         """Test updating an existing article."""
 
-        pipeline.process_item(item, spider)
-        pipeline.process_item(item_with_file_references, spider)
+        pipeline.process_item(item)
+        pipeline.process_item(item_with_file_references)
 
         item_data = item.model_dump()
         item_data.update(
@@ -72,7 +73,7 @@ class TestSQLModelPipeline:
         )
         updated_item = ArticleItem(**item_data)
 
-        pipeline.process_item(updated_item, spider)
+        pipeline.process_item(updated_item)
 
         with Session(pipeline.engine) as session:
             articles = session.exec(select(Article)).all()
@@ -95,7 +96,7 @@ class TestSQLModelPipeline:
     ) -> None:
         """Test updating an existing article with new files."""
 
-        pipeline.process_item(item, spider)
+        pipeline.process_item(item)
 
         item_data = item.model_dump()
         item_data.update(
@@ -111,7 +112,7 @@ class TestSQLModelPipeline:
             }
         )
         updated_item = ArticleItem(**item_data)
-        result = pipeline.process_item(updated_item, spider)
+        result = pipeline.process_item(updated_item)
 
         assert result is updated_item
 
@@ -130,7 +131,7 @@ class TestSQLModelPipeline:
         self, pipeline: SQLModelPipeline, spider: Spider, item: ArticleItem
     ) -> None:
         """Test that files with the same URL and same checksum are not duplicated."""
-        pipeline.process_item(item, spider)
+        pipeline.process_item(item)
 
         item_data = item.model_dump()
         item_data.update(
@@ -146,7 +147,7 @@ class TestSQLModelPipeline:
             }
         )
         updated_item = ArticleItem(**item_data)
-        pipeline.process_item(updated_item, spider)
+        pipeline.process_item(updated_item)
 
         with Session(pipeline.engine) as session:
             files = session.exec(select(ArticleFile)).all()
@@ -160,7 +161,7 @@ class TestSQLModelPipeline:
     ) -> None:
         """Test that file references with the same URL are not duplicated."""
 
-        pipeline.process_item(item_with_file_references, spider)
+        pipeline.process_item(item_with_file_references)
 
         item_data = item_with_file_references.model_dump()
         item_data.update(
@@ -181,7 +182,7 @@ class TestSQLModelPipeline:
         )
         updated_item = ArticleItem(**item_data)
 
-        pipeline.process_item(updated_item, spider)
+        pipeline.process_item(updated_item)
 
         with Session(pipeline.engine) as session:
             file_refs = session.exec(select(ArticleFileReference)).all()

--- a/tests/pipelines/test_sql_model_pipeline.py
+++ b/tests/pipelines/test_sql_model_pipeline.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from scrapy import Spider
+from scrapy.crawler import Crawler
 from sqlmodel import Session, select
 
 from open_ire.items import ArticleItem
@@ -15,20 +15,18 @@ class TestSQLModelPipeline:
     """Tests the processing and validation logic of the SQLModelPipeline."""
 
     @pytest.fixture
-    def pipeline(self, spider: Spider) -> Generator[SQLModelPipeline, None, None]:
+    def pipeline(self, crawler: Crawler) -> Generator[SQLModelPipeline, None, None]:
         """
         Create a pipeline instance with an in-memory SQLite DB for each test.
         """
         instance = SQLModelPipeline(":memory:", "output")
-        instance.crawler = spider.crawler
+        instance.crawler = crawler
         instance.open_spider()
         assert instance.engine is not None
         yield instance
         instance.engine.dispose()
 
-    def test_process_valid_item(
-        self, pipeline: SQLModelPipeline, spider: Spider, item: ArticleItem
-    ) -> None:
+    def test_process_valid_item(self, pipeline: SQLModelPipeline, item: ArticleItem) -> None:
         """A valid item is processed successfully."""
         result = pipeline.process_item(item)
         assert result is item
@@ -40,7 +38,6 @@ class TestSQLModelPipeline:
     def test_update_existing_article(
         self,
         pipeline: SQLModelPipeline,
-        spider: Spider,
         item: ArticleItem,
         item_with_file_references: ArticleItem,
     ) -> None:
@@ -92,7 +89,7 @@ class TestSQLModelPipeline:
             assert len(file_refs) == 1
 
     def test_update_existing_article_with_new_files(
-        self, pipeline: SQLModelPipeline, spider: Spider, item: ArticleItem
+        self, pipeline: SQLModelPipeline, item: ArticleItem
     ) -> None:
         """Test updating an existing article with new files."""
 
@@ -127,9 +124,7 @@ class TestSQLModelPipeline:
             checksums = {f.checksum for f in files}
             assert checksums == {"abcde12345", "xyz789"}
 
-    def test_file_deduplication(
-        self, pipeline: SQLModelPipeline, spider: Spider, item: ArticleItem
-    ) -> None:
+    def test_file_deduplication(self, pipeline: SQLModelPipeline, item: ArticleItem) -> None:
         """Test that files with the same URL and same checksum are not duplicated."""
         pipeline.process_item(item)
 
@@ -156,7 +151,6 @@ class TestSQLModelPipeline:
     def test_file_reference_deduplication(
         self,
         pipeline: SQLModelPipeline,
-        spider: Spider,
         item_with_file_references: ArticleItem,
     ) -> None:
         """Test that file references with the same URL are not duplicated."""

--- a/tests/test_author_models.py
+++ b/tests/test_author_models.py
@@ -15,7 +15,11 @@ from open_ire.models import Article, ArticleAuthor, Author, AuthorAffiliation, A
 def engine():
     """Create an in-memory SQLite engine for testing."""
     engine = create_engine("sqlite:///:memory:")
-    event.listen(engine, "connect", lambda dbapi_connection, _: dbapi_connection.execute("PRAGMA foreign_keys=ON"))
+    event.listen(
+        engine,
+        "connect",
+        lambda dbapi_connection, _: dbapi_connection.execute("PRAGMA foreign_keys=ON"),
+    )
     SQLModel.metadata.create_all(engine)
     try:
         yield engine
@@ -197,7 +201,9 @@ class TestAuthorModelRelationships:
 
         session.add_all(
             [
-                AuthorIdentifier(author_id=author.id, authority="ORCID", identifier="0000-0000-0000-0002"),
+                AuthorIdentifier(
+                    author_id=author.id, authority="ORCID", identifier="0000-0000-0000-0002"
+                ),
                 AuthorIdentifier(author_id=author.id, authority="UW", identifier="uw654321"),
             ]
         )


### PR DESCRIPTION
The Spider argument to `open_spider()`, `close_spider()`, and `process_item()` is or soon will be deprecated (see [release notes for Scrapy 2.14](https://docs.scrapy.org/en/2.14/news.html)).

The most significant impact is that some of the pipelines can no longer rely on the spider's logger, and instead have to use a module-level one.

Closes #59