### PR TITLE
Add AuthorItem and AuthorIdentifierPipeline

### DIFF
--- a/src/open_ire/items.py
+++ b/src/open_ire/items.py
@@ -1,3 +1,4 @@
+from pydantic import BaseModel
 from sqlmodel import Field, SQLModel
 
 from open_ire.models import ArticleBase
@@ -28,3 +29,17 @@ class UnavailableArticleItem(SQLModel):
     error: str
     request_method: str
     checked_at: str
+
+
+class AuthorItem(BaseModel):
+    """Author data with identifiers from a trusted source (e.g., OpenAlex).
+
+    Used when a spider successfully disambiguates an author and discovers
+    their canonical identifiers (OpenAlex ID, ORCID, etc.).
+    """
+
+    full_name: str
+    first_name: str | None = None
+    middle_names: str | None = None
+    last_name: str | None = None
+    identifiers: list[dict[str, str]] = Field(default_factory=list)

--- a/src/open_ire/models.py
+++ b/src/open_ire/models.py
@@ -232,6 +232,7 @@ class AuthorBase(SQLModel):
     middle_names: str | None = None
     last_name: str | None = None
     full_name: str = Field(index=True)
+    canonical_name: str = Field(index=True)
     uw_academic_unit: str | None = Field(default=None, index=True)
     explicitly_searched: bool = Field(default=False, index=True)
     created_at: datetime = Field(default_factory=datetime.now)

--- a/src/open_ire/pipelines/__init__.py
+++ b/src/open_ire/pipelines/__init__.py
@@ -1,3 +1,4 @@
+from .author_identifier_pipeline import AuthorIdentifierPipeline
 from .base_sql_model_pipeline import BaseSQLModelPipeline
 from .doi_duplicates_pipeline import DOIDuplicatesPipeline
 from .doi_normalization_pipeline import DOINormalizationPipeline
@@ -9,6 +10,7 @@ from .skip_existing_pipeline import SkipExistingPipeline
 from .sql_model_pipeline import SQLModelPipeline
 
 __all__ = [
+    "AuthorIdentifierPipeline",
     "BaseSQLModelPipeline",
     "DOIDuplicatesPipeline",
     "DOINormalizationPipeline",

--- a/src/open_ire/pipelines/author_identifier_pipeline.py
+++ b/src/open_ire/pipelines/author_identifier_pipeline.py
@@ -75,6 +75,7 @@ class AuthorIdentifierPipeline(BaseSQLModelPipeline):
     def _create_author_with_identifiers(session: Session, item: AuthorItem) -> Author:
         """Create a new author with all provided identifiers."""
         author = Author(
+            canonical_name=f"{item.last_name}, {item.first_name}",
             full_name=item.full_name,
             first_name=item.first_name,
             middle_names=item.middle_names,

--- a/src/open_ire/pipelines/author_identifier_pipeline.py
+++ b/src/open_ire/pipelines/author_identifier_pipeline.py
@@ -2,7 +2,6 @@ import logging
 from datetime import datetime
 from typing import Any
 
-from scrapy.crawler import Crawler
 from sqlmodel import Session, select
 
 from open_ire.author import ParsedAuthor
@@ -21,12 +20,6 @@ class AuthorIdentifierPipeline(BaseSQLModelPipeline):
     identifiers, using them for deterministic author matching.
 
     """
-
-    @classmethod
-    def from_crawler(cls, crawler: Crawler) -> "AuthorIdentifierPipeline":
-        pipeline = cls(crawler.settings.get("OPEN_IRE_DATABASE_FILE"))
-        pipeline.crawler = crawler
-        return pipeline
 
     def process_item(self, item: Any) -> Any:
         if not isinstance(item, AuthorItem):

--- a/src/open_ire/pipelines/author_identifier_pipeline.py
+++ b/src/open_ire/pipelines/author_identifier_pipeline.py
@@ -5,6 +5,7 @@ from typing import Any
 from scrapy.crawler import Crawler
 from sqlmodel import Session, select
 
+from open_ire.author import ParsedAuthor
 from open_ire.items import AuthorItem
 from open_ire.models import Author, AuthorIdentifier
 from open_ire.pipelines.base_sql_model_pipeline import BaseSQLModelPipeline
@@ -31,17 +32,17 @@ class AuthorIdentifierPipeline(BaseSQLModelPipeline):
         if not isinstance(item, AuthorItem):
             return item
 
-        if not item.identifiers:
-            logger.debug("AuthorItem for '%s' has no identifiers; skipping", item.full_name)
-            return item
-
         with Session(self.engine) as session:
-            author = self._find_author_by_identifier(session, item.identifiers)
+            by_identifier = self._find_author_by_identifier(session, item.identifiers)
+            by_name = self._find_author_by_name(session, item)
+            candidates = [a for a in (by_identifier, by_name) if a is not None]
 
-            if author:
-                self._update_author(session, author, item)
+            if not candidates:
+                self._create_author_with_identifiers(session, item)
+            elif len(candidates) == 1 or (candidates[0].id == candidates[1].id):
+                self._update_author(session, candidates[0], item)
             else:
-                author = self._create_author_with_identifiers(session, item)
+                raise RuntimeError("Multiple existing authors found for " + item.full_name)
 
             session.commit()
 
@@ -59,13 +60,36 @@ class AuthorIdentifierPipeline(BaseSQLModelPipeline):
                 .where(AuthorIdentifier.identifier == ident["identifier"])
             ).first()
             if existing:
+                logger.info(
+                    "Found existing author '%s' (id=%s) by identifier",
+                    existing.author.full_name,
+                    existing.author.id,
+                )
                 return existing.author
+        return None
+
+    @staticmethod
+    def _find_author_by_name(session: Session, item: AuthorItem) -> Author | None:
+        """Find an existing author by compatible parsed name."""
+        parsed = ParsedAuthor(item.full_name)
+        last_name = (item.last_name or parsed.last_name).strip()
+        if not last_name:
+            return None
+
+        candidates = session.exec(select(Author).where(Author.last_name == last_name)).all()
+        target = ParsedAuthor(item.full_name)
+        for candidate in candidates:
+            if ParsedAuthor(candidate.canonical_name).likely_same(target):
+                logger.info(
+                    "Found existing author '%s' (id=%s) by name",
+                    candidate.full_name,
+                    candidate.id,
+                )
+                return candidate
         return None
 
     def _update_author(self, session: Session, author: Author, item: AuthorItem) -> None:
         """Update an existing author with new data and add any missing identifiers."""
-        logger.info("Found existing author '%s' (id=%s) by identifier", author.full_name, author.id)
-
         author.updated_at = datetime.now()
 
         # Add any identifiers that don't already exist
@@ -74,12 +98,21 @@ class AuthorIdentifierPipeline(BaseSQLModelPipeline):
     @staticmethod
     def _create_author_with_identifiers(session: Session, item: AuthorItem) -> Author:
         """Create a new author with all provided identifiers."""
+        parsed = ParsedAuthor(item.full_name)
+        first_name = item.first_name or parsed.first_name or None
+        middle_names = item.middle_names or parsed.middle_names or None
+        last_name = item.last_name or parsed.last_name or None
+
+        canonical_name = ParsedAuthor(
+            " ".join(part for part in [first_name, middle_names, last_name] if part)
+        ).normalized_name
+
         author = Author(
-            canonical_name=f"{item.last_name}, {item.first_name}",
+            canonical_name=canonical_name,
             full_name=item.full_name,
-            first_name=item.first_name,
-            middle_names=item.middle_names,
-            last_name=item.last_name,
+            first_name=first_name,
+            middle_names=middle_names,
+            last_name=last_name,
             explicitly_searched=True,
         )
         session.add(author)

--- a/src/open_ire/pipelines/author_identifier_pipeline.py
+++ b/src/open_ire/pipelines/author_identifier_pipeline.py
@@ -1,0 +1,133 @@
+import logging
+from datetime import datetime
+from typing import Any
+
+from scrapy.crawler import Crawler
+from sqlmodel import Session, select
+
+from open_ire.items import AuthorItem
+from open_ire.models import Author, AuthorIdentifier
+from open_ire.pipelines.base_sql_model_pipeline import BaseSQLModelPipeline
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class AuthorIdentifierPipeline(BaseSQLModelPipeline):
+    """Store author identifiers discovered during crawling.
+
+    When a spider successfully disambiguates an author it yields an AuthorItem
+    containing the author's canonical identifiers. This pipeline stores those
+    identifiers, using them for deterministic author matching.
+
+    """
+
+    @classmethod
+    def from_crawler(cls, crawler: Crawler) -> "AuthorIdentifierPipeline":
+        pipeline = cls(crawler.settings.get("OPEN_IRE_DATABASE_FILE"))
+        pipeline.crawler = crawler
+        return pipeline
+
+    def process_item(self, item: Any) -> Any:
+        if not isinstance(item, AuthorItem):
+            return item
+
+        if not item.identifiers:
+            logger.debug("AuthorItem for '%s' has no identifiers; skipping", item.full_name)
+            return item
+
+        with Session(self.engine) as session:
+            author = self._find_author_by_identifier(session, item.identifiers)
+
+            if author:
+                self._update_author(session, author, item)
+            else:
+                author = self._create_author_with_identifiers(session, item)
+
+            session.commit()
+
+        return item
+
+    @staticmethod
+    def _find_author_by_identifier(
+        session: Session, identifiers: list[dict[str, str]]
+    ) -> Author | None:
+        """Find an existing author by any of the provided identifiers."""
+        for ident in identifiers:
+            existing = session.exec(
+                select(AuthorIdentifier)
+                .where(AuthorIdentifier.authority == ident["authority"])
+                .where(AuthorIdentifier.identifier == ident["identifier"])
+            ).first()
+            if existing:
+                return existing.author
+        return None
+
+    def _update_author(self, session: Session, author: Author, item: AuthorItem) -> None:
+        """Update an existing author with new data and add any missing identifiers."""
+        logger.info("Found existing author '%s' (id=%s) by identifier", author.full_name, author.id)
+
+        author.updated_at = datetime.now()
+
+        # Add any identifiers that don't already exist
+        self._add_missing_identifiers(session, author, item.identifiers)
+
+    @staticmethod
+    def _create_author_with_identifiers(session: Session, item: AuthorItem) -> Author:
+        """Create a new author with all provided identifiers."""
+        author = Author(
+            full_name=item.full_name,
+            first_name=item.first_name,
+            middle_names=item.middle_names,
+            last_name=item.last_name,
+            explicitly_searched=True,
+        )
+        session.add(author)
+        session.flush()  # Get the ID
+
+        logger.info(
+            "Created new author '%s' (id=%s) with %s identifier(s)",
+            author.full_name,
+            author.id,
+            len(item.identifiers),
+        )
+
+        for ident in item.identifiers:
+            author_identifier = AuthorIdentifier(
+                author_id=author.id,
+                authority=ident["authority"],
+                identifier=ident["identifier"],
+            )
+            session.add(author_identifier)
+            logger.debug(
+                "Added identifier %s:%s for author '%s'",
+                ident["authority"],
+                ident["identifier"],
+                author.full_name,
+            )
+
+        return author
+
+    @staticmethod
+    def _add_missing_identifiers(
+        session: Session,
+        author: Author,
+        identifiers: list[dict[str, str]],
+    ) -> None:
+        """Add identifiers that don't already exist for this author."""
+        existing_identifiers = {(ai.authority, ai.identifier) for ai in author.identifiers}
+
+        for ident in identifiers:
+            key = (ident["authority"], ident["identifier"])
+            if key not in existing_identifiers:
+                author_identifier = AuthorIdentifier(
+                    author_id=author.id,
+                    authority=ident["authority"],
+                    identifier=ident["identifier"],
+                )
+                session.add(author_identifier)
+                logger.info(
+                    "Added new identifier %s:%s for existing author '%s'",
+                    ident["authority"],
+                    ident["identifier"],
+                    author.full_name,
+                )

--- a/src/open_ire/pipelines/doi_normalization_pipeline.py
+++ b/src/open_ire/pipelines/doi_normalization_pipeline.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from open_ire.items import ArticleItem
 
 
@@ -36,6 +38,9 @@ class DOINormalizationPipeline:
 
         return doi
 
-    def process_item(self, item: ArticleItem) -> ArticleItem:
+    def process_item(self, item: Any) -> Any:
+        if not isinstance(item, ArticleItem):
+            return item
+
         item.doi = self.normalize(item.doi)
         return item

--- a/src/open_ire/pipelines/duplicates_pipeline.py
+++ b/src/open_ire/pipelines/duplicates_pipeline.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from scrapy.crawler import Crawler
 
 from open_ire.errors import DuplicateItemError
@@ -6,7 +8,7 @@ from open_ire.items import ArticleItem
 
 class DuplicatesPipeline:
     """
-    Drops duplicate items for a given spider session using the `reference` field.
+    Drops duplicate article items for a given spider session using the `reference` field.
     """
 
     def __init__(self) -> None:
@@ -22,7 +24,10 @@ class DuplicatesPipeline:
     def open_spider(self) -> None:
         pass
 
-    def process_item(self, item: ArticleItem) -> ArticleItem:
+    def process_item(self, item: Any) -> Any:
+        if not isinstance(item, ArticleItem):
+            return item
+
         if item.reference in self.seen:
             spider_name = (
                 self.crawler.spider.name

--- a/src/open_ire/pipelines/file_reference_pipeline.py
+++ b/src/open_ire/pipelines/file_reference_pipeline.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 from scrapy.crawler import Crawler
@@ -64,7 +65,10 @@ class FileReferencePipeline:
 
         return file_reference
 
-    async def process_item(self, item: ArticleItem) -> ArticleItem:
+    async def process_item(self, item: Any) -> Any:
+        if not isinstance(item, ArticleItem):
+            return item
+
         if self.crawler is None:
             msg = "Crawler context unavailable in FileReferencePipeline.process_item()."
             raise RuntimeError(msg)

--- a/src/open_ire/pipelines/sharepoint_pipeline.py
+++ b/src/open_ire/pipelines/sharepoint_pipeline.py
@@ -1,7 +1,7 @@
 import logging
 import math
 from pathlib import Path
-from typing import Self
+from typing import Any, Self
 
 from scrapy.crawler import Crawler
 
@@ -87,7 +87,10 @@ class SharePointPipeline:
 
         return store_url
 
-    async def process_item(self, item: ArticleItem) -> ArticleItem:
+    async def process_item(self, item: Any) -> Any:
+        if not isinstance(item, ArticleItem):
+            return item
+
         if not item.files:
             msg = f"No files found for article '{item.reference}'."
             logger.warning(msg)

--- a/src/open_ire/pipelines/skip_existing_pipeline.py
+++ b/src/open_ire/pipelines/skip_existing_pipeline.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from scrapy.crawler import Crawler
 from scrapy.exceptions import DropItem
@@ -27,7 +28,10 @@ class SkipExistingPipeline(BaseSQLModelPipeline):
 
         super().open_spider()
 
-    def process_item(self, item: ArticleItem) -> ArticleItem:
+    def process_item(self, item: Any) -> Any:
+        if not isinstance(item, ArticleItem):
+            return item
+
         if self.crawler is None or not self._should_skip_existing(self.crawler):
             return item
 

--- a/src/open_ire/pipelines/sql_model_pipeline.py
+++ b/src/open_ire/pipelines/sql_model_pipeline.py
@@ -120,7 +120,10 @@ class SQLModelPipeline(BaseSQLModelPipeline):
             session.rollback()
             raise DatabaseDuplicateItemError() from e
 
-    def process_item(self, item: ArticleItem) -> ArticleItem:
+    def process_item(self, item: Any) -> Any:
+        if not isinstance(item, ArticleItem):
+            return item
+
         article_files = self._get_article_files(item)
         file_references = self._get_article_file_references(item)
         item_data = item.model_dump(

--- a/src/open_ire/settings/base.py
+++ b/src/open_ire/settings/base.py
@@ -26,6 +26,8 @@ ITEM_PIPELINES = {
     # Filtering pipelines:
     "open_ire.pipelines.DuplicatesPipeline": 1,
     "open_ire.pipelines.SkipExistingPipeline": 2,
+    # Author identifier storage (early, before article processing):
+    "open_ire.pipelines.AuthorIdentifierPipeline": 5,
     # Data normalization pipelines:
     "open_ire.pipelines.DOINormalizationPipeline": 10,
     "open_ire.pipelines.DOIDuplicatesPipeline": 20,

--- a/tests/pipelines/conftest.py
+++ b/tests/pipelines/conftest.py
@@ -1,4 +1,5 @@
 from datetime import date
+from pathlib import Path
 from typing import cast
 from unittest.mock import MagicMock
 
@@ -8,6 +9,12 @@ from scrapy.crawler import Crawler
 from scrapy.settings import Settings
 
 from open_ire.items import ArticleItem
+
+
+@pytest.fixture
+def temp_db(tmp_path: Path) -> str:
+    """SQLite database URI for testing."""
+    return f"sqlite:///{tmp_path / 'test.db'}"
 
 
 @pytest.fixture

--- a/tests/pipelines/test_author_identifier_pipeline.py
+++ b/tests/pipelines/test_author_identifier_pipeline.py
@@ -54,7 +54,9 @@ class TestAuthorIdentifierPipeline:
         pipeline.process_item(item)
 
         with Session(pipeline.engine) as session:
-            author = session.exec(select(Author).where(Author.full_name == "Eunjung Kim")).first()
+            author = session.exec(
+                select(Author).where(Author.canonical_name == "Kim, Eunjung")
+            ).first()
 
             assert author is not None
             assert author.first_name == "Eunjung"
@@ -70,6 +72,8 @@ class TestAuthorIdentifierPipeline:
         # Create author with first item
         item1 = AuthorItem(
             full_name="Eunjung Kim",
+            first_name="Eunjung",
+            last_name="Kim",
             identifiers=[{"authority": "openalex", "identifier": "A5073669402"}],
         )
         pipeline.process_item(item1)
@@ -89,13 +93,15 @@ class TestAuthorIdentifierPipeline:
             assert len(authors) == 1  # No duplicate created
 
             author = authors[0]
-            assert author.full_name == "Eunjung Kim"  # Original name preserved
+            assert author.canonical_name == "Kim, Eunjung"  # Original name preserved
             assert len(author.identifiers) == 2  # ORCID was added
 
     def test_skips_item_without_identifiers(self, pipeline) -> None:
         """Items without identifiers are skipped."""
         item = AuthorItem(
             full_name="Test Author",
+            first_name="Test",
+            last_name="Author",
             identifiers=[],
         )
 

--- a/tests/pipelines/test_author_identifier_pipeline.py
+++ b/tests/pipelines/test_author_identifier_pipeline.py
@@ -96,17 +96,14 @@ class TestAuthorIdentifierPipeline:
             assert author.canonical_name == "Kim, Eunjung"  # Original name preserved
             assert len(author.identifiers) == 2  # ORCID was added
 
-    def test_skips_item_without_identifiers(self, pipeline) -> None:
-        """Items without identifiers are skipped."""
-        item = AuthorItem(
-            full_name="Test Author",
-            first_name="Test",
-            last_name="Author",
-            identifiers=[],
-        )
+    def test_finds_existing_author_by_name(self, pipeline) -> None:
+        """Existing author is found by name, not duplicated."""
+        item = AuthorItem(full_name="Test Author", identifiers=[])
+        pipeline.process_item(item)
 
+        item = AuthorItem(full_name="Test Author", identifiers=[])
         pipeline.process_item(item)
 
         with Session(pipeline.engine) as session:
             authors = session.exec(select(Author)).all()
-            assert len(authors) == 0
+            assert len(authors) == 1

--- a/tests/pipelines/test_author_identifier_pipeline.py
+++ b/tests/pipelines/test_author_identifier_pipeline.py
@@ -1,0 +1,106 @@
+"""Tests for AuthorIdentifierPipeline."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock
+
+import pytest
+from sqlmodel import Session, select
+
+from open_ire.items import ArticleItem, AuthorItem
+from open_ire.models import Author
+from open_ire.pipelines.author_identifier_pipeline import AuthorIdentifierPipeline
+
+
+@pytest.fixture
+def pipeline(temp_db: str) -> Generator[AuthorIdentifierPipeline, None, None]:
+    """Create a pipeline instance with test database."""
+    db_path = temp_db.replace("sqlite:///", "")
+    p = AuthorIdentifierPipeline(db_path)
+    p.open_spider()
+    yield p
+    p.close_spider()
+
+
+@pytest.fixture
+def mock_spider() -> MagicMock:
+    spider = MagicMock()
+    spider.name = "openalex"
+    return spider
+
+
+class TestAuthorIdentifierPipeline:
+    """Tests for author identifier storage pipeline."""
+
+    def test_passes_through_non_author_items(self, pipeline) -> None:
+        """Non-AuthorItem items are passed through unchanged."""
+        item = MagicMock(spec=ArticleItem)
+
+        result = pipeline.process_item(item)
+
+        assert result is item
+
+    def test_creates_author_with_identifiers(self, pipeline) -> None:
+        """New author and identifiers are created."""
+        item = AuthorItem(
+            full_name="Eunjung Kim",
+            first_name="Eunjung",
+            last_name="Kim",
+            identifiers=[
+                {"authority": "openalex", "identifier": "A5073669402"},
+                {"authority": "orcid", "identifier": "0000-0002-4664-9847"},
+            ],
+        )
+
+        pipeline.process_item(item)
+
+        with Session(pipeline.engine) as session:
+            author = session.exec(select(Author).where(Author.full_name == "Eunjung Kim")).first()
+
+            assert author is not None
+            assert author.first_name == "Eunjung"
+            assert author.last_name == "Kim"
+            assert author.explicitly_searched is True
+            assert len(author.identifiers) == 2
+
+            authorities = {ai.authority for ai in author.identifiers}
+            assert authorities == {"openalex", "orcid"}
+
+    def test_finds_existing_author_by_identifier(self, pipeline) -> None:
+        """Existing author is found by identifier, not duplicated."""
+        # Create author with first item
+        item1 = AuthorItem(
+            full_name="Eunjung Kim",
+            identifiers=[{"authority": "openalex", "identifier": "A5073669402"}],
+        )
+        pipeline.process_item(item1)
+
+        # Process second item with same OpenAlex ID but different name variant
+        item2 = AuthorItem(
+            full_name="Eun-Jung Kim",  # Different name variant
+            identifiers=[
+                {"authority": "openalex", "identifier": "A5073669402"},
+                {"authority": "orcid", "identifier": "0000-0002-4664-9847"},
+            ],
+        )
+        pipeline.process_item(item2)
+
+        with Session(pipeline.engine) as session:
+            authors = session.exec(select(Author)).all()
+            assert len(authors) == 1  # No duplicate created
+
+            author = authors[0]
+            assert author.full_name == "Eunjung Kim"  # Original name preserved
+            assert len(author.identifiers) == 2  # ORCID was added
+
+    def test_skips_item_without_identifiers(self, pipeline) -> None:
+        """Items without identifiers are skipped."""
+        item = AuthorItem(
+            full_name="Test Author",
+            identifiers=[],
+        )
+
+        pipeline.process_item(item)
+
+        with Session(pipeline.engine) as session:
+            authors = session.exec(select(Author)).all()
+            assert len(authors) == 0

--- a/tests/pipelines/test_base_sql_model_pipeline.py
+++ b/tests/pipelines/test_base_sql_model_pipeline.py
@@ -1,0 +1,59 @@
+"""Contract tests for BaseSQLModelPipeline subclasses."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from open_ire.errors import ConfigurationError
+from open_ire.pipelines import BaseSQLModelPipeline, SQLModelPipeline
+
+
+def _base_sql_model_pipeline_subclasses() -> list[type[BaseSQLModelPipeline]]:
+    return sorted(BaseSQLModelPipeline.__subclasses__(), key=lambda cls: cls.__name__)
+
+
+BASE_PIPELINE_SUBCLASSES = _base_sql_model_pipeline_subclasses()
+
+
+class TestBaseSQLModelPipeline:
+    """Contract tests for BaseSQLModelPipeline."""
+
+    @pytest.mark.parametrize("pipeline_cls", BASE_PIPELINE_SUBCLASSES)
+    def test_base_subclasses_do_not_override_from_crawler(
+        self,
+        pipeline_cls: type[BaseSQLModelPipeline],
+    ) -> None:
+        """Ensure subclasses inherit the shared from_crawler() setup."""
+        assert "from_crawler" not in pipeline_cls.__dict__, (
+            f"{pipeline_cls.__name__} overrides from_crawler(); this can bypass "
+            "BaseSQLModelPipeline setup and validations."
+        )
+
+    @pytest.mark.parametrize("pipeline_cls", BASE_PIPELINE_SUBCLASSES)
+    def test_base_subclasses_inherit_from_crawler_setup(
+        self, pipeline_cls: type[BaseSQLModelPipeline], tmp_path: Path
+    ) -> None:
+        missing_db = str(tmp_path / "missing_parent" / "open_ire.db")
+        crawler = SimpleNamespace(
+            settings={"OPEN_IRE_DATABASE_FILE": missing_db, "FILES_STORE": str(tmp_path)}
+        )
+
+        pipeline = pipeline_cls.from_crawler(crawler)  # type: ignore[arg-type]
+
+        assert isinstance(pipeline, pipeline_cls)
+        assert pipeline.crawler is crawler
+        assert Path(missing_db).parent.exists()
+
+    def test_from_crawler_raises_if_open_ire_database_file_missing(self, tmp_path: Path) -> None:
+        crawler = SimpleNamespace(settings={"FILES_STORE": str(tmp_path)})
+
+        with pytest.raises(ConfigurationError, match="OPEN_IRE_DATABASE_FILE"):
+            SQLModelPipeline.from_crawler(crawler)  # type: ignore[arg-type]
+
+    def test_from_crawler_raises_if_files_store_missing(self, tmp_path: Path) -> None:
+        db_path = str(tmp_path / "dbs" / "open_ire.db")
+        crawler = SimpleNamespace(settings={"OPEN_IRE_DATABASE_FILE": db_path})
+
+        with pytest.raises(ConfigurationError, match="FILES_STORE"):
+            SQLModelPipeline.from_crawler(crawler)  # type: ignore[arg-type]

--- a/tests/pipelines/test_doi_normalization_pipeline.py
+++ b/tests/pipelines/test_doi_normalization_pipeline.py
@@ -1,4 +1,5 @@
 from typing import Any, cast
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -13,6 +14,14 @@ class TestDOINormalizationPipeline:
     def pipeline(self) -> DOINormalizationPipeline:
         """Create a pipeline instance for testing."""
         return DOINormalizationPipeline()
+
+    def test_passes_through_non_article_items(self, pipeline: DOINormalizationPipeline) -> None:
+        """Test that non-ArticleItem items are passed through unchanged."""
+        item = MagicMock(spec=Any)
+
+        result = pipeline.process_item(item)
+
+        assert result is item
 
     def test_normalize_full_doi_url(
         self, pipeline: DOINormalizationPipeline, item: ArticleItem

--- a/tests/pipelines/test_duplicates_pipeline.py
+++ b/tests/pipelines/test_duplicates_pipeline.py
@@ -1,3 +1,6 @@
+from typing import Any
+from unittest.mock import MagicMock
+
 import pytest
 from scrapy.crawler import Crawler
 from scrapy.exceptions import DropItem
@@ -16,6 +19,13 @@ class TestDuplicatesPipeline:
         assert pipeline.crawler is not None
         assert pipeline.crawler.spider is not None
         return pipeline
+
+    def test_passes_through_non_article_items(self, pipeline: DuplicatesPipeline) -> None:
+        """Test that non-ArticleItem items are passed through unchanged."""
+        item = MagicMock(spec=Any)
+        result = pipeline.process_item(item)
+
+        assert result is item
 
     def test_process_unique_item(self, pipeline: DuplicatesPipeline, item: ArticleItem) -> None:
         """Test processing a unique item."""

--- a/tests/pipelines/test_sharepoint_pipeline.py
+++ b/tests/pipelines/test_sharepoint_pipeline.py
@@ -31,6 +31,14 @@ class TestSharePointPipeline:
             return pipeline
 
     @pytest.mark.asyncio
+    async def test_passes_through_non_article_items(self, pipeline: SharePointPipeline) -> None:
+        """Test that non-ArticleItem items are passed through unchanged."""
+        item = MagicMock(spec=Any)
+        result = await pipeline.process_item(item)
+
+        assert result is item
+
+    @pytest.mark.asyncio
     async def test_item_with_files(
         self, pipeline: SharePointPipeline, item: ArticleItem, tmp_path: Path
     ) -> None:

--- a/tests/pipelines/test_skip_existing_pipeline.py
+++ b/tests/pipelines/test_skip_existing_pipeline.py
@@ -1,4 +1,6 @@
 from collections.abc import Generator
+from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from scrapy.crawler import Crawler
@@ -41,6 +43,15 @@ class TestSkipExistingPipeline:
         self, pipeline_disabled: SkipExistingPipeline, item: ArticleItem
     ) -> None:
         result = pipeline_disabled.process_item(item)
+
+        assert result is item
+
+    def test_passes_through_non_article_items(
+        self, pipeline_enabled: SkipExistingPipeline, item: Any
+    ) -> None:
+        """Test that non-ArticleItem items are passed through unchanged."""
+        item = MagicMock(spec=Any)
+        result = pipeline_enabled.process_item(item)
 
         assert result is item
 

--- a/tests/pipelines/test_sql_model_pipeline.py
+++ b/tests/pipelines/test_sql_model_pipeline.py
@@ -1,6 +1,4 @@
 from collections.abc import Generator
-from pathlib import Path
-from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -190,11 +188,3 @@ class TestSQLModelPipeline:
         with Session(pipeline.engine) as session:
             file_refs = session.exec(select(ArticleFileReference)).all()
             assert len(file_refs) == 1
-
-    def test_from_crawler_creates_missing_db_parent_dir(self, tmp_path: Path) -> None:
-        missing_db = str(tmp_path / "missing_parent" / "open_ire.db")
-        crawler = SimpleNamespace(
-            settings={"OPEN_IRE_DATABASE_FILE": missing_db, "FILES_STORE": str(tmp_path)}
-        )
-        SQLModelPipeline.from_crawler(crawler)  # type: ignore[arg-type]
-        assert Path(missing_db).parent.exists()

--- a/tests/pipelines/test_sql_model_pipeline.py
+++ b/tests/pipelines/test_sql_model_pipeline.py
@@ -1,6 +1,8 @@
 from collections.abc import Generator
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from scrapy.crawler import Crawler
@@ -25,6 +27,13 @@ class TestSQLModelPipeline:
         assert instance.engine is not None
         yield instance
         instance.engine.dispose()
+
+    def test_passes_through_non_article_items(self, pipeline: SQLModelPipeline) -> None:
+        """Test that non-ArticleItem items are passed through unchanged."""
+        item = MagicMock(spec=Any)
+        result = pipeline.process_item(item)
+
+        assert result is item
 
     def test_process_valid_item(self, pipeline: SQLModelPipeline, item: ArticleItem) -> None:
         """A valid item is processed successfully."""

--- a/tests/test_author_models.py
+++ b/tests/test_author_models.py
@@ -57,7 +57,12 @@ class TestAuthorModelRelationships:
             url="https://example.com/test",
         )
 
-        author = Author(full_name="Test Author", first_name="Test", last_name="Author")
+        author = Author(
+            full_name="Test Author",
+            first_name="Test",
+            last_name="Author",
+            canonical_name="Author, Test",
+        )
 
         # Add to session to get IDs
         session.add(article)
@@ -101,8 +106,18 @@ class TestAuthorModelRelationships:
             url="https://example.com/test2",
         )
 
-        author1 = Author(full_name="Author One", first_name="Author", last_name="One")
-        author2 = Author(full_name="Author Two", first_name="Author", last_name="Two")
+        author1 = Author(
+            full_name="Author One",
+            first_name="Author",
+            last_name="One",
+            canonical_name="One, Author",
+        )
+        author2 = Author(
+            full_name="Author Two",
+            first_name="Author",
+            last_name="Two",
+            canonical_name="Two, Author",
+        )
 
         session.add_all([article, author1, author2])
         session.commit()
@@ -125,7 +140,12 @@ class TestAuthorModelRelationships:
 
     def test_multiple_articles_per_author(self, session: Session):
         """Test that an author can be associated with multiple articles."""
-        author = Author(full_name="Prolific Author", first_name="Prolific", last_name="Author")
+        author = Author(
+            full_name="Prolific Author",
+            first_name="Prolific",
+            last_name="Author",
+            canonical_name="Author, Prolific",
+        )
 
         article1 = Article(
             title="First Article",
@@ -166,7 +186,12 @@ class TestAuthorModelRelationships:
 
     def test_author_identifiers_relationship(self, session: Session):
         """Test that author identifiers are properly linked to authors."""
-        author = Author(full_name="Identified Author", first_name="Identified", last_name="Author")
+        author = Author(
+            full_name="Identified Author",
+            first_name="Identified",
+            last_name="Author",
+            canonical_name="Author, Identified",
+        )
 
         session.add(author)
         session.commit()
@@ -194,7 +219,12 @@ class TestAuthorModelRelationships:
 
     def test_delete_author_removes_identifiers(self, session: Session):
         """Deleting an author should remove related identifier rows."""
-        author = Author(full_name="Identified Author", first_name="Identified", last_name="Author")
+        author = Author(
+            full_name="Identified Author",
+            first_name="Identified",
+            last_name="Author",
+            canonical_name="Author, Identified",
+        )
         session.add(author)
         session.commit()
         session.refresh(author)
@@ -215,6 +245,15 @@ class TestAuthorModelRelationships:
 
         assert len(session.exec(select(AuthorIdentifier)).all()) == 0
 
+    def test_author_requires_canonical_name(self, session: Session):
+        """Creating an author without canonical_name should fail at commit time."""
+        author = Author(full_name="Missing Canonical", first_name="Missing", last_name="Canonical")
+        session.add(author)
+
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+
     def test_delete_junction_keeps_article_and_author(self, session: Session):
         """Test that relationships are maintained when objects are deleted."""
         # Create test data
@@ -227,7 +266,12 @@ class TestAuthorModelRelationships:
             url="https://example.com/test5",
         )
 
-        author = Author(full_name="Cascade Author", first_name="Cascade", last_name="Author")
+        author = Author(
+            full_name="Cascade Author",
+            first_name="Cascade",
+            last_name="Author",
+            canonical_name="Author, Cascade",
+        )
 
         session.add_all([article, author])
         session.commit()
@@ -261,7 +305,12 @@ class TestAuthorModelRelationships:
             reference="test_ref_006",
             url="https://example.com/test6",
         )
-        author = Author(full_name="Cascade Author", first_name="Cascade", last_name="Author")
+        author = Author(
+            full_name="Cascade Author",
+            first_name="Cascade",
+            last_name="Author",
+            canonical_name="Author, Cascade",
+        )
         session.add_all([article, author])
         session.commit()
         session.refresh(article)
@@ -287,7 +336,12 @@ class TestAuthorModelRelationships:
             reference="test_ref_007",
             url="https://example.com/test7",
         )
-        author = Author(full_name="Cascade Author", first_name="Cascade", last_name="Author")
+        author = Author(
+            full_name="Cascade Author",
+            first_name="Cascade",
+            last_name="Author",
+            canonical_name="Author, Cascade",
+        )
         session.add_all([article, author])
         session.commit()
         session.refresh(article)
@@ -306,7 +360,12 @@ class TestAuthorModelRelationships:
 
 class TestAuthorAffiliations:
     def test_author_affiliation_relationship(self, session: Session):
-        author = Author(full_name="Affiliated Author", first_name="Affiliated", last_name="Author")
+        author = Author(
+            full_name="Affiliated Author",
+            first_name="Affiliated",
+            last_name="Author",
+            canonical_name="Author, Affiliated",
+        )
         session.add(author)
         session.commit()
         session.refresh(author)
@@ -324,7 +383,12 @@ class TestAuthorAffiliations:
 
     def test_delete_author_removes_affiliations(self, session: Session):
         """Deleting an author should remove related affiliation rows."""
-        author = Author(full_name="Affiliated Author", first_name="Affiliated", last_name="Author")
+        author = Author(
+            full_name="Affiliated Author",
+            first_name="Affiliated",
+            last_name="Author",
+            canonical_name="Author, Affiliated",
+        )
         session.add(author)
         session.commit()
         session.refresh(author)
@@ -348,7 +412,12 @@ class TestAuthorAffiliations:
             AuthorAffiliation.model_validate({"author_id": 1, "year": 1899})
 
     def test_author_affiliation_year_check_constraint(self, session: Session):
-        author = Author(full_name="Bounded Year Author", first_name="Bounded", last_name="Author")
+        author = Author(
+            full_name="Bounded Year Author",
+            first_name="Bounded",
+            last_name="Author",
+            canonical_name="Author, Bounded",
+        )
         session.add(author)
         session.commit()
         session.refresh(author)
@@ -359,7 +428,12 @@ class TestAuthorAffiliations:
         session.rollback()
 
     def test_author_affiliation_unique_author_year(self, session: Session):
-        author = Author(full_name="Unique Year Author", first_name="Unique", last_name="Author")
+        author = Author(
+            full_name="Unique Year Author",
+            first_name="Unique",
+            last_name="Author",
+            canonical_name="Author, Unique",
+        )
         session.add(author)
         session.commit()
         session.refresh(author)


### PR DESCRIPTION
The pipeline handles `AuthorItem`s that AuthorSearchSpider (in an incoming PR) will generate alongside Requests that will end up generating `ArticleItem`s.