### PR TITLE
Collect OA evidence from DOAJ

### DIFF
--- a/src/open_ire/pipelines/doi_normalization_pipeline.py
+++ b/src/open_ire/pipelines/doi_normalization_pipeline.py
@@ -1,3 +1,6 @@
+import re
+from urllib.parse import unquote
+
 from open_ire.items import ArticleItem
 
 
@@ -15,7 +18,7 @@ class DOINormalizationPipeline:
         if not isinstance(doi, str) or not doi.strip():
             return None
 
-        doi = doi.strip()
+        doi = unquote(doi.strip())
         prefixes = [
             "https://doi.org/",
             "http://doi.org/",
@@ -25,16 +28,20 @@ class DOINormalizationPipeline:
             "doi:",
         ]
         for prefix in prefixes:
-            if doi.lower().startswith(prefix.lower()):
-                doi = doi[len(prefix) :]
-                break
+            while doi.lower().startswith(prefix.lower()):
+                doi = doi[len(prefix) :].strip()
 
-        doi = doi.strip()
+        doi = doi.strip().lstrip("/")
 
-        if not doi.startswith("10.") or "/" not in doi:
-            return None
+        if doi.startswith("10.") and "/" in doi:
+            return doi
 
-        return doi
+        doi_pattern = re.compile(r"10\.\d{4,9}/[^\s\"<>]+", re.IGNORECASE)
+        match = doi_pattern.search(doi)
+        if match:
+            return match.group(0)
+
+        return None
 
     def process_item(self, item: ArticleItem) -> ArticleItem:
         item.doi = self.normalize(item.doi)

--- a/src/open_ire/spiders/oa_doaj.py
+++ b/src/open_ire/spiders/oa_doaj.py
@@ -1,0 +1,241 @@
+import json
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote
+
+from scrapy.http import Request, Response
+from sqlmodel import Session, col, select
+
+from open_ire.enums import DepositTransitionReason, OAEvidenceKind
+from open_ire.models import Article
+from open_ire.pipelines import DOINormalizationPipeline
+from open_ire.spiders.oa_evidence import BaseOAEvidenceSpider
+
+
+class LogMessages:
+    ARTICLES_FOUND = "Found %d candidate articles for DOAJ lookup"
+    EVIDENCE_SAVED = "Saved DOAJ evidence for article %s (supports_oa=%s, strategy=%s)"
+    SEARCH_ERROR = "DOAJ lookup failed for article %s (%s)"
+    SEARCH_STATUS_ERROR = "DOAJ returned status %s for article %s"
+    SEARCH_INVALID_JSON = "DOAJ returned invalid JSON for article %s"
+    SKIPPING_ARTICLE = "Skipping article %s - already has evidence"
+
+
+@dataclass(frozen=True, slots=True)
+class _ArticleCandidate:
+    article_id: uuid.UUID
+    doi: str
+
+
+class OADOAJSpider(BaseOAEvidenceSpider):
+    """Fetch OA evidence from DOAJ using DOI article matching."""
+
+    name = "oa_doaj"
+    base_url = "https://doaj.org/api"
+    search_endpoint = "articles"
+    match_strategy = "article_doi"
+
+    @staticmethod
+    def build_search_query(candidate: _ArticleCandidate) -> str:
+        return f"doi:{candidate.doi}"
+
+    @staticmethod
+    def extract_bibjson(result: dict[str, Any]) -> dict[str, Any] | None:
+        bibjson = result.get("bibjson", {})
+        return bibjson if isinstance(bibjson, dict) else None
+
+    def has_existing_evidence(self, article_id: uuid.UUID) -> bool:
+        return self.has_any_oa_evidence(article_id)
+
+    def query_article_candidates(self) -> list[_ArticleCandidate]:
+        if not self.engine:
+            return []
+
+        with Session(self.engine) as session:
+            rows = session.exec(
+                select(Article.id, Article.doi).where(
+                    col(Article.doi).is_not(None),
+                    col(Article.doi) != "",
+                )
+            ).all()
+
+        candidates: list[_ArticleCandidate] = []
+        for article_id, doi in rows:
+            normalized_doi = DOINormalizationPipeline.normalize(doi)
+            if not normalized_doi:
+                continue
+
+            candidates.append(_ArticleCandidate(article_id=article_id, doi=normalized_doi))
+
+        return candidates
+
+    def build_search_request(
+        self,
+        candidate: _ArticleCandidate,
+    ) -> Request:
+        query = self.build_search_query(candidate)
+        encoded_query = quote(query, safe=":")
+        url = f"{self.base_url}/search/{self.search_endpoint}/{encoded_query}"
+
+        return Request(
+            url,
+            headers=self.request_headers,
+            callback=self.parse_search_response,
+            errback=self.handle_search_error,
+            cb_kwargs={
+                "candidate": candidate,
+            },
+            dont_filter=True,
+        )
+
+    def match_article_by_doi(
+        self, results: list[dict[str, Any]], expected_doi: str
+    ) -> dict[str, Any] | None:
+        normalized_expected_doi = DOINormalizationPipeline.normalize(expected_doi)
+        if not normalized_expected_doi:
+            return None
+
+        matches: list[dict[str, Any]] = []
+        for result in results:
+            bibjson = self.extract_bibjson(result)
+            if not bibjson:
+                continue
+
+            identifiers = bibjson.get("identifier", [])
+            if not isinstance(identifiers, list):
+                continue
+
+            normalized_result_dois: set[str] = set()
+            for identifier in identifiers:
+                if not isinstance(identifier, dict):
+                    continue
+
+                if identifier.get("type") != "doi":
+                    continue
+
+                normalized_doi = DOINormalizationPipeline.normalize(identifier.get("id"))
+                if normalized_doi:
+                    normalized_result_dois.add(normalized_doi)
+
+            if normalized_expected_doi in normalized_result_dois:
+                matches.append(result)
+
+        if len(matches) != 1:
+            return None
+
+        match = matches[0]
+        bibjson = self.extract_bibjson(match) or {}
+        return {
+            "supports_oa": True,
+            "allow_transition": True,
+            "confidence": "high",
+            "match_record": {
+                "id": match.get("id"),
+                "title": bibjson.get("title"),
+                "journal": bibjson.get("journal"),
+                "identifier": bibjson.get("identifier"),
+            },
+        }
+
+    def save_doaj_evidence(
+        self,
+        article_id: uuid.UUID,
+        *,
+        supports_oa: bool,
+        allow_transition: bool,
+        evidence_data: dict[str, Any],
+    ) -> None:
+        self.save_oa_evidence(
+            article_id,
+            kind=OAEvidenceKind.EXTERNAL_OA,
+            source="doaj",
+            supports_oa=supports_oa,
+            data=evidence_data,
+            transition_reason=DepositTransitionReason.EXTERNAL_OA,
+            allow_transition=allow_transition,
+        )
+
+    @classmethod
+    def build_evidence_data(
+        cls,
+        candidate: _ArticleCandidate,
+        attempts: list[dict[str, Any]],
+        match_data: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "attempts": attempts,
+            "matched": True,
+            "match_strategy": cls.match_strategy,
+            "confidence": match_data.get("confidence"),
+            "match_record": match_data.get("match_record"),
+            "article_input": {
+                "doi": candidate.doi,
+            },
+        }
+
+    def parse_search_response(
+        self,
+        response: Response,
+        candidate: _ArticleCandidate,
+    ) -> Request | None:
+        query = self.build_search_query(candidate)
+
+        if response.status != 200:
+            self.logger.debug(
+                LogMessages.SEARCH_STATUS_ERROR, response.status, candidate.article_id
+            )
+            return None
+
+        try:
+            payload = json.loads(response.text or "{}")
+        except json.JSONDecodeError:
+            self.logger.warning(LogMessages.SEARCH_INVALID_JSON, candidate.article_id)
+            return None
+
+        results_raw = payload.get("results", [])
+        results = [result for result in results_raw if isinstance(result, dict)]
+        attempts = [
+            {
+                "strategy": self.match_strategy,
+                "endpoint": self.search_endpoint,
+                "query": query,
+                "status": response.status,
+                "total": payload.get("total"),
+                "results_count": len(results),
+            }
+        ]
+
+        match_data = self.match_article_by_doi(results, candidate.doi)
+        if not match_data:
+            return None
+
+        supports_oa = bool(match_data.get("supports_oa"))
+        allow_transition = bool(match_data.get("allow_transition"))
+        self.save_doaj_evidence(
+            candidate.article_id,
+            supports_oa=supports_oa,
+            allow_transition=allow_transition,
+            evidence_data=self.build_evidence_data(candidate, attempts, match_data),
+        )
+        self.logger.info(
+            LogMessages.EVIDENCE_SAVED, candidate.article_id, supports_oa, self.match_strategy
+        )
+        return None
+
+    def handle_search_error(self, failure: Any) -> None:
+        request = failure.request
+        candidate = request.cb_kwargs["candidate"]
+        self.logger.debug(LogMessages.SEARCH_ERROR, candidate.article_id, failure.value)
+
+    async def start(self) -> AsyncIterator[Request]:
+        candidates = self.query_article_candidates()
+        self.logger.info(LogMessages.ARTICLES_FOUND, len(candidates))
+
+        for candidate in candidates:
+            if self.has_existing_evidence(candidate.article_id):
+                self.logger.debug(LogMessages.SKIPPING_ARTICLE, candidate.article_id)
+                continue
+
+            yield self.build_search_request(candidate)

--- a/src/open_ire/spiders/oa_evidence.py
+++ b/src/open_ire/spiders/oa_evidence.py
@@ -4,7 +4,6 @@ from typing import Any, Self
 from scrapy import Spider
 from sqlalchemy.engine import Engine
 from sqlmodel import Session, SQLModel, col, create_engine, select
-from twisted.internet.defer import Deferred
 
 from open_ire.enums import DepositStatus, DepositTransitionReason, OAEvidenceKind
 from open_ire.models import Article, ArticleDepositStatusTransition, ArticleOAEvidence
@@ -39,14 +38,9 @@ class BaseOAEvidenceSpider(Spider):
 
         return spider
 
-    @staticmethod
-    def close(spider: Spider, reason: str) -> Deferred[None] | None:
-        close_result = Spider.close(spider, reason)
-
-        if isinstance(spider, BaseOAEvidenceSpider) and spider.engine:
-            spider.engine.dispose()
-
-        return close_result
+    def closed(self, reason: str) -> None:  # noqa: ARG002
+        if self.engine:
+            self.engine.dispose()
 
     def has_oa_evidence(
         self,

--- a/src/open_ire/spiders/oa_evidence.py
+++ b/src/open_ire/spiders/oa_evidence.py
@@ -1,0 +1,131 @@
+import uuid
+from typing import Any, Self
+
+from scrapy import Spider
+from sqlalchemy.engine import Engine
+from sqlmodel import Session, SQLModel, col, create_engine, select
+from twisted.internet.defer import Deferred
+
+from open_ire.enums import DepositStatus, DepositTransitionReason, OAEvidenceKind
+from open_ire.models import Article, ArticleDepositStatusTransition, ArticleOAEvidence
+from open_ire.settings import OPEN_IRE_CONTACT_EMAIL
+
+
+class BaseOAEvidenceSpider(Spider):
+    custom_settings = {  # noqa: RUF012
+        "AUTOTHROTTLE_TARGET_CONCURRENCY": 2.0,
+        "DOWNLOAD_DELAY": 1,
+        "ITEM_PIPELINES": {},
+        "ROBOTSTXT_OBEY": False,
+    }
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.engine: Engine | None = None
+        self.request_headers = {
+            "User-Agent": f"mailto:{OPEN_IRE_CONTACT_EMAIL}",
+            "Accept": "application/json",
+        }
+
+    @classmethod
+    def from_crawler(cls, crawler: Any, *args: Any, **kwargs: Any) -> Self:
+        spider = super().from_crawler(crawler, *args, **kwargs)
+        db_path = crawler.settings.get("OPEN_IRE_DATABASE_FILE")
+        if db_path:
+            spider.engine = create_engine(
+                f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+            )
+            SQLModel.metadata.create_all(spider.engine)
+
+        return spider
+
+    @staticmethod
+    def close(spider: Spider, reason: str) -> Deferred[None] | None:
+        close_result = Spider.close(spider, reason)
+
+        if isinstance(spider, BaseOAEvidenceSpider) and spider.engine:
+            spider.engine.dispose()
+
+        return close_result
+
+    def has_oa_evidence(
+        self,
+        article_id: uuid.UUID,
+        *,
+        kind: OAEvidenceKind,
+        sources: list[str] | None = None,
+    ) -> bool:
+        if not self.engine:
+            return False
+
+        with Session(self.engine) as session:
+            statement = select(ArticleOAEvidence).where(
+                ArticleOAEvidence.article_id == article_id,
+                ArticleOAEvidence.kind == kind,
+            )
+            if sources:
+                statement = statement.where(col(ArticleOAEvidence.source).in_(sources))
+
+            return session.exec(statement).first() is not None
+
+    def has_any_oa_evidence(self, article_id: uuid.UUID) -> bool:
+        if not self.engine:
+            return False
+
+        with Session(self.engine) as session:
+            statement = select(ArticleOAEvidence).where(ArticleOAEvidence.article_id == article_id)
+            return session.exec(statement).first() is not None
+
+    def save_oa_evidence(
+        self,
+        article_id: uuid.UUID,
+        *,
+        kind: OAEvidenceKind,
+        source: str,
+        supports_oa: bool,
+        data: dict[str, Any] | None = None,
+        transition_reason: DepositTransitionReason | None = None,
+        allow_transition: bool = True,
+    ) -> None:
+        if not self.engine:
+            self.logger.error("No database engine available")
+            return
+
+        with Session(self.engine) as session:
+            article = session.get(Article, article_id)
+            if not article:
+                self.logger.warning("Article %s not found in database", article_id)
+                return
+
+            current_status = article.deposit_status
+
+            evidence = ArticleOAEvidence(
+                article_id=article_id,
+                kind=kind,
+                supports_oa=supports_oa,
+                source=source,
+                data=data or {},
+            )
+            session.add(evidence)
+
+            if (
+                supports_oa
+                and allow_transition
+                and transition_reason
+                and current_status not in (DepositStatus.READY, DepositStatus.PUBLISHED)
+            ):
+                transition = ArticleDepositStatusTransition(
+                    article_id=article_id,
+                    from_status=current_status,
+                    to_status=DepositStatus.READY,
+                    reasons=[transition_reason],
+                )
+                session.add(transition)
+                self.logger.info(
+                    "Article %s transitioned to READY based on %s evidence from %s",
+                    article_id,
+                    kind,
+                    source,
+                )
+
+            session.commit()

--- a/src/open_ire/spiders/oa_license.py
+++ b/src/open_ire/spiders/oa_license.py
@@ -4,15 +4,13 @@ from collections.abc import AsyncIterator
 from typing import Any
 from urllib.parse import quote
 
-from scrapy import Spider
 from scrapy.http import Request, Response
-from sqlalchemy import Engine
-from sqlmodel import Session, create_engine, select
+from sqlmodel import Session, col, select
 
-from open_ire.enums import DepositStatus, DepositTransitionReason, OAEvidenceKind
-from open_ire.models import Article, ArticleDepositStatusTransition, ArticleOAEvidence
+from open_ire.enums import DepositTransitionReason, OAEvidenceKind
+from open_ire.models import Article
 from open_ire.pipelines import DOINormalizationPipeline
-from open_ire.settings import OPEN_IRE_CONTACT_EMAIL
+from open_ire.spiders.oa_evidence import BaseOAEvidenceSpider
 
 
 class LogMessages:
@@ -29,7 +27,7 @@ class LogMessages:
     SKIPPING_ARTICLE = "Skipping article %s - already has license evidence"
 
 
-class OALicenseSpider(Spider):
+class OALicenseSpider(BaseOAEvidenceSpider):
     """
     Fetch license information from Crossref and DataCite APIs.
     This spider queries the database for articles with DOIs, then:
@@ -42,22 +40,6 @@ class OALicenseSpider(Spider):
     name = "oa_license"
     crossref_base_url = "https://api.crossref.org/works"
     datacite_base_url = "https://api.datacite.org/dois"
-
-    custom_settings = {  # noqa: RUF012
-        "AUTOTHROTTLE_TARGET_CONCURRENCY": 2.0,
-        "DOWNLOAD_DELAY": 1,
-        "ITEM_PIPELINES": {},
-        "ROBOTSTXT_OBEY": False,
-    }
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self.engine: Engine | None = None
-        self.contact_email = OPEN_IRE_CONTACT_EMAIL
-        self.request_headers = {
-            "User-Agent": f"mailto:{OPEN_IRE_CONTACT_EMAIL}",
-            "Accept": "application/json",
-        }
 
     @staticmethod
     def is_oa_license(license_url: str | None) -> bool:
@@ -150,60 +132,24 @@ class OALicenseSpider(Spider):
             "supports_oa": supports_oa,
         }
 
-    @classmethod
-    def from_crawler(cls, crawler: Any, *args: Any, **kwargs: Any) -> "OALicenseSpider":
-        spider = super().from_crawler(crawler, *args, **kwargs)
-        db_path = crawler.settings.get("OPEN_IRE_DATABASE_FILE")
-        if db_path:
-            spider.engine = create_engine(
-                f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
-            )
-
-        return spider
-
-    def closed(self, reason: str) -> None:  # noqa: ARG002
-        """Clean up database engine when spider closes."""
-        if self.engine:
-            self.engine.dispose()
-
     def query_articles_with_doi(self) -> list[tuple[uuid.UUID, str]]:
         if not self.engine:
             return []
 
         with Session(self.engine) as session:
             statement = select(Article.id, Article.doi).where(
-                Article.doi.isnot(None),  # type: ignore[union-attr]
-                Article.doi != "",
+                col(Article.doi).is_not(None),
+                col(Article.doi) != "",
             )
             results = session.exec(statement).all()
             return [(row[0], row[1]) for row in results if row[1]]
 
     def has_license_evidence(self, article_id: uuid.UUID) -> bool:
-        if not self.engine:
-            return False
-
-        with Session(self.engine) as session:
-            statement = select(ArticleOAEvidence).where(
-                ArticleOAEvidence.article_id == article_id,
-                ArticleOAEvidence.kind == OAEvidenceKind.LICENSE,
-                ArticleOAEvidence.source.in_(["crossref", "datacite"]),  # type: ignore[union-attr]
-            )
-            return session.exec(statement).first() is not None
-
-    async def start(self) -> AsyncIterator[Request]:
-        articles = self.query_articles_with_doi()
-        self.logger.info(LogMessages.ARTICLES_FOUND, len(articles))
-
-        for article_id, doi in articles:
-            if self.has_license_evidence(article_id):
-                self.logger.debug(LogMessages.SKIPPING_ARTICLE, article_id)
-                continue
-
-            normalized_doi = DOINormalizationPipeline.normalize(doi)
-            if not normalized_doi:
-                continue
-
-            yield self.build_crossref_request(article_id, normalized_doi)
+        return self.has_oa_evidence(
+            article_id,
+            kind=OAEvidenceKind.LICENSE,
+            sources=["crossref", "datacite"],
+        )
 
     def build_crossref_request(self, article_id: uuid.UUID, doi: str) -> Request:
         encoded_doi = quote(doi, safe="")
@@ -306,43 +252,32 @@ class OALicenseSpider(Spider):
         source: str,
         license_data: dict[str, Any],
     ) -> None:
-        if not self.engine:
-            self.logger.error(LogMessages.NO_DATABASE_ENGINE)
-            return
-
         supports_oa = license_data.get("supports_oa", False)
+        self.save_oa_evidence(
+            article_id,
+            kind=OAEvidenceKind.LICENSE,
+            source=source,
+            supports_oa=supports_oa,
+            data={
+                "doi": doi,
+                "license_urls": license_data.get("license_urls", []),
+                "license_details": license_data.get("license_details", []),
+            },
+            transition_reason=DepositTransitionReason.LICENSE_OA,
+        )
+        self.logger.info(LogMessages.LICENSE_EVIDENCE_SAVED, article_id, source, supports_oa)
 
-        with Session(self.engine) as session:
-            article = session.get(Article, article_id)
-            if not article:
-                self.logger.warning(LogMessages.ARTICLE_NOT_FOUND, article_id)
-                return
+    async def start(self) -> AsyncIterator[Request]:
+        articles = self.query_articles_with_doi()
+        self.logger.info(LogMessages.ARTICLES_FOUND, len(articles))
 
-            current_status = article.deposit_status
-            evidence = ArticleOAEvidence(
-                article_id=article_id,
-                kind=OAEvidenceKind.LICENSE,
-                supports_oa=supports_oa,
-                source=source,
-                data={
-                    "doi": doi,
-                    "license_urls": license_data.get("license_urls", []),
-                    "license_details": license_data.get("license_details", []),
-                },
-            )
-            session.add(evidence)
+        for article_id, doi in articles:
+            if self.has_license_evidence(article_id):
+                self.logger.debug(LogMessages.SKIPPING_ARTICLE, article_id)
+                continue
 
-            if supports_oa and current_status not in (DepositStatus.READY, DepositStatus.PUBLISHED):
-                transition = ArticleDepositStatusTransition(
-                    article_id=article_id,
-                    from_status=current_status,
-                    to_status=DepositStatus.READY,
-                    reasons=[DepositTransitionReason.LICENSE_OA],
-                )
-                session.add(transition)
+            normalized_doi = DOINormalizationPipeline.normalize(doi)
+            if not normalized_doi:
+                continue
 
-                self.logger.info(LogMessages.ARTICLE_TRANSITIONED, article_id, source)
-
-            session.commit()
-
-            self.logger.info(LogMessages.LICENSE_EVIDENCE_SAVED, article_id, source, supports_oa)
+            yield self.build_crossref_request(article_id, normalized_doi)

--- a/src/open_ire/spiders/unavailable_articles.py
+++ b/src/open_ire/spiders/unavailable_articles.py
@@ -10,7 +10,6 @@ from scrapy.exporters import CsvItemExporter
 from scrapy.http import Request, Response
 from sqlalchemy import Engine
 from sqlmodel import asc, create_engine, select
-from twisted.internet.defer import Deferred
 from twisted.python.failure import Failure
 
 from open_ire.items import UnavailableArticleItem
@@ -130,19 +129,6 @@ class UnavailableArticlesSpider(Spider):
         self.repository_stats: dict[str, _RepositoryAvailabilityStats] = defaultdict(
             _RepositoryAvailabilityStats
         )
-
-    @staticmethod
-    def close(spider: Spider, reason: str) -> Deferred[None] | None:
-        close_result = Spider.close(spider, reason)
-
-        if isinstance(spider, UnavailableArticlesSpider):
-            spider.exporter.close()
-            spider._log_summary(reason)
-
-            if spider.engine:
-                spider.engine.dispose()
-
-        return close_result
 
     @classmethod
     def from_crawler(cls, crawler: Any, *args: Any, **kwargs: Any) -> "UnavailableArticlesSpider":
@@ -292,6 +278,13 @@ class UnavailableArticlesSpider(Spider):
                 repository_stats.http_errors,
                 repository_stats.request_errors,
             )
+
+    def closed(self, reason: str) -> None:
+        self.exporter.close()
+        self._log_summary(reason)
+
+        if self.engine:
+            self.engine.dispose()
 
     async def start(self) -> AsyncIterator[Request]:
         if not self.engine:

--- a/src/open_ire/spiders/unavailable_articles.py
+++ b/src/open_ire/spiders/unavailable_articles.py
@@ -10,6 +10,7 @@ from scrapy.exporters import CsvItemExporter
 from scrapy.http import Request, Response
 from sqlalchemy import Engine
 from sqlmodel import asc, create_engine, select
+from twisted.internet.defer import Deferred
 from twisted.python.failure import Failure
 
 from open_ire.items import UnavailableArticleItem
@@ -17,7 +18,7 @@ from open_ire.models import Article
 
 
 @dataclass(frozen=True, slots=True)
-class CollectedArticleRecord:
+class _CollectedArticleRecord:
     article_id: str
     repository: str
     reference: str
@@ -25,14 +26,14 @@ class CollectedArticleRecord:
 
 
 @dataclass(slots=True)
-class RepositoryAvailabilityStats:
+class _RepositoryAvailabilityStats:
     checked: int = 0
     available: int = 0
     unavailable: int = 0
     http_errors: int = 0
     request_errors: int = 0
 
-    def add(self, other: "RepositoryAvailabilityStats") -> None:
+    def add(self, other: "_RepositoryAvailabilityStats") -> None:
         self.checked += other.checked
         self.available += other.available
         self.unavailable += other.unavailable
@@ -126,9 +127,22 @@ class UnavailableArticlesSpider(Spider):
         self._scheduled_articles = 0
         self._unavailable_items = 0
 
-        self.repository_stats: dict[str, RepositoryAvailabilityStats] = defaultdict(
-            RepositoryAvailabilityStats
+        self.repository_stats: dict[str, _RepositoryAvailabilityStats] = defaultdict(
+            _RepositoryAvailabilityStats
         )
+
+    @staticmethod
+    def close(spider: Spider, reason: str) -> Deferred[None] | None:
+        close_result = Spider.close(spider, reason)
+
+        if isinstance(spider, UnavailableArticlesSpider):
+            spider.exporter.close()
+            spider._log_summary(reason)
+
+            if spider.engine:
+                spider.engine.dispose()
+
+        return close_result
 
     @classmethod
     def from_crawler(cls, crawler: Any, *args: Any, **kwargs: Any) -> "UnavailableArticlesSpider":
@@ -142,7 +156,7 @@ class UnavailableArticlesSpider(Spider):
 
         return spider
 
-    def _iter_articles(self) -> Iterator[CollectedArticleRecord]:
+    def _iter_articles(self) -> Iterator[_CollectedArticleRecord]:
         if not self.engine:
             return
 
@@ -171,14 +185,14 @@ class UnavailableArticlesSpider(Spider):
                     if not normalized_url:
                         continue
 
-                    yield CollectedArticleRecord(
+                    yield _CollectedArticleRecord(
                         article_id=str(article_id),
                         repository=str(repository),
                         reference=str(reference),
                         url=normalized_url,
                     )
 
-    def _build_request(self, article: CollectedArticleRecord, method: str) -> Request:
+    def _build_request(self, article: _CollectedArticleRecord, method: str) -> Request:
         return Request(
             article.url,
             method=method,
@@ -194,7 +208,7 @@ class UnavailableArticlesSpider(Spider):
 
     def _record_unavailable(
         self,
-        article: CollectedArticleRecord,
+        article: _CollectedArticleRecord,
         status_code: int | None,
         error: str,
         request_method: str,
@@ -243,7 +257,7 @@ class UnavailableArticlesSpider(Spider):
         )
 
     def _log_summary(self, reason: str) -> None:
-        totals = RepositoryAvailabilityStats()
+        totals = _RepositoryAvailabilityStats()
 
         for repository_stats in self.repository_stats.values():
             totals.add(repository_stats)
@@ -307,17 +321,10 @@ class UnavailableArticlesSpider(Spider):
             self._scheduled_articles,
         )
 
-    def closed(self, reason: str) -> None:
-        self.exporter.close()
-        self._log_summary(reason)
-
-        if self.engine:
-            self.engine.dispose()
-
     def parse_article_availability(
         self,
         response: Response,
-        article: CollectedArticleRecord,
+        article: _CollectedArticleRecord,
         request_method: str,
     ) -> Request | None:
         if request_method == "HEAD" and response.status in {405, 501}:
@@ -345,7 +352,7 @@ class UnavailableArticlesSpider(Spider):
         article = request.cb_kwargs.get("article")
         request_method = str(request.cb_kwargs.get("request_method") or request.method)
 
-        if not isinstance(article, CollectedArticleRecord):
+        if not isinstance(article, _CollectedArticleRecord):
             self.logger.warning("Request failed without article metadata: %s", failure.value)
             return
 

--- a/tests/pipelines/test_doi_normalization_pipeline.py
+++ b/tests/pipelines/test_doi_normalization_pipeline.py
@@ -73,3 +73,33 @@ class TestDOINormalizationPipeline:
         result = pipeline.process_item(item)
 
         assert result.doi is None
+
+    def test_normalize_percent_encoded_doi(
+        self, pipeline: DOINormalizationPipeline, item: ArticleItem
+    ) -> None:
+        """Test decoding percent-encoded DOI separators."""
+        item.doi = "10.1029%2F2019jc015650"
+
+        result = pipeline.process_item(item)
+
+        assert result.doi == "10.1029/2019jc015650"
+
+    def test_normalize_repeated_prefixes(
+        self, pipeline: DOINormalizationPipeline, item: ArticleItem
+    ) -> None:
+        """Test collapsing duplicated DOI URL prefixes."""
+        item.doi = "http://dx.doi.org/http://dx.doi.org/10.1214/17-BA1056R"
+
+        result = pipeline.process_item(item)
+
+        assert result.doi == "10.1214/17-BA1056R"
+
+    def test_normalize_embedded_doi_with_leading_slash(
+        self, pipeline: DOINormalizationPipeline, item: ArticleItem
+    ) -> None:
+        """Test extracting DOI with leading slash."""
+        item.doi = "/10.25923/hvy6-fe44"
+
+        result = pipeline.process_item(item)
+
+        assert result.doi == "10.25923/hvy6-fe44"

--- a/tests/spiders/conftest.py
+++ b/tests/spiders/conftest.py
@@ -1,0 +1,47 @@
+import uuid
+from collections.abc import Generator
+from datetime import date
+from typing import Any
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+
+from open_ire.models import Article
+
+
+@pytest.fixture
+def spider_with_db(spider: Any) -> Generator[Any, None, None]:
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+    spider.engine = engine
+    yield spider
+    engine.dispose()
+
+
+@pytest.fixture
+def article_id() -> uuid.UUID:
+    return uuid.UUID("12345678-1234-5678-1234-567812345678")
+
+
+@pytest.fixture
+def sample_article(spider_with_db: Any, article_id: uuid.UUID) -> Article:
+    engine = getattr(spider_with_db, "engine", None)
+    if engine is None:
+        msg = "Expected spider_with_db to expose a database engine"
+        raise RuntimeError(msg)
+
+    with Session(engine) as session:
+        article = Article(
+            id=article_id,
+            title="Test Article",
+            authors="Test Author",
+            publication_date=date(2023, 1, 15),
+            repository="test_repo",
+            reference="TEST001",
+            url="https://example.com/article",
+            doi="10.1234/test.doi",
+        )
+        session.add(article)
+        session.commit()
+        session.refresh(article)
+        return article

--- a/tests/spiders/test_oa_doaj.py
+++ b/tests/spiders/test_oa_doaj.py
@@ -1,0 +1,256 @@
+import json
+import uuid
+from collections.abc import Generator
+from datetime import date
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from scrapy.http import HtmlResponse
+from sqlmodel import Session, select
+
+from open_ire.enums import DepositStatus, DepositTransitionReason, OAEvidenceKind
+from open_ire.models import Article, ArticleDepositStatusTransition, ArticleOAEvidence
+from open_ire.spiders.oa_doaj import OADOAJSpider, _ArticleCandidate
+
+
+@pytest.fixture
+def spider() -> Generator[OADOAJSpider, None, None]:
+    with patch.object(OADOAJSpider, "logger", new_callable=MagicMock):
+        spider_instance = OADOAJSpider()
+        yield spider_instance
+
+
+class TestCandidates:
+    def test_query_article_candidates_filters_and_normalizes(
+        self, spider_with_db: OADOAJSpider
+    ) -> None:
+        with Session(spider_with_db.engine) as session:
+            session.add(
+                Article(
+                    title="Valid DOI",
+                    authors="A",
+                    publication_date=date(2023, 1, 1),
+                    repository="repo",
+                    reference="R1",
+                    url="https://example.com/1",
+                    doi="https://doi.org/10.5555/valid",
+                )
+            )
+            session.add(
+                Article(
+                    title="Invalid DOI",
+                    authors="B",
+                    publication_date=date(2023, 1, 2),
+                    repository="repo",
+                    reference="R2",
+                    url="https://example.com/2",
+                    doi="not-a-doi",
+                )
+            )
+            session.add(
+                Article(
+                    title="No DOI",
+                    authors="C",
+                    publication_date=date(2023, 1, 3),
+                    repository="repo",
+                    reference="R3",
+                    url="https://example.com/3",
+                    doi=None,
+                )
+            )
+            session.commit()
+
+        candidates = spider_with_db.query_article_candidates()
+
+        assert len(candidates) == 1
+        assert candidates[0].doi == "10.5555/valid"
+
+
+class TestRequests:
+    def test_build_search_request(self, spider: OADOAJSpider, article_id: uuid.UUID) -> None:
+        candidate = _ArticleCandidate(
+            article_id=article_id,
+            doi="10.1234/example",
+        )
+
+        request = spider.build_search_request(candidate)
+
+        assert request.url == "https://doaj.org/api/search/articles/doi:10.1234%2Fexample"
+        assert request.cb_kwargs["candidate"] == candidate
+
+
+class TestMatching:
+    def test_match_article_by_doi(self, spider: OADOAJSpider) -> None:
+        results: list[dict[str, Any]] = [
+            {
+                "id": "article-1",
+                "bibjson": {
+                    "title": "Test Article",
+                    "identifier": [
+                        {"type": "doi", "id": "10.1234/test.doi"},
+                        {"type": "eissn", "id": "1860-5974"},
+                    ],
+                },
+            }
+        ]
+
+        match = spider.match_article_by_doi(results, "10.1234/test.doi")
+
+        assert match is not None
+        assert match["supports_oa"] is True
+        assert match["allow_transition"] is True
+        assert match["confidence"] == "high"
+
+
+class TestParseFlow:
+    def test_parse_search_response_non_match_does_not_save_evidence(
+        self, spider: OADOAJSpider, article_id: uuid.UUID
+    ) -> None:
+        candidate = _ArticleCandidate(
+            article_id=article_id,
+            doi="10.1234/test.doi",
+        )
+
+        response_data: dict[str, Any] = {"total": 0, "results": []}
+        response = HtmlResponse(
+            url="https://doaj.org/api/search/articles/doi:10.1234/test.doi",
+            body=json.dumps(response_data).encode(),
+            encoding="utf-8",
+        )
+        spider.save_doaj_evidence = MagicMock()  # type: ignore[method-assign]
+
+        result = spider.parse_search_response(response, candidate)
+
+        assert result is None
+        spider.save_doaj_evidence.assert_not_called()
+
+    def test_parse_search_response_saves_match(
+        self, spider: OADOAJSpider, article_id: uuid.UUID
+    ) -> None:
+        candidate = _ArticleCandidate(article_id=article_id, doi="10.1234/test.doi")
+        response_data: dict[str, Any] = {
+            "total": 1,
+            "results": [
+                {
+                    "id": "article-1",
+                    "bibjson": {
+                        "title": "Test Article",
+                        "identifier": [{"type": "doi", "id": "10.1234/test.doi"}],
+                    },
+                }
+            ],
+        }
+        response = HtmlResponse(
+            url="https://doaj.org/api/search/articles/doi:10.1234/test.doi",
+            body=json.dumps(response_data).encode(),
+            encoding="utf-8",
+        )
+        spider.save_doaj_evidence = MagicMock()  # type: ignore[method-assign]
+
+        result = spider.parse_search_response(response, candidate)
+
+        assert result is None
+        spider.save_doaj_evidence.assert_called_once()
+
+    def test_parse_search_response_http_error_does_not_save(
+        self, spider: OADOAJSpider, article_id: uuid.UUID
+    ) -> None:
+        candidate = _ArticleCandidate(article_id=article_id, doi="10.1234/test.doi")
+        response = HtmlResponse(
+            url="https://doaj.org/api/search/articles/doi:10.1234/test.doi",
+            status=503,
+            body=b"",
+            encoding="utf-8",
+        )
+        spider.save_doaj_evidence = MagicMock()  # type: ignore[method-assign]
+
+        result = spider.parse_search_response(response, candidate)
+
+        assert result is None
+        spider.save_doaj_evidence.assert_not_called()
+
+
+class TestSaveDOAJEvidence:
+    def test_save_supporting_evidence_creates_transition(
+        self, spider_with_db: OADOAJSpider, sample_article: Article
+    ) -> None:
+        spider_with_db.save_doaj_evidence(
+            sample_article.id,
+            supports_oa=True,
+            allow_transition=True,
+            evidence_data={"matched": True, "match_strategy": "article_doi"},
+        )
+
+        with Session(spider_with_db.engine) as session:
+            evidence = session.exec(
+                select(ArticleOAEvidence).where(ArticleOAEvidence.article_id == sample_article.id)
+            ).first()
+            assert evidence is not None
+            assert evidence.kind == OAEvidenceKind.EXTERNAL_OA
+            assert evidence.source == "doaj"
+            assert evidence.supports_oa is True
+
+            transition = session.exec(
+                select(ArticleDepositStatusTransition).where(
+                    ArticleDepositStatusTransition.article_id == sample_article.id
+                )
+            ).first()
+            assert transition is not None
+            assert transition.to_status == DepositStatus.READY
+            assert DepositTransitionReason.EXTERNAL_OA in transition.reasons
+
+    def test_save_non_supporting_evidence_without_transition(
+        self, spider_with_db: OADOAJSpider, sample_article: Article
+    ) -> None:
+        spider_with_db.save_doaj_evidence(
+            sample_article.id,
+            supports_oa=False,
+            allow_transition=False,
+            evidence_data={"matched": False},
+        )
+
+        with Session(spider_with_db.engine) as session:
+            evidence = session.exec(
+                select(ArticleOAEvidence).where(ArticleOAEvidence.article_id == sample_article.id)
+            ).first()
+            assert evidence is not None
+            assert evidence.supports_oa is False
+
+            transition = session.exec(
+                select(ArticleDepositStatusTransition).where(
+                    ArticleDepositStatusTransition.article_id == sample_article.id
+                )
+            ).first()
+            assert transition is None
+
+
+class TestStart:
+    @pytest.mark.asyncio
+    async def test_start_skips_article_with_existing_evidence(
+        self, spider_with_db: OADOAJSpider, sample_article: Article
+    ) -> None:
+        with Session(spider_with_db.engine) as session:
+            session.add(
+                ArticleOAEvidence(
+                    article_id=sample_article.id,
+                    kind=OAEvidenceKind.LICENSE,
+                    supports_oa=True,
+                    source="crossref",
+                    data={},
+                )
+            )
+            session.commit()
+
+        requests = [request async for request in spider_with_db.start()]
+
+        assert requests == []
+
+    @pytest.mark.asyncio
+    async def test_start_emits_request_when_no_existing_evidence(
+        self, spider_with_db: OADOAJSpider, sample_article: Article
+    ) -> None:
+        requests = [request async for request in spider_with_db.start()]
+
+        assert len(requests) == 1
+        assert requests[0].url == "https://doaj.org/api/search/articles/doi:10.1234%2Ftest.doi"

--- a/tests/spiders/test_oa_license.py
+++ b/tests/spiders/test_oa_license.py
@@ -1,13 +1,12 @@
 import json
 import uuid
 from collections.abc import Generator
-from datetime import date
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 from scrapy.http import HtmlResponse, Request
-from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel import Session, select
 
 from open_ire.enums import DepositStatus, DepositTransitionReason, OAEvidenceKind
 from open_ire.models import Article, ArticleDepositStatusTransition, ArticleOAEvidence
@@ -16,42 +15,9 @@ from open_ire.spiders.oa_license import OALicenseSpider
 
 @pytest.fixture
 def spider() -> Generator[OALicenseSpider, None, None]:
-    with patch.object(OALicenseSpider, "logger", new_callable=lambda: MagicMock()):
+    with patch.object(OALicenseSpider, "logger", new_callable=MagicMock):
         spider_instance = OALicenseSpider()
         yield spider_instance
-
-
-@pytest.fixture
-def spider_with_db(spider: OALicenseSpider) -> Generator[OALicenseSpider, None, None]:
-    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
-    SQLModel.metadata.create_all(engine)
-    spider.engine = engine
-    yield spider
-    engine.dispose()
-
-
-@pytest.fixture
-def article_id() -> uuid.UUID:
-    return uuid.UUID("12345678-1234-5678-1234-567812345678")
-
-
-@pytest.fixture
-def sample_article(spider_with_db: OALicenseSpider, article_id: uuid.UUID) -> Article:
-    with Session(spider_with_db.engine) as session:
-        article = Article(
-            id=article_id,
-            title="Test Article",
-            authors="Test Author",
-            publication_date=date(2023, 1, 15),
-            repository="test_repo",
-            reference="TEST001",
-            url="https://example.com/article",
-            doi="10.1234/test.doi",
-        )
-        session.add(article)
-        session.commit()
-        session.refresh(article)
-        return article
 
 
 @pytest.fixture

--- a/tests/spiders/test_unavailable_articles.py
+++ b/tests/spiders/test_unavailable_articles.py
@@ -11,8 +11,8 @@ from twisted.python.failure import Failure
 
 from open_ire.models import Article
 from open_ire.spiders.unavailable_articles import (
-    CollectedArticleRecord,
     UnavailableArticlesSpider,
+    _CollectedArticleRecord,
 )
 
 
@@ -29,7 +29,7 @@ def spider(tmp_path: Path) -> Generator[UnavailableArticlesSpider, None, None]:
 
     yield spider_instance
 
-    spider_instance.closed("test_teardown")
+    spider_instance.close(spider_instance, "test_teardown")
     engine.dispose()
 
 
@@ -77,7 +77,7 @@ class TestUnavailableArticlesSpider:
         self,
         spider: UnavailableArticlesSpider,
     ) -> None:
-        article = CollectedArticleRecord(
+        article = _CollectedArticleRecord(
             article_id="id-1",
             repository="repo_a",
             reference="A1",
@@ -97,7 +97,7 @@ class TestUnavailableArticlesSpider:
         self,
         spider: UnavailableArticlesSpider,
     ) -> None:
-        article = CollectedArticleRecord(
+        article = _CollectedArticleRecord(
             article_id="id-success",
             repository="repo_success",
             reference="S1",
@@ -116,7 +116,7 @@ class TestUnavailableArticlesSpider:
         assert spider.repository_stats["repo_success"].request_errors == 0
 
     def test_parse_article_availability_fallback(self, spider: UnavailableArticlesSpider) -> None:
-        article = CollectedArticleRecord(
+        article = _CollectedArticleRecord(
             article_id="id-2",
             repository="repo_b",
             reference="B1",
@@ -132,7 +132,7 @@ class TestUnavailableArticlesSpider:
         assert spider.repository_stats["repo_b"].checked == 0
 
     def test_handle_request_error(self, spider: UnavailableArticlesSpider) -> None:
-        article = CollectedArticleRecord(
+        article = _CollectedArticleRecord(
             article_id="id-3",
             repository="repo_c",
             reference="C1",
@@ -149,13 +149,13 @@ class TestUnavailableArticlesSpider:
         assert spider.repository_stats["repo_c"].request_errors == 1
 
     def test_csv_writes(self, spider: UnavailableArticlesSpider) -> None:
-        article_a = CollectedArticleRecord(
+        article_a = _CollectedArticleRecord(
             article_id="id-4",
             repository="repo_d",
             reference="D1",
             url="https://example.org/d1",
         )
-        article_b = CollectedArticleRecord(
+        article_b = _CollectedArticleRecord(
             article_id="id-5",
             repository="repo_d",
             reference="D2",
@@ -171,7 +171,7 @@ class TestUnavailableArticlesSpider:
         spider.parse_article_availability(response_a, article_a, "HEAD")
         spider.parse_article_availability(response_b, article_b, "HEAD")
 
-        spider.closed("finished")
+        spider.close(spider, "finished")
 
         csv_path = spider.output_csv
         assert csv_path.exists()


### PR DESCRIPTION
This PR adds a new spider to expand our methods for finding open-access status evidence based on article-journal association and the DOAJ directory. For now, it relies only on the article DOI to find matches, and I found that ~25% of articles with a DOI had matches on DOAJ, using a random sample (`n=100`) from the latest database. However, I did not implement journal title matching because coverage was super low (only 22 articles), which is likely caused by #82 