### PR TITLE
Feat/search author command

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,18 +126,32 @@ pixi run search-terms eric "ocean acidification,coral bleaching"
 
 ### Search by Author
 
-To run a spider that supports searching by author against a list of authors, use
-the `search-authors` command. This requires a CSV file with `FirstName`,
-`LastName`, and `Email` columns.
+To search for a single author's name, use the `search-author` (singular)
+command:
 
 ```bash
-pixi run search-authors <spider_name> <path_to_csv>
+pixi run search-author <spider_name> "<author's full name>"
 ```
 
-For example, to search `openalex` using an author file:
+For example:
 
 ```bash
-pixi run search-authors openalex data/authors.csv
+pixi run search-author openalex "Michelle Habell-Pallán"
+```
+
+To run a spider that supports searching by author against a list of authors, use
+the `search-authors` (plural) command. This requires a CSV file with
+`FirstName`, `MiddleNames` (optional), `LastName`, and `Email` columns.
+
+```bash
+pixi run search-authors <spider_name> "<path_to_csv>"
+```
+
+For example, to search `openalex` for publications by any one among a number of
+authors:
+
+```bash
+pixi run search-authors openalex "data/authors.csv"
 ```
 
 ## Contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,9 +192,13 @@ args = [
 ]
 cmd = "scrapy crawl {{ spider }} -s JOBDIR=crawls/{{ spider }}{% if '--skip-existing' in flag %} -s OPEN_IRE_SKIP_EXISTING=True{% endif %}"
 
+[tool.pixi.tasks.search-author]
+args = ["spider", "author_name"]
+cmd = "scrapy crawl {{ spider }} -a author_name=\"{{ author_name }}\""
+
 [tool.pixi.tasks.search-authors]
 args = ["spider", "author_csv"]
-cmd = "scrapy crawl {{ spider }} -a author_csv={{ author_csv }}"
+cmd = "scrapy crawl {{ spider }} -a author_csv=\"{{ author_csv }}\""
 
 [tool.pixi.tasks.search-terms]
 args = ["spider", "terms", "page"]

--- a/src/open_ire/spiders/search.py
+++ b/src/open_ire/spiders/search.py
@@ -1,4 +1,5 @@
 import abc
+from abc import ABC
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -32,7 +33,7 @@ class SearchSpider(Spider, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
 
-class TermSearchSpider(SearchSpider):
+class TermSearchSpider(SearchSpider, ABC):
     """
     A base spider that generates search requests from a list of terms
     provided via the 'terms' argument.
@@ -51,21 +52,38 @@ class TermSearchSpider(SearchSpider):
         self.search_terms = [term.strip() for term in (terms or "").split(",")]
 
 
-class AuthorSearchSpider(SearchSpider):
+class AuthorSearchSpider(SearchSpider, ABC):
     """
-    A specialized base spider that only searches using an author CSV file.
+    A specialized base spider that searches using author names from CSV file and/or individual author names.
 
-    This spider requires the `author_csv` argument. Subclasses can override
-    `_get_author_name` to specify the required name format for the target API.
+    This spider accepts `author_csv` and/or `author_name` arguments. If both are provided, the individual
+    author name is added to the list from the CSV. Subclasses can override `_get_author_name` to specify
+    the required name format for the target API.
     """
 
-    def __init__(self, author_csv: str | None = None, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        author_csv: str | None = None,
+        author_name: str | None = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(*args, **kwargs)
-        if not author_csv:
-            msg = f"The '{self.name}' spider requires the 'author_csv' argument."
+
+        author_csv = author_csv.strip() if author_csv else None
+        author_name = author_name.strip() if author_name else None
+        if not author_csv and not author_name:
+            msg = f"The '{self.name}' spider requires either the 'author_csv' or 'author_name' argument (or both)."
             raise ValueError(msg)
 
-        self.search_terms = self._get_search_terms(author_csv)
+        self.search_terms = []
+
+        if author_csv:
+            self.search_terms.extend(self._get_search_terms(author_csv))
+
+        if author_name:
+            parsed = ParsedAuthor(author_name)
+            self.search_terms.append(self._get_author_name(parsed))
 
     def _get_author_name(self, record: ParsedAuthor) -> str:
         """Return the author name in the default 'Firstname Lastname' format."""

--- a/tests/spiders/test_openalex.py
+++ b/tests/spiders/test_openalex.py
@@ -24,6 +24,11 @@ def spider(tmp_path: Path, five_authors: list[ParsedAuthor]) -> OpenAlexSpider:
 
 
 @pytest.fixture
+def spider_with_author_name(five_authors: list[ParsedAuthor]) -> OpenAlexSpider:
+    return OpenAlexSpider(author_name=five_authors[1].full_name)
+
+
+@pytest.fixture
 def five_authors() -> list[ParsedAuthor]:
     return [
         ParsedAuthor("Luis Manuel Garcia-Mispireta"),
@@ -221,3 +226,52 @@ class TestOpenAlexSpider:
 
     def test_normalize_type_unknown(self) -> None:
         assert OpenAlexSpider._normalize_type("unknown-type") is None
+
+    @pytest.mark.asyncio
+    async def test_start_with_author_name(self, spider_with_author_name) -> None:
+        requests = []
+        async for req in spider_with_author_name.start():
+            requests.append(req)
+        assert len(requests) == 1
+        assert isinstance(requests[0], Request)
+        assert "E.V.S.S.K.+Babu" in requests[-1].url
+
+    def test_author_name_parameter(self) -> None:
+        spider = OpenAlexSpider(author_name="Jane Smith")
+        assert spider.search_terms == ["Jane Smith"]
+
+    def test_both_parameters_allowed(self, tmp_path: Path) -> None:
+        csv_content = """Full Name,FirstName,LastName,Email
+Test User,Test,User,test@example.com
+"""
+        csv_path = tmp_path / "test.csv"
+        csv_path.write_text(csv_content)
+
+        spider = OpenAlexSpider(author_csv=str(csv_path), author_name="John Doe")
+        assert len(spider.search_terms) == 2
+        assert "Test User" in spider.search_terms
+        assert "John Doe" in spider.search_terms
+
+    @pytest.mark.asyncio
+    async def test_start_with_both_parameters(self, tmp_path: Path) -> None:
+        csv_content = """Full Name,FirstName,LastName,Email
+Alice Johnson,Alice,Johnson,alice@example.com
+"""
+        csv_path = tmp_path / "test.csv"
+        csv_path.write_text(csv_content)
+
+        spider = OpenAlexSpider(author_csv=str(csv_path), author_name="Bob Smith")
+        requests = []
+        async for req in spider.start():
+            requests.append(req)
+
+        assert len(requests) == 2
+        assert all(isinstance(req, Request) for req in requests)
+        # Check that both authors are searched
+        urls = [req.url for req in requests]
+        assert any("Alice+Johnson" in url for url in urls)
+        assert any("Bob+Smith" in url for url in urls)
+
+    def test_no_parameters_error(self) -> None:
+        with pytest.raises(ValueError, match="requires either"):
+            OpenAlexSpider()

--- a/tests/spiders/test_wos.py
+++ b/tests/spiders/test_wos.py
@@ -158,6 +158,17 @@ class TestWoSSpider:
 
         assert request.url.startswith(spider.base_url + "?count=25&databaseId=WOS")
 
+    def test_build_search_request_with_author_name_normalizes_to_wos_format(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("WOS_API_KEY", "dummy_api_key")
+        spider = WoSSpider(author_name="John Doe")
+
+        request = spider.build_search_request(spider.search_terms[0])
+
+        assert spider.search_terms == ["Doe, John"]
+        assert 'AU=("Doe, John")' in request.cb_kwargs["query"]
+
     def test_parse_publications_no_results_records_empty_string(
         self, spider: WoSSpider, five_authors: list[ParsedAuthor]
     ) -> None:


### PR DESCRIPTION
This allows for easier single-author queries:

`pixi run search-author openalex "Kemi Adeyemi"`

The existing CSV search interface is then reserved for multiple authors:

`pixi run search-authors openalex authors_to_search.csv`