### PR TITLE
Add ability to perform author search by command line argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,18 +126,32 @@ pixi run search-terms eric "ocean acidification,coral bleaching"
 
 ### Search by Author
 
-To run a spider that supports searching by author against a list of authors, use
-the `search-authors` command. This requires a CSV file with `FirstName`,
-`LastName`, and `Email` columns.
+To search for a single author's name, use the `search-author` (singular)
+command:
 
 ```bash
-pixi run search-authors <spider_name> <path_to_csv>
+pixi run search-author <spider_name> "<author's full name>"
 ```
 
-For example, to search `openalex` using an author file:
+For example:
 
 ```bash
-pixi run search-authors openalex data/authors.csv
+pixi run search-author openalex "Michelle Habell-Pallán"
+```
+
+To run a spider that supports searching by author against a list of authors, use
+the `search-authors` (plural) command. This requires a CSV file with
+`FirstName`, `MiddleNames` (optional), `LastName`, and `Email` columns.
+
+```bash
+pixi run search-authors <spider_name> "<path_to_csv>"
+```
+
+For example, to search `openalex` for publications by any one among a number of
+authors:
+
+```bash
+pixi run search-authors openalex "data/authors.csv"
 ```
 
 ## Contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,9 +192,13 @@ args = [
 ]
 cmd = "scrapy crawl {{ spider }} -s JOBDIR=crawls/{{ spider }}{% if '--skip-existing' in flag %} -s OPEN_IRE_SKIP_EXISTING=True{% endif %}"
 
+[tool.pixi.tasks.search-author]
+args = ["spider", "author_name"]
+cmd = "scrapy crawl {{ spider }} -a author_name=\"{{ author_name }}\""
+
 [tool.pixi.tasks.search-authors]
 args = ["spider", "author_csv"]
-cmd = "scrapy crawl {{ spider }} -a author_csv={{ author_csv }}"
+cmd = "scrapy crawl {{ spider }} -a author_csv=\"{{ author_csv }}\""
 
 [tool.pixi.tasks.search-terms]
 args = ["spider", "terms", "page"]

--- a/src/open_ire/author.py
+++ b/src/open_ire/author.py
@@ -231,6 +231,7 @@ class AuthorIndex:
     """
 
     _required_fields = frozenset({"FirstName", "LastName", "Email"})
+    _optional_fields = frozenset({"MiddleNames"})
 
     def __init__(self, csv_path: Path) -> None:
         self.path = csv_path
@@ -255,7 +256,10 @@ class AuthorIndex:
 
             for row in reader:
                 record = self._build_record(
-                    row.get("FirstName"), row.get("LastName"), row.get("Email")
+                    row.get("FirstName"),
+                    row.get("MiddleNames") or "",
+                    row.get("LastName"),
+                    row.get("Email"),
                 )
                 if record:
                     records.append(record)
@@ -269,17 +273,19 @@ class AuthorIndex:
     def _build_record(
         self,
         first_name: str | None,
+        middle_names: str | None,
         last_name: str | None,
         email: str | None,
     ) -> ParsedAuthor | None:
         """Build a ParsedAuthor from CSV row data, returning None if invalid."""
         email = (email or "").strip()
         first_name = (first_name or "").strip()
+        middle_names = (middle_names or "").strip()
         last_name = (last_name or "").strip()
 
-        if not any((email, first_name, last_name)):
+        if not any((email, first_name, middle_names, last_name)):
             return None
 
         # Construct full name from components and parse it
-        full_name = f"{first_name} {last_name}"
-        return ParsedAuthor(email=email, name=HumanName(full_name))
+        full_name = f"{first_name} {middle_names} {last_name}"
+        return ParsedAuthor(name=HumanName(full_name), email=email)

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -60,6 +60,8 @@ class OpenAlexSpider(AuthorSearchSpider):
         self.request_headers: dict[str, str] = {"User-Agent": f"mailto:{OPEN_IRE_CONTACT_EMAIL}"}
 
     def _get_author_name(self, record: ParsedAuthor) -> str:
+        if record.middle_names:
+            return f"{record.first_name} {record.middle_names} {record.last_name}"
         return f"{record.first_name} {record.last_name}"
 
     # === HIGH-LEVEL WORKFLOW METHODS ===

--- a/src/open_ire/spiders/search.py
+++ b/src/open_ire/spiders/search.py
@@ -53,19 +53,36 @@ class TermSearchSpider(SearchSpider):
 
 class AuthorSearchSpider(SearchSpider):
     """
-    A specialized base spider that only searches using an author CSV file.
+    A specialized base spider that searches using author names from CSV file and/or individual author names.
 
-    This spider requires the `author_csv` argument. Subclasses can override
-    `_get_author_name` to specify the required name format for the target API.
+    This spider accepts `author_csv` and/or `author_name` arguments. If both are provided, the individual
+    author name is added to the list from the CSV. Subclasses can override `_get_author_name` to specify
+    the required name format for the target API.
     """
 
-    def __init__(self, author_csv: str | None = None, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        author_csv: str | None = None,
+        author_name: str | None = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(*args, **kwargs)
-        if not author_csv:
-            msg = f"The '{self.name}' spider requires the 'author_csv' argument."
+
+        if not author_csv and not author_name:
+            msg = f"The '{self.name}' spider requires either the 'author_csv' or 'author_name' argument (or both)."
             raise ValueError(msg)
 
-        self.search_terms = self._get_search_terms(author_csv)
+        # Start with empty list
+        self.search_terms = []
+
+        # Add authors from CSV if provided
+        if author_csv:
+            self.search_terms.extend(self._get_search_terms(author_csv))
+
+        # Add individual author name if provided
+        if author_name:
+            self.search_terms.append(author_name.strip())
 
     def _get_author_name(self, record: ParsedAuthor) -> str:
         """Return the author name in the default 'Firstname Lastname' format."""

--- a/tests/spiders/test_openalex.py
+++ b/tests/spiders/test_openalex.py
@@ -24,6 +24,11 @@ def spider(tmp_path: Path, five_authors: list[ParsedAuthor]) -> OpenAlexSpider:
 
 
 @pytest.fixture
+def spider_with_author_name(five_authors: list[ParsedAuthor]) -> OpenAlexSpider:
+    return OpenAlexSpider(author_name=five_authors[1].full_name)
+
+
+@pytest.fixture
 def five_authors() -> list[ParsedAuthor]:
     return [
         ParsedAuthor("Luis Manuel Garcia-Mispireta"),
@@ -138,7 +143,11 @@ class TestOpenAlexSpider:
                 },
                 "invalid publication",
             ],
-            "meta": {"next_cursor": "cursor123"},
+            "meta": {
+                "cursor": "*",
+                "next_cursor": "cursor123",
+                "count": 2,
+            },
         }
         request = Request(
             url="http://dummy.url", meta={"matched_author": five_authors[0].normalized_name}
@@ -221,3 +230,52 @@ class TestOpenAlexSpider:
 
     def test_normalize_type_unknown(self) -> None:
         assert OpenAlexSpider._normalize_type("unknown-type") is None
+
+    @pytest.mark.asyncio
+    async def test_start_with_author_name(self, spider_with_author_name) -> None:
+        requests = []
+        async for req in spider_with_author_name.start():
+            requests.append(req)
+        assert len(requests) == 1
+        assert isinstance(requests[0], Request)
+        assert "John+Doe" in requests[0].url
+
+    def test_author_name_parameter(self) -> None:
+        spider = OpenAlexSpider(author_name="Jane Smith")
+        assert spider.search_terms == ["Jane Smith"]
+
+    def test_both_parameters_allowed(self, tmp_path: Path) -> None:
+        csv_content = """Full Name,FirstName,LastName,Email
+Test User,Test,User,test@example.com
+"""
+        csv_path = tmp_path / "test.csv"
+        csv_path.write_text(csv_content)
+
+        spider = OpenAlexSpider(author_csv=str(csv_path), author_name="John Doe")
+        assert len(spider.search_terms) == 2
+        assert "Test User" in spider.search_terms
+        assert "John Doe" in spider.search_terms
+
+    @pytest.mark.asyncio
+    async def test_start_with_both_parameters(self, tmp_path: Path) -> None:
+        csv_content = """Full Name,FirstName,LastName,Email
+Alice Johnson,Alice,Johnson,alice@example.com
+"""
+        csv_path = tmp_path / "test.csv"
+        csv_path.write_text(csv_content)
+
+        spider = OpenAlexSpider(author_csv=str(csv_path), author_name="Bob Smith")
+        requests = []
+        async for req in spider.start():
+            requests.append(req)
+
+        assert len(requests) == 2
+        assert all(isinstance(req, Request) for req in requests)
+        # Check that both authors are searched
+        urls = [req.url for req in requests]
+        assert any("Alice+Johnson" in url for url in urls)
+        assert any("Bob+Smith" in url for url in urls)
+
+    def test_no_parameters_error(self) -> None:
+        with pytest.raises(ValueError, match="requires either"):
+            OpenAlexSpider()

--- a/tests/spiders/test_openalex.py
+++ b/tests/spiders/test_openalex.py
@@ -26,8 +26,8 @@ def five_authors() -> list[ParsedAuthor]:
 @pytest.fixture
 def spider(tmp_path: Path, five_authors: list[ParsedAuthor]) -> OpenAlexSpider:
     author = five_authors[4]
-    csv_content = f"""Full Name,FirstName,LastName,Email
-{author.full_name},{author.first_name},{author.last_name},{author.email}
+    csv_content = f"""Full Name,FirstName,MiddleNames,LastName,Email
+{author.full_name},{author.first_name},{author.middle_names},{author.last_name},{author.email}
 """
     csv_path = tmp_path / "authors.csv"
     csv_path.write_text(csv_content)
@@ -255,8 +255,8 @@ class TestOpenAlexSpider:
     ) -> None:
         csv_author = five_authors[0]
         csv_path = tmp_path / "authors.csv"
-        csv_path.write_text(f"""Full Name,FirstName,LastName,Email
-{csv_author.full_name},{csv_author.first_name},{csv_author.last_name},{csv_author.email}
+        csv_path.write_text(f"""Full Name,FirstName,MiddleNames,LastName,Email
+{csv_author.full_name},{csv_author.first_name},{csv_author.middle_names},{csv_author.last_name},{csv_author.email}
 """)
 
         name_author = five_authors[3]
@@ -266,13 +266,33 @@ class TestOpenAlexSpider:
         assert name_author.full_name in spider.search_terms
 
     @pytest.mark.asyncio
+    async def test_old_csv_format_still_supported(
+        self, tmp_path: Path, five_authors: list[ParsedAuthor]
+    ) -> None:
+        """CSVs with only FirstName and LastName columns are still supported."""
+        csv_author = five_authors[0]
+        csv_path = tmp_path / "authors.csv"
+        csv_path.write_text(
+            f"Full Name,FirstName,LastName,Email\n"
+            f"{csv_author.full_name},{csv_author.first_name},{csv_author.last_name},{csv_author.email}\n"
+        )
+        spider = OpenAlexSpider(author_csv=str(csv_path))
+        requests = []
+        async for req in spider.start():
+            requests.append(req)
+        assert len(requests) == 1
+        assert isinstance(requests[0], Request)
+        query_params = parse_qs(urlparse(requests[0].url).query)
+        assert query_params["search"] == [f"{csv_author.first_name} {csv_author.last_name}"]
+
+    @pytest.mark.asyncio
     async def test_start_with_both_parameters(
         self, tmp_path: Path, five_authors: list[ParsedAuthor]
     ) -> None:
         csv_author = five_authors[0]
         csv_path = tmp_path / "authors.csv"
-        csv_path.write_text(f"""Full Name,FirstName,LastName,Email
-{csv_author.full_name},{csv_author.first_name} {csv_author.middle_names},{csv_author.last_name},{csv_author.email}
+        csv_path.write_text(f"""Full Name,FirstName,MiddleNames,LastName,Email
+{csv_author.full_name},{csv_author.first_name},{csv_author.middle_names},{csv_author.last_name},{csv_author.email}
 """)
 
         name_author = five_authors[1]

--- a/tests/spiders/test_openalex.py
+++ b/tests/spiders/test_openalex.py
@@ -13,22 +13,6 @@ from open_ire.spiders.openalex import OpenAlexSpider
 
 
 @pytest.fixture
-def spider(tmp_path: Path, five_authors: list[ParsedAuthor]) -> OpenAlexSpider:
-    csv_content = f"""Full Name,FirstName,LastName,Email
-{five_authors[4].full_name},{five_authors[4].first_name},{five_authors[4].last_name},{five_authors[4].email}
-"""
-    csv_path = tmp_path / "adeyemi.csv"
-    csv_path.write_text(csv_content)
-
-    return OpenAlexSpider(author_csv=str(csv_path))
-
-
-@pytest.fixture
-def spider_with_author_name(five_authors: list[ParsedAuthor]) -> OpenAlexSpider:
-    return OpenAlexSpider(author_name=five_authors[1].full_name)
-
-
-@pytest.fixture
 def five_authors() -> list[ParsedAuthor]:
     return [
         ParsedAuthor("Luis Manuel Garcia-Mispireta"),
@@ -37,6 +21,23 @@ def five_authors() -> list[ParsedAuthor]:
         ParsedAuthor("M. Elena Alvarez-Alvarez"),
         ParsedAuthor("Kemi Adeyemi", email="kadeyemi@uw.edu"),
     ]
+
+
+@pytest.fixture
+def spider(tmp_path: Path, five_authors: list[ParsedAuthor]) -> OpenAlexSpider:
+    author = five_authors[4]
+    csv_content = f"""Full Name,FirstName,LastName,Email
+{author.full_name},{author.first_name},{author.last_name},{author.email}
+"""
+    csv_path = tmp_path / "authors.csv"
+    csv_path.write_text(csv_content)
+
+    return OpenAlexSpider(author_csv=str(csv_path))
+
+
+@pytest.fixture
+def spider_with_author_name(five_authors: list[ParsedAuthor]) -> OpenAlexSpider:
+    return OpenAlexSpider(author_name=five_authors[1].full_name)
 
 
 @pytest.fixture
@@ -232,49 +233,60 @@ class TestOpenAlexSpider:
         assert OpenAlexSpider._normalize_type("unknown-type") is None
 
     @pytest.mark.asyncio
-    async def test_start_with_author_name(self, spider_with_author_name) -> None:
+    async def test_start_with_author_name(
+        self, spider_with_author_name: OpenAlexSpider, five_authors: list[ParsedAuthor]
+    ) -> None:
         requests = []
         async for req in spider_with_author_name.start():
             requests.append(req)
         assert len(requests) == 1
         assert isinstance(requests[0], Request)
-        assert "John+Doe" in requests[0].url
+        parsed_url = urlparse(requests[0].url)
+        query_params = parse_qs(parsed_url.query)
+        assert query_params["search"] == [five_authors[1].full_name]
 
-    def test_author_name_parameter(self) -> None:
-        spider = OpenAlexSpider(author_name="Jane Smith")
-        assert spider.search_terms == ["Jane Smith"]
+    def test_author_name_parameter(self, five_authors: list[ParsedAuthor]) -> None:
+        author = five_authors[2]
+        spider = OpenAlexSpider(author_name=author.full_name)
+        assert spider.search_terms == [author.full_name]
 
-    def test_both_parameters_allowed(self, tmp_path: Path) -> None:
-        csv_content = """Full Name,FirstName,LastName,Email
-Test User,Test,User,test@example.com
-"""
-        csv_path = tmp_path / "test.csv"
-        csv_path.write_text(csv_content)
+    def test_both_parameters_allowed(
+        self, tmp_path: Path, five_authors: list[ParsedAuthor]
+    ) -> None:
+        csv_author = five_authors[0]
+        csv_path = tmp_path / "authors.csv"
+        csv_path.write_text(f"""Full Name,FirstName,LastName,Email
+{csv_author.full_name},{csv_author.first_name},{csv_author.last_name},{csv_author.email}
+""")
 
-        spider = OpenAlexSpider(author_csv=str(csv_path), author_name="John Doe")
+        name_author = five_authors[3]
+        spider = OpenAlexSpider(author_csv=str(csv_path), author_name=name_author.full_name)
         assert len(spider.search_terms) == 2
-        assert "Test User" in spider.search_terms
-        assert "John Doe" in spider.search_terms
+        assert csv_author.full_name in spider.search_terms
+        assert name_author.full_name in spider.search_terms
 
     @pytest.mark.asyncio
-    async def test_start_with_both_parameters(self, tmp_path: Path) -> None:
-        csv_content = """Full Name,FirstName,LastName,Email
-Alice Johnson,Alice,Johnson,alice@example.com
-"""
-        csv_path = tmp_path / "test.csv"
-        csv_path.write_text(csv_content)
+    async def test_start_with_both_parameters(
+        self, tmp_path: Path, five_authors: list[ParsedAuthor]
+    ) -> None:
+        csv_author = five_authors[0]
+        csv_path = tmp_path / "authors.csv"
+        csv_path.write_text(f"""Full Name,FirstName,LastName,Email
+{csv_author.full_name},{csv_author.first_name} {csv_author.middle_names},{csv_author.last_name},{csv_author.email}
+""")
 
-        spider = OpenAlexSpider(author_csv=str(csv_path), author_name="Bob Smith")
+        name_author = five_authors[1]
+        spider = OpenAlexSpider(author_csv=str(csv_path), author_name=name_author.full_name)
         requests = []
         async for req in spider.start():
             requests.append(req)
 
         assert len(requests) == 2
         assert all(isinstance(req, Request) for req in requests)
-        # Check that both authors are searched
-        urls = [req.url for req in requests]
-        assert any("Alice+Johnson" in url for url in urls)
-        assert any("Bob+Smith" in url for url in urls)
+        query_params0 = parse_qs(urlparse(requests[0].url).query)
+        assert query_params0["search"] == [csv_author.full_name]
+        query_params1 = parse_qs(urlparse(requests[1].url).query)
+        assert query_params1["search"] == [name_author.full_name]
 
     def test_no_parameters_error(self) -> None:
         with pytest.raises(ValueError, match="requires either"):


### PR DESCRIPTION
This allows for easier single-author queries:

`pixi run search-author openalex "Kemi Adeyemi"`

The existing CSV search interface is then reserved for multiple authors:

`pixi run search-authors openalex authors_to_search.csv`