### PR TITLE
Update ArticleBase model to allow None in article.publication_date

### DIFF
--- a/src/open_ire/models.py
+++ b/src/open_ire/models.py
@@ -40,7 +40,7 @@ class ArticleBase(SQLModel):
     extra: dict[str, Any] = Field(default_factory=dict)
     isbn: str | None = None
     issn: str | None = None
-    publication_date: date = Field(index=True)
+    publication_date: date | None = Field(default=None, index=True)
     reference: str = Field(index=True)
     repository: str = Field(index=True)
     title: str

--- a/src/open_ire/spiders/epa.py
+++ b/src/open_ire/spiders/epa.py
@@ -2,13 +2,13 @@ from collections.abc import Generator
 from typing import Any, cast
 from urllib.parse import urlencode, urlparse
 
-from dateutil.parser import parse
 from scrapy import Spider
 from scrapy.http import Request, Response, TextResponse
 
 from open_ire.items import ArticleItem
 from open_ire.links import ValidLinkExtractor
 from open_ire.settings import OPEN_IRE_DEFAULT_TERMS
+from open_ire.utils import parse_date
 
 
 class EPASpider(Spider):
@@ -96,10 +96,7 @@ class EPASpider(Spider):
             or text_response.css('meta[name="DC.date.created"]::attr(content)').get()
         ) or ""
 
-        try:
-            publication_date = parse(publication_date_text).date()
-        except ValueError:
-            publication_date = None
+        publication_date = parse_date(publication_date_text)
 
         item = ArticleItem(
             abstract=abstract,

--- a/src/open_ire/spiders/eric.py
+++ b/src/open_ire/spiders/eric.py
@@ -2,12 +2,12 @@ from collections.abc import Generator
 from typing import Any
 from urllib.parse import urlencode
 
-from dateutil.parser import parse
 from scrapy import Spider
 from scrapy.http import Request, Response
 
 from open_ire.items import ArticleItem
 from open_ire.settings import OPEN_IRE_DEFAULT_TERMS
+from open_ire.utils import parse_date
 
 
 class EricSpider(Spider):
@@ -54,7 +54,7 @@ class EricSpider(Spider):
             file_urls.append(response.urljoin(file_href))
 
         eric_number = self.extract_article_attribute("ERIC Number", response)
-        publication_date = self.extract_article_attribute("Publication Date", response) or ""
+        publication_date_text = self.extract_article_attribute("Publication Date", response)
         eissn = self.extract_article_attribute("EISSN", response)
 
         item = ArticleItem(
@@ -62,7 +62,7 @@ class EricSpider(Spider):
             authors=response.css(".r_a>div>div::text").get(),
             eissn=eissn,
             file_urls=file_urls,
-            publication_date=parse(publication_date).date(),
+            publication_date=parse_date(publication_date_text),
             reference=eric_number,
             repository=self.name,
             title=response.css(".title::text").get(),

--- a/src/open_ire/spiders/gsearch.py
+++ b/src/open_ire/spiders/gsearch.py
@@ -3,12 +3,12 @@ from datetime import date
 from typing import Any
 from urllib.parse import urlencode, urlparse
 
-from dateutil.parser import parse
 from scrapy import Spider
 from scrapy.http import Request, Response
 
 from open_ire.items import ArticleItem
 from open_ire.settings import OPEN_IRE_DEFAULT_TERMS
+from open_ire.utils import parse_date
 
 
 class GSearchSpider(Spider):
@@ -71,12 +71,7 @@ class GSearchSpider(Spider):
 
     def _extract_publication_date(self, response: Response) -> date | None:
         date_text = self._extract_from_meta(response, "citation_publication_date") or ""
-        try:
-            return parse(date_text).date()
-        except (ValueError, TypeError):
-            pass
-
-        return None
+        return parse_date(date_text)
 
     def _extract_extra_details(self, response: Response) -> dict[str, Any]:
         extra: dict[str, Any] = {}

--- a/src/open_ire/spiders/noaa_meta.py
+++ b/src/open_ire/spiders/noaa_meta.py
@@ -5,12 +5,12 @@ from types import MappingProxyType
 from typing import Any
 
 import requests
-from dateutil.parser import parse
 from scrapy import Spider
 
 from open_ire.errors import SpiderParameterError
 from open_ire.items import ArticleItem
 from open_ire.settings import OPEN_IRE_DEFAULT_TERMS
+from open_ire.utils import parse_date
 
 # See https://github.com/NOAA-Central-Library-NCL/NOAA_IR/blob/master/noaa_json_api/pandas-ir.ipynb for
 # details on the document fields.
@@ -103,10 +103,7 @@ class NOAAMetaSpider(Spider):
                 continue
 
             date_text = self._normalize_field_value(date_value) or ""
-            try:
-                return parse(date_text).date()
-            except (ValueError, TypeError):
-                continue
+            return parse_date(date_text)
 
         return None
 

--- a/src/open_ire/spiders/wos.py
+++ b/src/open_ire/spiders/wos.py
@@ -215,6 +215,11 @@ class WoSSpider(AuthorSearchSpider):
         authors = self._extract_authors(names)
 
         pub_info = summary.get("pub_info", {})
+        publication_date = parse_date(pub_info.get("coverdate") or pub_info.get("sortdate"))
+        if publication_date is None:
+            pub_year = pub_info.get("pubyear")
+            if pub_year:
+                publication_date = parse_date(f"{pub_year}-01-01")
         cluster_related = publication.get("dynamic_data", {}).get("cluster_related", {})
         identifiers = as_list(cluster_related.get("identifiers", {}).get("identifier"))
         doi = next(
@@ -237,7 +242,7 @@ class WoSSpider(AuthorSearchSpider):
                     "type": raw_type,
                 },
             },
-            publication_date=parse_date(pub_info.get("coverdate") or pub_info.get("sortdate")),
+            publication_date=publication_date,
             reference=str(external_id),
             repository=self.name,
             title=title,

--- a/src/open_ire/utils.py
+++ b/src/open_ire/utils.py
@@ -1,9 +1,12 @@
 """Common utility functions."""
 
-from datetime import date
+import logging
+from datetime import date, datetime
 from typing import Any
 
 from dateutil.parser import parse
+
+logger = logging.getLogger(__name__)
 
 
 def parse_date(value: Any) -> date | None:
@@ -11,8 +14,11 @@ def parse_date(value: Any) -> date | None:
     if not value:
         return None
     try:
-        return parse(str(value)).date()
+        # Value containing just YYYY will produce YYYY-01-01; if unspecified, default defaults to today's date.
+        january_first = datetime.today().replace(day=1, month=1)
+        return parse(str(value), default=january_first).date()
     except (ValueError, TypeError):
+        logger.warning("Can't parse date '%s'", value)
         return None
 
 

--- a/tests/spiders/test_noaa_meta.py
+++ b/tests/spiders/test_noaa_meta.py
@@ -176,6 +176,7 @@ class TestNOAAMetaSpider:
         assert item.abstract == "Unittest abstract"
         assert item.doi == "10.1000/unittest"
         assert item.authors == "Unittest Author"
+        assert item.publication_date is not None
         assert item.publication_date.year == 2025
         assert item.issn == "1234-5678"
         assert item.repository == "noaa_meta"


### PR DESCRIPTION
EPA, GSEARCH, and NOAA_META spiders already default to None, so this fix just updates the model so that pydantic doesn't freak out when an article without (or with malformed) publication date is encountered.

* Refactor: All spiders use utils.parse_date(), which returns parsed date or None, and handles ValueError.
* Feature: utils.parse_date() emits a warning log message if it can't parse date.

Rationale: Pydantic also complains about some `str | None` assignments to `reference` and `title` (both of which are `str` in the model). For those fields it would make little sense to relax the model's expected type. It's quite possible for a publication to exist and be valuable but not have a precise date yet or have a badly formatted date, so allowing nullable `publication_date` makes sense, I think.

