### PR TITLE
Add remote DB snapshot via SharePoint

### DIFF
--- a/src/open_ire/pipelines/sharepoint_pipeline.py
+++ b/src/open_ire/pipelines/sharepoint_pipeline.py
@@ -1,8 +1,11 @@
 import logging
 import math
+from datetime import datetime
 from pathlib import Path
+from posixpath import join as posix_join
 from typing import Self
 
+from scrapy import Spider, signals
 from scrapy.crawler import Crawler
 
 from open_ire.errors import ConfigurationError
@@ -18,11 +21,15 @@ class SharePointPipeline:
     """
 
     def __init__(
-        self, sharepoint_base_path: str, local_base_path: str, crawler: Crawler | None = None
+        self,
+        sharepoint_base_path: str,
+        local_base_path: str,
+        crawler: Crawler | None = None,
     ) -> None:
         self.sharepoint = SharePoint(base_path=sharepoint_base_path)
         self.base_path = Path(local_base_path)
         self.crawler = crawler
+        self.db_path: Path | None = None
 
     @classmethod
     def from_crawler(cls, crawler: Crawler) -> Self:
@@ -31,8 +38,12 @@ class SharePointPipeline:
             raise ConfigurationError(conf)
 
         sharepoint_base_path = crawler.settings.get("SHAREPOINT_BASE_PATH", "open_ire")
+        db_path = crawler.settings.get("OPEN_IRE_DATABASE_FILE")
+        pipeline = cls(sharepoint_base_path, local_base_path, crawler)
+        pipeline.db_path = Path(db_path) if db_path else None
+        crawler.signals.connect(pipeline._upload_database_backup, signal=signals.spider_closed)
 
-        return cls(sharepoint_base_path, local_base_path, crawler)
+        return pipeline
 
     @staticmethod
     def _remove_local_file(local_file_path: Path) -> None:
@@ -42,11 +53,62 @@ class SharePointPipeline:
             msg = f"Failed to remove local file {local_file_path}: {e}"
             logger.warning(msg)
 
-    def open_spider(self) -> None:
-        pass
+    @staticmethod
+    def _backup_filename(db_path: Path, run_at: datetime) -> str:
+        date_stamp = run_at.strftime("%Y-%m-%d")
+        return f"{db_path.stem}__{date_stamp}{db_path.suffix}"
 
-    def close_spider(self) -> None:
-        pass
+    @staticmethod
+    def _build_db_sharepoint_path(db_path: Path, run_at: datetime) -> str:
+        filename = SharePointPipeline._backup_filename(db_path, run_at)
+        backup_dir = db_path.parent.as_posix().strip("/")
+        if backup_dir in ("", "."):
+            return filename
+
+        return posix_join(backup_dir, filename)
+
+    async def _upload_database_backup(
+        self,
+        spider: Spider | None = None,
+        reason: str = "completed",
+    ) -> None:
+        if not self.db_path:
+            logger.warning("OPEN_IRE_DATABASE_FILE is not configured; skipping DB backup upload.")
+            return
+
+        local_db_path = self.db_path
+        if not local_db_path.exists():
+            logger.warning("Database file not found: %s", local_db_path)
+            return
+
+        backup_time = datetime.now()
+        sharepoint_path = self._build_db_sharepoint_path(local_db_path, backup_time)
+        logger.info(
+            "Uploading database snapshot to SharePoint: %s -> %s",
+            local_db_path,
+            sharepoint_path,
+        )
+
+        upload_result = await self.sharepoint.upload_file(local_db_path, sharepoint_path)
+        if not upload_result.location:
+            spider_name = spider.name if spider else "unknown"
+            logger.error(
+                "Failed to upload database snapshot for spider '%s' (reason=%s): %s",
+                spider_name,
+                reason,
+                local_db_path,
+            )
+            return
+
+        drive_item = await self.sharepoint.get_item(sharepoint_path)
+        if not drive_item:
+            logger.error("Could not confirm SharePoint database snapshot: %s", sharepoint_path)
+            return
+
+        logger.info(
+            "Database snapshot uploaded successfully: %s",
+            drive_item.web_url or sharepoint_path,
+        )
 
     async def _save_file(self, file_data: dict[str, str | int | None]) -> str:
         sharepoint_path = str(file_data.get("path") or "")
@@ -86,6 +148,12 @@ class SharePointPipeline:
             logger.error(msg)
 
         return store_url
+
+    def open_spider(self) -> None:
+        pass
+
+    def close_spider(self) -> None:
+        pass
 
     async def process_item(self, item: ArticleItem) -> ArticleItem:
         if not item.files:

--- a/tests/pipelines/test_sharepoint_pipeline.py
+++ b/tests/pipelines/test_sharepoint_pipeline.py
@@ -1,8 +1,10 @@
+from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from scrapy import signals
 from scrapy.crawler import Crawler
 
 from open_ire.items import ArticleItem
@@ -111,3 +113,56 @@ class TestSharePointPipeline:
         mock_drive_item.size = 5000
         await pipeline.process_item(item)
         assert local_file.exists()  # preserve local copy
+
+    def test_db_snapshot_on_spider_close(self, crawler: Crawler, tmp_path: Path) -> None:
+        crawler.settings.set("FILES_STORE", str(tmp_path))
+        crawler.settings.set("OPEN_IRE_DATABASE_FILE", "dbs/open_ire.db")
+        crawler.settings.set("SHAREPOINT_BASE_PATH", "test_sharepoint")
+        crawler.signals = MagicMock()
+
+        with patch("open_ire.pipelines.sharepoint_pipeline.SharePoint"):
+            pipeline = SharePointPipeline.from_crawler(crawler)
+
+        assert pipeline.db_path == Path("dbs/open_ire.db")
+
+        connect = cast(Any, crawler.signals.connect)
+        connect.assert_called_once()
+        assert connect.call_args.kwargs["signal"] == signals.spider_closed
+        assert connect.call_args.args[0] == pipeline._upload_database_backup
+
+    def test_build_db_sharepoint_path(self, pipeline: SharePointPipeline) -> None:
+        db_path = Path("dbs/open_ire.db")
+        run_at = datetime(2026, 2, 18)
+
+        result = pipeline._build_db_sharepoint_path(db_path, run_at)
+
+        assert result == "dbs/open_ire__2026-02-18.db"
+
+    @pytest.mark.asyncio
+    async def test_upload_database_backup(
+        self, pipeline: SharePointPipeline, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "open_ire.db"
+        db_path.write_text("sqlite-content")
+        pipeline.db_path = db_path
+
+        backup_path = "open_ire__2026-01-27.db"
+        mock_upload_result = MagicMock()
+        mock_upload_result.location = "https://sharepoint.com/uploaded-db"
+        mock_drive_item = MagicMock()
+        mock_drive_item.size = db_path.stat().st_size
+        mock_drive_item.web_url = "https://sharepoint.com/db-web-url"
+
+        sharepoint = cast(Any, pipeline.sharepoint)
+        sharepoint.upload_file = AsyncMock(return_value=mock_upload_result)
+        sharepoint.get_item = AsyncMock(return_value=mock_drive_item)
+
+        with patch.object(
+            pipeline,
+            "_build_db_sharepoint_path",
+            return_value=backup_path,
+        ):
+            await pipeline._upload_database_backup()
+
+        sharepoint.upload_file.assert_awaited_once_with(db_path, backup_path)
+        sharepoint.get_item.assert_awaited_once_with(backup_path)


### PR DESCRIPTION
With these changes, the SharePoint pipeline will upload a copy of the local database file to the archiving drive each time a spider completes an execution.