### PR TITLE
Rename AuthorRecord to ParsedAuthor and add name-matching heuristics

### DIFF
--- a/src/open_ire/author.py
+++ b/src/open_ire/author.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from nameparser import HumanName
 
 
-class AuthorRecord:
+class ParsedAuthor:
     """
     Represents an author with email and parsed name information.
 
@@ -23,13 +23,13 @@ class AuthorRecord:
             self._parsed_name = HumanName(name)
         else:
             self._parsed_name = name
-        self._email = email
+        self._email = self._normalize_email(email)
 
     def __repr__(self) -> str:
-        return f"AuthorRecord(name='{self._parsed_name}', email='{self._email}')"
+        return f"ParsedAuthor(name='{self._parsed_name}', email='{self._email}')"
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, AuthorRecord):
+        if not isinstance(other, ParsedAuthor):
             return NotImplemented
         return self.normalized_name == other.normalized_name and self.email == other.email
 
@@ -112,9 +112,96 @@ class AuthorRecord:
             return given_name
         return str(self._parsed_name).strip() or "Unknown"
 
+    @staticmethod
+    def _normalize_name(s: str | None) -> str:
+        """Normalize string for fuzzy matching: lowercase, remove diacritics and punctuation."""
+        if not s:
+            return ""
+        # Decompose unicode characters and filter out combining marks (accents)
+        s = unicodedata.normalize("NFKD", s or "")
+        # Keep only alphanumeric and spaces, then collapse whitespace
+        s = "".join(c for c in s if c.isalnum() or c.isspace())
+        return " ".join(s.lower().split())
+
+    @staticmethod
+    def _normalize_email(email: str | None) -> str | None:
+        """Normalize email address for consistent storage and comparison."""
+        if not email:
+            return None
+        return email.strip().lower()
+
+    def _names_compatible(self, name1: str, name2: str) -> bool:
+        """Check if two names are compatible (exact match, initial match, or prefix match)."""
+        # If either name is empty, they're compatible (one person may not have that name component)
+        if not name1 or not name2:
+            return True
+
+        if name1 == name2:
+            return True
+
+        # Remove periods and spaces for comparison
+        name1_clean = name1.replace(".", "").replace(" ", "").strip()
+        name2_clean = name2.replace(".", "").replace(" ", "").strip()
+
+        if not name1_clean or not name2_clean:
+            return True
+
+        is_name1_initial = len(name1_clean) == 1
+        is_name2_initial = len(name2_clean) == 1
+
+        # If one is an initial, check if it matches the first letter of the other
+        if is_name1_initial and not is_name2_initial:
+            return name1_clean == name2_clean[0]
+        if is_name2_initial and not is_name1_initial:
+            return name2_clean == name1_clean[0]
+
+        # For non-initials, check prefix matching (handles hyphenated names)
+        # e.g., "Su" matches "Su-Ling" or "SuLing"
+        return name1_clean.startswith(name2_clean) or name2_clean.startswith(name1_clean)
+
+    def _emails_compatible(self, email1: str | None, email2: str | None) -> bool:
+        """Check if two emails are compatible (both empty or matching)."""
+        if not email1 or not email2:
+            return True
+        return self._normalize_email(email1) == self._normalize_email(email2)
+
+    def likely_same(self, other: "ParsedAuthor") -> bool:
+        """
+        Determine if two ParsedAuthor instances likely represent the same person.
+
+        This method handles cases where one name is a subset of another:
+        - 'Welland, Sasha' and 'Welland, Sasha Su-Ling' -> True (likely same)
+        - 'Welland, Sasha Su-Ling' and 'Welland, Sasha Mary' -> False (likely different)
+        - 'Welland, S.' and 'Welland, Sasha' -> True (likely same)
+        - 'Su-Ling Welland' and 'S. Welland' -> True (likely same)
+
+        Rules:
+        1. Last names must match exactly (case-insensitive, diacritic-insensitive)
+        2. First names must be compatible:
+           - Match exactly (case-insensitive, diacritic-insensitive), OR
+           - One is an initial that matches the other's first letter, OR
+           - One is a prefix of the other (e.g., "Su" matches "Su-Ling")
+        3. If both have middle names, they must be compatible (same rules as first names)
+        4. If emails are both present and non-empty, they must match
+        """
+        if not self._emails_compatible(self.email, other.email):
+            return False
+
+        if self._normalize_name(self.last_name) != self._normalize_name(other.last_name):
+            return False
+
+        if not self._names_compatible(
+            self._normalize_name(self.first_name), self._normalize_name(other.first_name)
+        ):
+            return False
+
+        return self._names_compatible(
+            self._normalize_name(self.middle_name), self._normalize_name(other.middle_name)
+        )
+
     @classmethod
-    def parse_author_string(cls, author_string: str) -> list["AuthorRecord"]:
-        """Parse a semicolon-separated author string into AuthorRecord objects.
+    def parse_author_string(cls, author_string: str) -> list["ParsedAuthor"]:
+        """Parse a semicolon-separated author string into ParsedAuthor objects.
 
         Authors are separated by semicolons. Each author name is parsed by nameparser
         which handles both "Last, First" and "First Last" formats.
@@ -123,7 +210,7 @@ class AuthorRecord:
             author_string: Semicolon-separated string of author names
 
         Returns:
-            List of AuthorRecord objects (with empty email fields)
+            List of ParsedAuthor objects (with empty email fields)
         """
         if not author_string or not author_string.strip():
             return []
@@ -133,8 +220,8 @@ class AuthorRecord:
         return [cls(name=name, email="") for name in parts]
 
     @classmethod
-    def encode_author_string(cls, authors: list["AuthorRecord"]) -> str:
-        """Encode a list of AuthorRecord objects back into a semicolon-separated string."""
+    def encode_author_string(cls, authors: list["ParsedAuthor"]) -> str:
+        """Encode a list of ParsedAuthor objects back into a semicolon-separated string."""
         return "; ".join(str(author.normalized_name) for author in authors)
 
 
@@ -151,13 +238,13 @@ class AuthorIndex:
 
     # === DATA LOADING AND PROCESSING ===
 
-    def _load_records(self) -> list[AuthorRecord]:
+    def _load_records(self) -> list[ParsedAuthor]:
         """Load and validate author records from CSV file."""
         if not self.path.exists():
             msg = f"Author file not found: {self.path}"
             raise FileNotFoundError(msg)
 
-        records: list[AuthorRecord] = []
+        records: list[ParsedAuthor] = []
         with self.path.open(encoding="utf-8-sig", newline="") as handle:
             reader = csv.DictReader(handle)
             if not reader.fieldnames or not self._required_fields.issubset(reader.fieldnames):
@@ -184,8 +271,8 @@ class AuthorIndex:
         first_name: str | None,
         last_name: str | None,
         email: str | None,
-    ) -> AuthorRecord | None:
-        """Build an AuthorRecord from CSV row data, returning None if invalid."""
+    ) -> ParsedAuthor | None:
+        """Build a ParsedAuthor from CSV row data, returning None if invalid."""
         email = (email or "").strip()
         first_name = (first_name or "").strip()
         last_name = (last_name or "").strip()
@@ -195,14 +282,4 @@ class AuthorIndex:
 
         # Construct full name from components and parse it
         full_name = f"{first_name} {last_name}"
-        return AuthorRecord(email=email, name=HumanName(full_name))
-
-    # === TEXT PROCESSING UTILITIES ===
-
-    @staticmethod
-    def _normalize_text(value: str) -> str:
-        """Normalize text for consistent matching by removing accents and standardizing case."""
-        normalized = unicodedata.normalize("NFKD", value or "")
-        normalized = "".join(c for c in normalized if c.isalnum() or c.isspace())
-
-        return " ".join(normalized.lower().split())
+        return ParsedAuthor(email=email, name=HumanName(full_name))

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -5,7 +5,7 @@ from urllib.parse import urlencode
 
 from scrapy.http import Request, Response
 
-from open_ire.author import AuthorRecord
+from open_ire.author import ParsedAuthor
 from open_ire.enums import ArticleType
 from open_ire.items import ArticleItem
 from open_ire.settings import OPEN_IRE_CONTACT_EMAIL, OPENALEX_INSTITUTION_ID
@@ -59,7 +59,7 @@ class OpenAlexSpider(AuthorSearchSpider):
         self.institution_id = OPENALEX_INSTITUTION_ID
         self.request_headers: dict[str, str] = {"User-Agent": f"mailto:{OPEN_IRE_CONTACT_EMAIL}"}
 
-    def _get_author_name(self, record: AuthorRecord) -> str:
+    def _get_author_name(self, record: ParsedAuthor) -> str:
         return f"{record.first_name} {record.last_name}"
 
     # === HIGH-LEVEL WORKFLOW METHODS ===
@@ -149,7 +149,7 @@ class OpenAlexSpider(AuthorSearchSpider):
 
         raw_type = publication.get("type")
         return ArticleItem(
-            authors=AuthorRecord.encode_author_string(authors),
+            authors=ParsedAuthor.encode_author_string(authors),
             doi=publication.get("doi"),
             extra={
                 "is_open_access": is_oa,
@@ -172,9 +172,9 @@ class OpenAlexSpider(AuthorSearchSpider):
     # These methods extract specific data from OpenAlex API responses
 
     @staticmethod
-    def _extract_authors(publication: dict[str, Any]) -> list[AuthorRecord]:
+    def _extract_authors(publication: dict[str, Any]) -> list[ParsedAuthor]:
         """Extract author names from publication authorship data."""
-        authors: list[AuthorRecord] = []
+        authors: list[ParsedAuthor] = []
         authorships = publication.get("authorships", [])
         for authorship in authorships:
             if not isinstance(authorship, dict):
@@ -182,7 +182,7 @@ class OpenAlexSpider(AuthorSearchSpider):
 
             display_name = authorship.get("author", {}).get("display_name")
             if display_name and isinstance(display_name, str):
-                authors.append(AuthorRecord(display_name))
+                authors.append(ParsedAuthor(display_name))
 
         return authors
 

--- a/src/open_ire/spiders/search.py
+++ b/src/open_ire/spiders/search.py
@@ -6,7 +6,7 @@ from typing import Any
 from scrapy import Spider
 from scrapy.http import Request
 
-from open_ire.author import AuthorIndex, AuthorRecord
+from open_ire.author import AuthorIndex, ParsedAuthor
 from open_ire.settings import OPEN_IRE_DEFAULT_TERMS
 
 
@@ -67,7 +67,7 @@ class AuthorSearchSpider(SearchSpider):
 
         self.search_terms = self._get_search_terms(author_csv)
 
-    def _get_author_name(self, record: AuthorRecord) -> str:
+    def _get_author_name(self, record: ParsedAuthor) -> str:
         """Return the author name in the default 'Firstname Lastname' format."""
         return f"{record.first_name} {record.last_name}"
 

--- a/src/open_ire/spiders/wos.py
+++ b/src/open_ire/spiders/wos.py
@@ -7,7 +7,7 @@ from urllib.parse import urlencode
 
 from scrapy.http import Request, Response
 
-from open_ire.author import AuthorRecord
+from open_ire.author import ParsedAuthor
 from open_ire.enums import ArticleType
 from open_ire.items import ArticleItem
 from open_ire.settings import WOS_ORGANIZATION
@@ -70,7 +70,7 @@ class WoSSpider(AuthorSearchSpider):
 
         self.headers = {"X-ApiKey": self.api_key}
 
-    def _get_author_name(self, record: AuthorRecord) -> str:
+    def _get_author_name(self, record: ParsedAuthor) -> str:
         return f"{record.last_name}, {record.first_name}"
 
     # === HIGH-LEVEL WORKFLOW METHODS ===
@@ -212,7 +212,7 @@ class WoSSpider(AuthorSearchSpider):
 
         raw_type = summary.get("doctypes", {}).get("doctype")
         return ArticleItem(
-            authors=AuthorRecord.encode_author_string(authors),
+            authors=ParsedAuthor.encode_author_string(authors),
             doi=doi,
             extra={
                 "journal_name": self._extract_journal_name(titles),
@@ -235,9 +235,9 @@ class WoSSpider(AuthorSearchSpider):
     # These methods extract specific data from WoS API responses
 
     @staticmethod
-    def _extract_authors(names: list[Any]) -> list[AuthorRecord]:
+    def _extract_authors(names: list[Any]) -> list[ParsedAuthor]:
         """Extract author names from WoS names data structure."""
-        authors: list[AuthorRecord] = []
+        authors: list[ParsedAuthor] = []
         for author in names:
             if not isinstance(author, dict):
                 continue
@@ -246,7 +246,7 @@ class WoSSpider(AuthorSearchSpider):
                 author.get("full_name") or author.get("display_name") or author.get("wos_standard")
             )
             if author_name:
-                authors.append(AuthorRecord(author_name))
+                authors.append(ParsedAuthor(author_name))
 
         return authors
 

--- a/tests/spiders/test_openalex.py
+++ b/tests/spiders/test_openalex.py
@@ -6,14 +6,14 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from scrapy.http import HtmlResponse, Request
 
-from open_ire.author import AuthorRecord
+from open_ire.author import ParsedAuthor
 from open_ire.enums import ArticleType
 from open_ire.items import ArticleItem
 from open_ire.spiders.openalex import OpenAlexSpider
 
 
 @pytest.fixture
-def spider(tmp_path: Path, five_authors: list[AuthorRecord]) -> OpenAlexSpider:
+def spider(tmp_path: Path, five_authors: list[ParsedAuthor]) -> OpenAlexSpider:
     csv_content = f"""Full Name,FirstName,LastName,Email
 {five_authors[4].full_name},{five_authors[4].first_name},{five_authors[4].last_name},{five_authors[4].email}
 """
@@ -24,18 +24,18 @@ def spider(tmp_path: Path, five_authors: list[AuthorRecord]) -> OpenAlexSpider:
 
 
 @pytest.fixture
-def five_authors() -> list[AuthorRecord]:
+def five_authors() -> list[ParsedAuthor]:
     return [
-        AuthorRecord("Luis Manuel Garcia-Mispireta"),
-        AuthorRecord("E.V.S.S.K. Babu"),
-        AuthorRecord("Ramón H. Rivera-Servera"),
-        AuthorRecord("M. Elena Alvarez-Alvarez"),
-        AuthorRecord("Kemi Adeyemi", email="kadeyemi@uw.edu"),
+        ParsedAuthor("Luis Manuel Garcia-Mispireta"),
+        ParsedAuthor("E.V.S.S.K. Babu"),
+        ParsedAuthor("Ramón H. Rivera-Servera"),
+        ParsedAuthor("M. Elena Alvarez-Alvarez"),
+        ParsedAuthor("Kemi Adeyemi", email="kadeyemi@uw.edu"),
     ]
 
 
 @pytest.fixture
-def dummy_publication(five_authors: list[AuthorRecord]) -> dict[str, Any]:
+def dummy_publication(five_authors: list[ParsedAuthor]) -> dict[str, Any]:
     return {
         "id": "W123",
         "title": "A Study on Testing",
@@ -71,7 +71,7 @@ class TestOpenAlexSpider:
         assert journal_name is None
 
     def test_extract_authors(
-        self, five_authors: list[AuthorRecord], dummy_publication: dict[str, Any]
+        self, five_authors: list[ParsedAuthor], dummy_publication: dict[str, Any]
     ) -> None:
         authors = OpenAlexSpider._extract_authors(dummy_publication)
         assert authors == [five_authors[0], five_authors[1]]
@@ -89,7 +89,7 @@ class TestOpenAlexSpider:
     def test_request_publications(
         self,
         spider: OpenAlexSpider,
-        five_authors: list[AuthorRecord],
+        five_authors: list[ParsedAuthor],
         author_id: str,
         cursor: str,
     ) -> None:
@@ -106,7 +106,7 @@ class TestOpenAlexSpider:
         assert query_params["cursor"] == [cursor]
 
     def test_author_publication_requests(
-        self, spider: OpenAlexSpider, five_authors: list[AuthorRecord]
+        self, spider: OpenAlexSpider, five_authors: list[ParsedAuthor]
     ) -> None:
         response_data = {"results": [{"id": "A1"}, {"id": "A2"}]}
         request = Request(
@@ -128,7 +128,7 @@ class TestOpenAlexSpider:
     def test_parse_publications(
         self,
         spider: OpenAlexSpider,
-        five_authors: list[AuthorRecord],
+        five_authors: list[ParsedAuthor],
         dummy_publication: dict[str, Any],
     ) -> None:
         publication_data = {
@@ -157,7 +157,7 @@ class TestOpenAlexSpider:
     def test_build_item(
         self,
         spider: OpenAlexSpider,
-        five_authors: list[AuthorRecord],
+        five_authors: list[ParsedAuthor],
         dummy_publication: dict[str, Any],
     ) -> None:
         item = spider._build_item(dummy_publication, five_authors[0].normalized_name)
@@ -168,10 +168,10 @@ class TestOpenAlexSpider:
         assert item.title == "A Study on Testing"
         assert item.extra["journal_name"] == "Journal of Testing"
         assert item.extra["matched_author"] == five_authors[0].normalized_name
-        assert item.authors == AuthorRecord.encode_author_string([five_authors[0], five_authors[1]])
+        assert item.authors == ParsedAuthor.encode_author_string([five_authors[0], five_authors[1]])
 
     def test_build_search_request(
-        self, spider: OpenAlexSpider, five_authors: list[AuthorRecord]
+        self, spider: OpenAlexSpider, five_authors: list[ParsedAuthor]
     ) -> None:
         request = spider.build_search_request(five_authors[0].normalized_name)
         assert isinstance(request, Request)

--- a/tests/spiders/test_wos.py
+++ b/tests/spiders/test_wos.py
@@ -6,25 +6,25 @@ from typing import Any
 import pytest
 from scrapy.http import HtmlResponse, Request
 
-from open_ire.author import AuthorRecord
+from open_ire.author import ParsedAuthor
 from open_ire.enums import ArticleType
 from open_ire.items import ArticleItem
 from open_ire.spiders.wos import WoSSpider
 
 
 @pytest.fixture
-def five_authors() -> list[AuthorRecord]:
+def five_authors() -> list[ParsedAuthor]:
     return [
-        AuthorRecord("Luis Manuel Garcia-Mispireta"),
-        AuthorRecord("E.V.S.S.K. Babu"),
-        AuthorRecord("Ramón H. Rivera-Servera"),
-        AuthorRecord("M. Elena Alvarez-Alvarez"),
-        AuthorRecord("Kemi Adeyemi", email="kadeyemi@uw.edu"),
+        ParsedAuthor("Luis Manuel Garcia-Mispireta"),
+        ParsedAuthor("E.V.S.S.K. Babu"),
+        ParsedAuthor("Ramón H. Rivera-Servera"),
+        ParsedAuthor("M. Elena Alvarez-Alvarez"),
+        ParsedAuthor("Kemi Adeyemi", email="kadeyemi@uw.edu"),
     ]
 
 
 @pytest.fixture
-def dummy_csv(tmp_path: Path, five_authors: list[AuthorRecord]) -> Path:
+def dummy_csv(tmp_path: Path, five_authors: list[ParsedAuthor]) -> Path:
     csv_content = f"""Full Name,FirstName,LastName,Email
 {five_authors[4].full_name},{five_authors[4].first_name},{five_authors[4].last_name},{five_authors[4].email}
 """
@@ -34,7 +34,7 @@ def dummy_csv(tmp_path: Path, five_authors: list[AuthorRecord]) -> Path:
 
 
 @pytest.fixture
-def dummy_record(five_authors: list[AuthorRecord]) -> dict[str, Any]:
+def dummy_record(five_authors: list[ParsedAuthor]) -> dict[str, Any]:
     return {
         "UID": "WOS:000123456789",
         "static_data": {
@@ -90,7 +90,7 @@ def spider(dummy_csv: Path, monkeypatch: pytest.MonkeyPatch) -> WoSSpider:
 
 class TestWoSSpider:
     def test_build_item(
-        self, spider: WoSSpider, five_authors: list[AuthorRecord], dummy_record: dict[str, Any]
+        self, spider: WoSSpider, five_authors: list[ParsedAuthor], dummy_record: dict[str, Any]
     ) -> None:
         item = spider._build_item(dummy_record, five_authors[4].normalized_name)
 
@@ -98,11 +98,11 @@ class TestWoSSpider:
         assert item.title == "Sample Publication Title"
         assert item.extra["matched_author"] == five_authors[4].normalized_name
         assert item.doi == "10.1000/sampledoi"
-        assert item.authors == AuthorRecord.encode_author_string([five_authors[4], five_authors[0]])
+        assert item.authors == ParsedAuthor.encode_author_string([five_authors[4], five_authors[0]])
         assert item.url == "https://doi.org/10.1000/sampledoi"
 
     def test_build_item_without_doi(
-        self, spider: WoSSpider, five_authors: list[AuthorRecord], dummy_record: dict[str, Any]
+        self, spider: WoSSpider, five_authors: list[ParsedAuthor], dummy_record: dict[str, Any]
     ) -> None:
         # Remove DOI from the record
         record_without_doi = copy.deepcopy(dummy_record)
@@ -115,7 +115,7 @@ class TestWoSSpider:
         assert item.url == "https://www.webofscience.com/wos/woscc/full-record/WOS:000123456789"
 
     def test_build_item_missing_identifiers_section(
-        self, spider: WoSSpider, five_authors: list[AuthorRecord], dummy_record: dict[str, Any]
+        self, spider: WoSSpider, five_authors: list[ParsedAuthor], dummy_record: dict[str, Any]
     ) -> None:
         # Remove entire identifiers section
         record_no_identifiers = copy.deepcopy(dummy_record)
@@ -128,7 +128,7 @@ class TestWoSSpider:
         assert item.url == "https://www.webofscience.com/wos/woscc/full-record/WOS:000123456789"
 
     def test_parse_publications(
-        self, spider: WoSSpider, five_authors: list[AuthorRecord], dummy_response: HtmlResponse
+        self, spider: WoSSpider, five_authors: list[ParsedAuthor], dummy_response: HtmlResponse
     ) -> None:
         query = spider._build_query(five_authors[4].normalized_name)
         # Create a request with meta to tie to the response
@@ -149,17 +149,17 @@ class TestWoSSpider:
         assert item.title == "Sample Publication Title"
         assert item.extra["matched_author"] == five_authors[4].normalized_name
         assert item.doi == "10.1000/sampledoi"
-        assert item.authors == AuthorRecord.encode_author_string([five_authors[4], five_authors[0]])
+        assert item.authors == ParsedAuthor.encode_author_string([five_authors[4], five_authors[0]])
 
     def test_build_search_request(
-        self, spider: WoSSpider, five_authors: list[AuthorRecord]
+        self, spider: WoSSpider, five_authors: list[ParsedAuthor]
     ) -> None:
         request = spider.build_search_request(five_authors[4].normalized_name)
 
         assert request.url.startswith(spider.base_url + "?count=25&databaseId=WOS")
 
     def test_parse_publications_no_results_records_empty_string(
-        self, spider: WoSSpider, five_authors: list[AuthorRecord]
+        self, spider: WoSSpider, five_authors: list[ParsedAuthor]
     ) -> None:
         # WoS empty results schema: records is an empty string
         json_body = {
@@ -184,7 +184,7 @@ class TestWoSSpider:
         assert requests == []
 
     def test_parse_publications_records_container_string_is_ignored(
-        self, spider: WoSSpider, five_authors: list[AuthorRecord]
+        self, spider: WoSSpider, five_authors: list[ParsedAuthor]
     ) -> None:
         # Sometimes WoS returns a string in `records` (e.g., error-ish message).
         json_body = {

--- a/tests/test_author.py
+++ b/tests/test_author.py
@@ -5,15 +5,15 @@ from pathlib import Path
 import pytest
 from nameparser import HumanName
 
-from open_ire.author import AuthorIndex, AuthorRecord
+from open_ire.author import AuthorIndex, ParsedAuthor
 
 
-class TestAuthorRecord:
-    """Tests for AuthorRecord class."""
+class TestParsedAuthor:
+    """Tests for ParsedAuthor class."""
 
     def test_create_with_string(self) -> None:
-        """Test creating AuthorRecord with a string name."""
-        record = AuthorRecord(name="John A. Doe Jr.", email="john@example.com")
+        """Test creating ParsedAuthor with a string name."""
+        record = ParsedAuthor(name="John A. Doe Jr.", email="john@example.com")
 
         assert record.email == "john@example.com"
         assert record.first_name == "John"
@@ -22,9 +22,9 @@ class TestAuthorRecord:
         assert record.suffix == "Jr."
 
     def test_create_with_human_name(self) -> None:
-        """Test creating AuthorRecord with a HumanName object."""
+        """Test creating ParsedAuthor with a HumanName object."""
         human_name = HumanName("Dr. Jane Smith")
-        record = AuthorRecord(name=human_name, email="jane@example.com")
+        record = ParsedAuthor(name=human_name, email="jane@example.com")
 
         assert record.email == "jane@example.com"
         assert record.first_name == "Jane"
@@ -33,22 +33,22 @@ class TestAuthorRecord:
 
     def test_first_initial(self) -> None:
         """Test first_initial property."""
-        record = AuthorRecord(name="John Doe", email="test@example.com")
+        record = ParsedAuthor(name="John Doe", email="test@example.com")
         assert record.first_initial == "J"
 
     def test_middle_initial(self) -> None:
         """Test middle_initial property."""
-        record = AuthorRecord(name="John Andrew Doe", email="test@example.com")
+        record = ParsedAuthor(name="John Andrew Doe", email="test@example.com")
         assert record.middle_initial == "A"
 
     def test_middle_initial_empty(self) -> None:
         """Test middle_initial when no middle name exists."""
-        record = AuthorRecord(name="John Doe", email="test@example.com")
+        record = ParsedAuthor(name="John Doe", email="test@example.com")
         assert record.middle_initial == ""
 
     def test_complex_name_parsing(self) -> None:
         """Test parsing of complex names with titles and suffixes."""
-        record = AuthorRecord(name="Prof. Robert James Smith III, PhD", email="rsmith@example.com")
+        record = ParsedAuthor(name="Prof. Robert James Smith III, PhD", email="rsmith@example.com")
 
         assert record.title == "Prof."
         assert record.first_name == "Robert"
@@ -58,7 +58,7 @@ class TestAuthorRecord:
 
     def test_empty_name_components(self) -> None:
         """Test that empty name components return empty strings."""
-        record = AuthorRecord(name="", email="test@example.com")
+        record = ParsedAuthor(name="", email="test@example.com")
 
         assert record.first_name == ""
         assert record.last_name == ""
@@ -161,3 +161,162 @@ John,Doe,john@example.com
 
         assert len(index.records) == 1
         assert index.records[0].first_name == "John"
+
+
+class TestLikelySame:
+    """Test the likely_same() method for fuzzy author matching."""
+
+    def test_exact_match_with_middle_names(self):
+        """Exact matches should return True."""
+        author1 = ParsedAuthor("Welland, Sasha Su-Ling")
+        author2 = ParsedAuthor("Welland, Sasha Su-Ling")
+        assert author1.likely_same(author2)
+
+    def test_one_has_middle_name_other_does_not(self):
+        """One author with middle name, other without -> likely same person."""
+        author1 = ParsedAuthor("Welland, Sasha")
+        author2 = ParsedAuthor("Welland, Sasha Su-Ling")
+        assert author1.likely_same(author2)
+        assert author2.likely_same(author1)  # Symmetric
+
+    def test_middle_name_is_prefix(self):
+        """Middle name that is a prefix of another -> likely same person."""
+        author1 = ParsedAuthor("Welland, Sasha Su")
+        author2 = ParsedAuthor("Welland, Sasha Su-Ling")
+        assert author1.likely_same(author2)
+        assert author2.likely_same(author1)  # Symmetric
+
+    def test_different_middle_names(self):
+        """Different middle names that aren't prefixes -> likely different people."""
+        author1 = ParsedAuthor("Welland, Sasha Su-Ling")
+        author2 = ParsedAuthor("Welland, Sasha Mary")
+        assert not author1.likely_same(author2)
+
+    def test_different_last_names(self):
+        """Different last names -> different people."""
+        author1 = ParsedAuthor("Welland, Sasha")
+        author2 = ParsedAuthor("Smith, Sasha")
+        assert not author1.likely_same(author2)
+
+    def test_different_first_names(self):
+        """Different first names -> different people."""
+        author1 = ParsedAuthor("Welland, Sasha", "sasha@example.com")
+        author2 = ParsedAuthor("Welland, Mary", "mary@example.com")
+        assert not author1.likely_same(author2)
+
+    def test_same_name_different_emails(self):
+        """Same name but different emails -> different people."""
+        author1 = ParsedAuthor("Welland, Sasha", "sasha1@example.com")
+        author2 = ParsedAuthor("Welland, Sasha", "sasha2@example.com")
+        assert not author1.likely_same(author2)
+
+    def test_same_name_one_email_missing(self):
+        """Same name, one email missing -> likely same person."""
+        author1 = ParsedAuthor("Welland, Sasha Su-Ling", "sasha@example.com")
+        author2 = ParsedAuthor("Welland, Sasha Su-Ling", None)
+        assert author1.likely_same(author2)
+        assert author2.likely_same(author1)  # Symmetric
+
+    def test_case_insensitive_matching(self):
+        """Matching should be case-insensitive."""
+        author1 = ParsedAuthor("WELLAND, SASHA", "SASHA@EXAMPLE.COM")
+        author2 = ParsedAuthor("welland, sasha", "sasha@example.com")
+        assert author1.likely_same(author2)
+
+    def test_middle_name_with_spaces(self):
+        """Middle names with multiple parts should work."""
+        author1 = ParsedAuthor("Smith, John Paul")
+        author2 = ParsedAuthor("Smith, John Paul George")
+        assert author1.likely_same(author2)
+
+    def test_both_no_middle_names(self):
+        """Both authors without middle names -> likely same person."""
+        author1 = ParsedAuthor("Welland, Sasha")
+        author2 = ParsedAuthor("Welland, Sasha")
+        assert author1.likely_same(author2)
+
+    def test_both_no_emails(self):
+        """Both authors without emails but matching names -> likely same person."""
+        author1 = ParsedAuthor("Welland, Sasha Su-Ling", None)
+        author2 = ParsedAuthor("Welland, Sasha", None)
+        assert author1.likely_same(author2)
+
+    def test_middle_initial_vs_full_middle_name(self):
+        """Middle initial vs full middle name -> likely same person."""
+        author1 = ParsedAuthor("Welland, Sasha S")
+        author2 = ParsedAuthor("Welland, Sasha Su-Ling")
+        assert author1.likely_same(author2)
+
+    def test_different_middle_initials(self):
+        """Different middle initials -> likely different people."""
+        author1 = ParsedAuthor("Welland, Sasha S", "sasha1@example.com")
+        author2 = ParsedAuthor("Welland, Sasha M", "sasha2@example.com")
+        assert not author1.likely_same(author2)
+
+    def test_diacritics_ignored(self):
+        """Names with and without diacritics should match (ASCII folding)."""
+        author1 = ParsedAuthor("Tarragó, David")
+        author2 = ParsedAuthor("Tarrago, David")
+        assert author1.likely_same(author2)
+
+    def test_various_diacritics(self):
+        """Various diacritics should be normalized."""
+        author1 = ParsedAuthor("Müller, José")
+        author2 = ParsedAuthor("Muller, Jose")
+        assert author1.likely_same(author2)
+
+    def test_hyphenated_names(self):
+        """Hyphenated names should match with or without hyphens."""
+        author1 = ParsedAuthor("Welland, Sasha Su-Ling")
+        author2 = ParsedAuthor("Welland, Sasha Su Ling")
+        assert author1.likely_same(author2)
+
+    def test_apostrophes_in_names(self):
+        """Names with apostrophes should match without them."""
+        author1 = ParsedAuthor("O'Brien, Patrick")
+        author2 = ParsedAuthor("OBrien, Patrick")
+        assert author1.likely_same(author2)
+
+    def test_first_initial_vs_full_first_name(self):
+        """First initial vs full first name -> likely same person."""
+        author1 = ParsedAuthor("Welland, S.")
+        author2 = ParsedAuthor("Welland, Sasha")
+        assert author1.likely_same(author2)
+        assert author2.likely_same(author1)
+
+    def test_first_initial_matches_different_names_same_letter(self):
+        """First initial should match any name starting with that letter."""
+        author_j = ParsedAuthor("Smith, J.")
+        author_john = ParsedAuthor("Smith, John")
+        author_jane = ParsedAuthor("Smith, Jane")
+
+        assert author_j.likely_same(author_john)
+        assert author_j.likely_same(author_jane)
+        assert author_john.likely_same(author_j)
+        assert author_jane.likely_same(author_j)
+
+    def test_different_first_initials(self):
+        """Different first initials -> different people."""
+        author1 = ParsedAuthor("Smith, J.")
+        author2 = ParsedAuthor("Smith, K.")
+        assert not author1.likely_same(author2)
+
+    def test_first_initial_with_middle_name(self):
+        """First initial with middle name should still match."""
+        author1 = ParsedAuthor("Welland, S. Su-Ling")
+        author2 = ParsedAuthor("Welland, Sasha Su-Ling")
+        assert author1.likely_same(author2)
+        assert author2.likely_same(author1)
+
+    def test_first_initial_different_letter(self):
+        """First initial with different starting letter -> different people."""
+        author1 = ParsedAuthor("Welland, S.")
+        author2 = ParsedAuthor("Welland, Mary")
+        assert not author1.likely_same(author2)
+
+    def test_hyphenated_first_name_with_initial(self):
+        """Hyphenated first name should match its initial."""
+        author1 = ParsedAuthor("Welland, Su-Ling")
+        author2 = ParsedAuthor("Welland, S.")
+        assert author1.likely_same(author2)
+        assert author2.likely_same(author1)


### PR DESCRIPTION
The rename hopefully makes it clearer what the class is doing. The deterministic "fuzzy matching" should account for at least the majority of name discrepancies while protecting against misattribution.