### PR TITLE
Add a new pipeline to deduplicate based on matching DOI

### DIFF
--- a/src/open_ire/models.py
+++ b/src/open_ire/models.py
@@ -40,7 +40,7 @@ class ArticleBase(SQLModel):
     extra: dict[str, Any] = Field(default_factory=dict)
     isbn: str | None = None
     issn: str | None = None
-    publication_date: date = Field(index=True)
+    publication_date: date | None = Field(default=None, index=True)
     reference: str = Field(index=True)
     repository: str = Field(index=True)
     title: str

--- a/src/open_ire/pipelines/__init__.py
+++ b/src/open_ire/pipelines/__init__.py
@@ -1,4 +1,5 @@
 from .base_sql_model_pipeline import BaseSQLModelPipeline
+from .doi_duplicates_pipeline import DOIDuplicatesPipeline
 from .doi_normalization_pipeline import DOINormalizationPipeline
 from .duplicates_pipeline import DuplicatesPipeline
 from .file_reference_pipeline import FileReferencePipeline
@@ -9,6 +10,7 @@ from .sql_model_pipeline import SQLModelPipeline
 
 __all__ = [
     "BaseSQLModelPipeline",
+    "DOIDuplicatesPipeline",
     "DOINormalizationPipeline",
     "DuplicatesPipeline",
     "FileReferencePipeline",

--- a/src/open_ire/pipelines/doi_duplicates_pipeline.py
+++ b/src/open_ire/pipelines/doi_duplicates_pipeline.py
@@ -1,0 +1,107 @@
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from scrapy.exceptions import DropItem
+from sqlmodel import Session, select
+
+from open_ire.items import ArticleItem
+from open_ire.models import Article
+from open_ire.pipelines.base_sql_model_pipeline import BaseSQLModelPipeline
+from open_ire.pipelines.doi_normalization_pipeline import DOINormalizationPipeline
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class _ExistingArticle:
+    id: str
+    repository: str
+    reference: str
+
+
+class DOIDuplicatesPipeline(BaseSQLModelPipeline):
+    """Merges duplicate DOI records into an existing article and drops the duplicate item."""
+
+    def __init__(self, db_path: str, files_base_path: str | None = None) -> None:
+        super().__init__(db_path, files_base_path)
+        # Populated once spider opens
+        self._doi_to_article: dict[str, _ExistingArticle] = {}
+
+    def open_spider(self) -> None:
+        super().open_spider()
+
+        assert self.engine is not None
+        with Session(self.engine) as session:
+            rows = session.exec(
+                select(Article.id, Article.doi, Article.repository, Article.reference).where(
+                    Article.doi.is_not(None)  # type: ignore[union-attr]
+                )
+            ).all()
+            for article_id, doi, repository, reference in rows:
+                assert doi is not None
+                self._doi_to_article[doi] = _ExistingArticle(
+                    id=str(article_id), repository=repository, reference=reference
+                )
+
+    def process_item(self, item: Any) -> Any:
+        if not isinstance(item, ArticleItem):
+            return item
+
+        doi = DOINormalizationPipeline.normalize(item.doi)
+        if doi is None:
+            return item
+
+        if doi not in self._doi_to_article:
+            return item
+
+        assert self.engine is not None
+        with Session(self.engine) as session:
+            existing_article = session.exec(select(Article).where(Article.doi == doi)).first()
+            if existing_article is None:
+                return item
+            self._append_duplicate_source(existing_article, item)
+            session.add(existing_article)
+            session.commit()
+
+        cached = self._doi_to_article[doi]
+        logger.info(
+            "Dropping article '%s' from '%s': DOI '%s' already exists as '%s' in '%s'.",
+            item.reference,
+            item.repository,
+            doi,
+            cached.reference,
+            cached.repository,
+        )
+        msg = "Article DOI already exists in database."
+        raise DropItem(msg)
+
+    @staticmethod
+    def _append_duplicate_source(existing_article: Article, item: ArticleItem) -> None:
+        """Add the duplicate source reference to the existing article's extra data."""
+        new_source: dict[str, Any] = {
+            "repository": item.repository,
+            "reference": item.reference,
+        }
+        new_source |= DOIDuplicatesPipeline._differing_fields(existing_article, item)
+
+        extra = dict(existing_article.extra)
+        duplicate_sources = extra.get("duplicate_sources", [])
+        if not isinstance(duplicate_sources, list):
+            duplicate_sources = []
+        if new_source not in duplicate_sources:
+            duplicate_sources.append(new_source)
+        extra["duplicate_sources"] = duplicate_sources
+        existing_article.extra = extra
+
+    @staticmethod
+    def _differing_fields(existing_article: Article, item: ArticleItem) -> dict[str, Any]:
+        """Returns a dictionary of fields from the duplicate item that differ from the existing article."""
+        diffs: dict[str, Any] = {}
+        if item.title != existing_article.title:
+            diffs["title"] = item.title
+        if item.publication_date != existing_article.publication_date:
+            diffs["publication_date"] = str(item.publication_date)
+        if item.type != existing_article.type:
+            diffs["type"] = item.type.value if item.type else None
+        return diffs

--- a/src/open_ire/settings/base.py
+++ b/src/open_ire/settings/base.py
@@ -28,6 +28,7 @@ ITEM_PIPELINES = {
     "open_ire.pipelines.SkipExistingPipeline": 2,
     # Data normalization pipelines:
     "open_ire.pipelines.DOINormalizationPipeline": 10,
+    "open_ire.pipelines.DOIDuplicatesPipeline": 20,
     # Processing pipelines:
     "open_ire.pipelines.LocalFilePipeline": 100,
     "open_ire.pipelines.FileReferencePipeline": 200,

--- a/src/open_ire/spiders/epa.py
+++ b/src/open_ire/spiders/epa.py
@@ -2,13 +2,13 @@ from collections.abc import Generator
 from typing import Any, cast
 from urllib.parse import urlencode, urlparse
 
-from dateutil.parser import parse
 from scrapy import Spider
 from scrapy.http import Request, Response, TextResponse
 
 from open_ire.items import ArticleItem
 from open_ire.links import ValidLinkExtractor
 from open_ire.settings import OPEN_IRE_DEFAULT_TERMS
+from open_ire.utils import parse_date
 
 
 class EPASpider(Spider):
@@ -96,10 +96,7 @@ class EPASpider(Spider):
             or text_response.css('meta[name="DC.date.created"]::attr(content)').get()
         ) or ""
 
-        try:
-            publication_date = parse(publication_date_text).date()
-        except ValueError:
-            publication_date = None
+        publication_date = parse_date(publication_date_text)
 
         item = ArticleItem(
             abstract=abstract,

--- a/src/open_ire/spiders/eric.py
+++ b/src/open_ire/spiders/eric.py
@@ -2,12 +2,12 @@ from collections.abc import Generator
 from typing import Any
 from urllib.parse import urlencode
 
-from dateutil.parser import parse
 from scrapy import Spider
 from scrapy.http import Request, Response
 
 from open_ire.items import ArticleItem
 from open_ire.settings import OPEN_IRE_DEFAULT_TERMS
+from open_ire.utils import parse_date
 
 
 class EricSpider(Spider):
@@ -54,7 +54,7 @@ class EricSpider(Spider):
             file_urls.append(response.urljoin(file_href))
 
         eric_number = self.extract_article_attribute("ERIC Number", response)
-        publication_date = self.extract_article_attribute("Publication Date", response) or ""
+        publication_date_text = self.extract_article_attribute("Publication Date", response)
         eissn = self.extract_article_attribute("EISSN", response)
 
         item = ArticleItem(
@@ -62,7 +62,7 @@ class EricSpider(Spider):
             authors=response.css(".r_a>div>div::text").get(),
             eissn=eissn,
             file_urls=file_urls,
-            publication_date=parse(publication_date).date(),
+            publication_date=parse_date(publication_date_text),
             reference=eric_number,
             repository=self.name,
             title=response.css(".title::text").get(),

--- a/src/open_ire/spiders/gsearch.py
+++ b/src/open_ire/spiders/gsearch.py
@@ -3,12 +3,12 @@ from datetime import date
 from typing import Any
 from urllib.parse import urlencode, urlparse
 
-from dateutil.parser import parse
 from scrapy import Spider
 from scrapy.http import Request, Response
 
 from open_ire.items import ArticleItem
 from open_ire.settings import OPEN_IRE_DEFAULT_TERMS
+from open_ire.utils import parse_date
 
 
 class GSearchSpider(Spider):
@@ -71,12 +71,7 @@ class GSearchSpider(Spider):
 
     def _extract_publication_date(self, response: Response) -> date | None:
         date_text = self._extract_from_meta(response, "citation_publication_date") or ""
-        try:
-            return parse(date_text).date()
-        except (ValueError, TypeError):
-            pass
-
-        return None
+        return parse_date(date_text)
 
     def _extract_extra_details(self, response: Response) -> dict[str, Any]:
         extra: dict[str, Any] = {}

--- a/src/open_ire/spiders/noaa_meta.py
+++ b/src/open_ire/spiders/noaa_meta.py
@@ -5,12 +5,12 @@ from types import MappingProxyType
 from typing import Any
 
 import requests
-from dateutil.parser import parse
 from scrapy import Spider
 
 from open_ire.errors import SpiderParameterError
 from open_ire.items import ArticleItem
 from open_ire.settings import OPEN_IRE_DEFAULT_TERMS
+from open_ire.utils import parse_date
 
 # See https://github.com/NOAA-Central-Library-NCL/NOAA_IR/blob/master/noaa_json_api/pandas-ir.ipynb for
 # details on the document fields.
@@ -103,10 +103,7 @@ class NOAAMetaSpider(Spider):
                 continue
 
             date_text = self._normalize_field_value(date_value) or ""
-            try:
-                return parse(date_text).date()
-            except (ValueError, TypeError):
-                continue
+            return parse_date(date_text)
 
         return None
 

--- a/src/open_ire/spiders/wos.py
+++ b/src/open_ire/spiders/wos.py
@@ -215,6 +215,11 @@ class WoSSpider(AuthorSearchSpider):
         authors = self._extract_authors(names)
 
         pub_info = summary.get("pub_info", {})
+        publication_date = parse_date(pub_info.get("coverdate") or pub_info.get("sortdate"))
+        if publication_date is None:
+            pub_year = pub_info.get("pubyear")
+            if pub_year:
+                publication_date = parse_date(f"{pub_year}-01-01")
         cluster_related = publication.get("dynamic_data", {}).get("cluster_related", {})
         identifiers = as_list(cluster_related.get("identifiers", {}).get("identifier"))
         doi = next(
@@ -237,7 +242,7 @@ class WoSSpider(AuthorSearchSpider):
                     "type": raw_type,
                 },
             },
-            publication_date=parse_date(pub_info.get("coverdate") or pub_info.get("sortdate")),
+            publication_date=publication_date,
             reference=str(external_id),
             repository=self.name,
             title=title,

--- a/src/open_ire/utils.py
+++ b/src/open_ire/utils.py
@@ -1,9 +1,12 @@
 """Common utility functions."""
 
-from datetime import date
+import logging
+from datetime import date, datetime
 from typing import Any
 
 from dateutil.parser import parse
+
+logger = logging.getLogger(__name__)
 
 
 def parse_date(value: Any) -> date | None:
@@ -11,8 +14,11 @@ def parse_date(value: Any) -> date | None:
     if not value:
         return None
     try:
-        return parse(str(value)).date()
+        # Value containing just YYYY will produce YYYY-01-01; if unspecified, default defaults to today's date.
+        january_first = datetime.today().replace(day=1, month=1)
+        return parse(str(value), default=january_first).date()
     except (ValueError, TypeError):
+        logger.warning("Can't parse date '%s'", value)
         return None
 
 

--- a/tests/pipelines/test_doi_duplicates_pipeline.py
+++ b/tests/pipelines/test_doi_duplicates_pipeline.py
@@ -1,0 +1,135 @@
+from collections.abc import Generator
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from scrapy.crawler import Crawler
+from scrapy.exceptions import DropItem
+from sqlmodel import Session, select
+
+from open_ire.items import ArticleItem
+from open_ire.models import Article
+from open_ire.pipelines import DOIDuplicatesPipeline
+
+
+@pytest.fixture
+def pipeline(crawler: Crawler) -> Generator[DOIDuplicatesPipeline, None, None]:
+    instance = DOIDuplicatesPipeline(":memory:", "output")
+    instance.crawler = crawler
+    instance.open_spider()
+    assert instance.engine is not None
+    yield instance
+    instance.engine.dispose()
+
+
+@pytest.fixture
+def pipeline_with_existing(
+    crawler: Crawler,
+    tmp_path: Path,
+) -> Generator[DOIDuplicatesPipeline, None, None]:
+    """Pipeline with an existing OpenAlex article in the database."""
+    db_path = str(tmp_path / "test.db")
+    instance = DOIDuplicatesPipeline(db_path, "output")
+    instance.crawler = crawler
+
+    # First open: create the schema and seed an article.
+    instance.open_spider()
+    assert instance.engine is not None
+    with Session(instance.engine) as session:
+        article = Article(
+            title="Existing Article",
+            authors="Author One",
+            publication_date=date(2024, 1, 15),
+            repository="openalex",
+            reference="OA123",
+            url="https://doi.org/10.1234/test",
+            doi="10.1234/test",
+        )
+        session.add(article)
+        session.commit()
+    instance.close_spider()
+
+    # Second open: reload the DOI cache from the persisted DB.
+    instance.open_spider()
+    assert instance.engine is not None
+    yield instance
+    instance.close_spider()
+
+
+class TestDOIDuplicatesPipeline:
+    def test_passes_through_non_article_items(self, pipeline: DOIDuplicatesPipeline) -> None:
+        item = MagicMock()
+        result = pipeline.process_item(item)
+        assert result is item
+
+    def test_passes_through_article_without_doi(
+        self, pipeline: DOIDuplicatesPipeline, item: ArticleItem
+    ) -> None:
+        item.doi = None
+        result = pipeline.process_item(item)
+        assert result is item
+        assert "duplicate_sources" not in item.extra
+
+    def test_passes_through_article_with_no_existing_match(
+        self, pipeline: DOIDuplicatesPipeline, item: ArticleItem
+    ) -> None:
+        item.doi = "10.9999/unique"
+        result = pipeline.process_item(item)
+        assert result is item
+        assert "duplicate_sources" not in item.extra
+
+    def test_drops_duplicate_doi_and_stores_duplicate_source(
+        self,
+        pipeline_with_existing: DOIDuplicatesPipeline,
+    ) -> None:
+        pipeline = pipeline_with_existing
+        assert pipeline.engine is not None
+        wos_item = ArticleItem(
+            title="Same Article from WoS",
+            authors="Author One",
+            publication_date=date(2024, 1, 15),
+            repository="wos",
+            reference="WOS:000123",
+            url="https://www.webofscience.com/wos/woscc/full-record/WOS:000123",
+            doi="10.1234/test",
+        )
+
+        with pytest.raises(DropItem):
+            pipeline.process_item(wos_item)
+
+        with Session(pipeline.engine) as session:
+            article = session.exec(select(Article).where(Article.doi == "10.1234/test")).first()
+            assert article is not None
+            duplicate_sources = article.extra["duplicate_sources"]
+            assert duplicate_sources == [
+                {"repository": "wos", "reference": "WOS:000123", "title": "Same Article from WoS"}
+            ]
+
+    def test_normalizes_doi_before_matching(
+        self,
+        pipeline_with_existing: DOIDuplicatesPipeline,
+    ) -> None:
+        """DOI with URL prefix should still merge against normalized DOI in the database."""
+        pipeline = pipeline_with_existing
+        assert pipeline.engine is not None
+        wos_item = ArticleItem(
+            title="Article with URL DOI",
+            authors="Author One",
+            publication_date=date(2024, 1, 15),
+            repository="wos",
+            reference="WOS:000456",
+            url="https://www.webofscience.com/wos/woscc/full-record/WOS:000456",
+            doi="https://doi.org/10.1234/test",
+        )
+
+        with pytest.raises(DropItem):
+            pipeline.process_item(wos_item)
+
+        with Session(pipeline.engine) as session:
+            article = session.exec(select(Article).where(Article.doi == "10.1234/test")).first()
+            assert article is not None
+            duplicate_sources = article.extra["duplicate_sources"]
+            assert duplicate_sources == [
+                {"repository": "wos", "reference": "WOS:000456", "title": "Article with URL DOI"}
+            ]

--- a/tests/spiders/test_noaa_meta.py
+++ b/tests/spiders/test_noaa_meta.py
@@ -176,6 +176,7 @@ class TestNOAAMetaSpider:
         assert item.abstract == "Unittest abstract"
         assert item.doi == "10.1000/unittest"
         assert item.authors == "Unittest Author"
+        assert item.publication_date is not None
         assert item.publication_date.year == 2025
         assert item.issn == "1234-5678"
         assert item.repository == "noaa_meta"


### PR DESCRIPTION
If a new ArticleItem has the same DOI as an existing record, the pipeline annotates (in `article.extra.cross_source_doi_match`) the new record with enough information to locate the existing one.