### PR TITLE
Fix skipped unavailable article tracking requests due to Scrapy resumption

### DIFF
--- a/src/open_ire/spiders/unavailable_articles.py
+++ b/src/open_ire/spiders/unavailable_articles.py
@@ -103,13 +103,13 @@ class UnavailableArticlesSpider(Spider):
     name = "unavailable_articles"
 
     custom_settings = {  # noqa: RUF012
+        "ITEM_PIPELINES": {},
         "CONCURRENT_REQUESTS": 8,
         "ROBOTSTXT_OBEY": False,
         "DOWNLOAD_HANDLERS": {
-            "http": "scrapy.core.downloader.handlers.http.HTTPDownloadHandler",
-            "https": "scrapy.core.downloader.handlers.http.HTTPDownloadHandler",
+            "http": "scrapy.core.downloader.handlers.http11.HTTP11DownloadHandler",
+            "https": "scrapy.core.downloader.handlers.http11.HTTP11DownloadHandler",
         },
-        "ITEM_PIPELINES": {},
     }
 
     def __init__(
@@ -121,7 +121,7 @@ class UnavailableArticlesSpider(Spider):
         super().__init__(*args, **kwargs)
 
         self.engine: Engine | None = None
-        self.output_csv = Path(output_csv)
+        self.output_csv = self._dated_output_csv(Path(output_csv))
         self.db_batch_size = 5000
         self.exporter = UnavailableArticleExporter(self.output_csv)
 
@@ -131,6 +131,15 @@ class UnavailableArticlesSpider(Spider):
         self.repository_stats: dict[str, RepositoryAvailabilityStats] = defaultdict(
             RepositoryAvailabilityStats
         )
+
+    @staticmethod
+    def _dated_output_csv(output_csv: Path) -> Path:
+        date_suffix = datetime.now(UTC).date().isoformat()
+        stem = output_csv.stem
+        if stem.endswith(date_suffix):
+            return output_csv
+
+        return output_csv.with_name(f"{stem}_{date_suffix}{output_csv.suffix}")
 
     @classmethod
     def from_crawler(cls, crawler: Any, *args: Any, **kwargs: Any) -> "UnavailableArticlesSpider":

--- a/src/open_ire/spiders/unavailable_articles.py
+++ b/src/open_ire/spiders/unavailable_articles.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, BinaryIO, cast
 
 from scrapy import Spider
+from scrapy.exceptions import IgnoreRequest
 from scrapy.exporters import CsvItemExporter
 from scrapy.http import Request, Response
 from sqlalchemy import Engine
@@ -103,6 +104,7 @@ class UnavailableArticlesSpider(Spider):
 
     custom_settings = {  # noqa: RUF012
         "CONCURRENT_REQUESTS": 8,
+        "ROBOTSTXT_OBEY": False,
         "DOWNLOAD_HANDLERS": {
             "http": "scrapy.core.downloader.handlers.http.HTTPDownloadHandler",
             "https": "scrapy.core.downloader.handlers.http.HTTPDownloadHandler",
@@ -347,6 +349,14 @@ class UnavailableArticlesSpider(Spider):
 
         if not isinstance(article, CollectedArticleRecord):
             self.logger.warning("Request failed without article metadata: %s", failure.value)
+            return
+
+        if isinstance(failure.value, IgnoreRequest):
+            self.logger.info(
+                "Skipping unavailable article record for filtered request (%s): %s",
+                article.url,
+                failure.value,
+            )
             return
 
         response = getattr(failure.value, "response", None)

--- a/tests/spiders/test_unavailable_articles.py
+++ b/tests/spiders/test_unavailable_articles.py
@@ -4,6 +4,7 @@ from datetime import date
 from pathlib import Path
 
 import pytest
+from scrapy.exceptions import IgnoreRequest
 from scrapy.http import HtmlResponse, Request
 from sqlmodel import Session, SQLModel, create_engine
 from twisted.internet.error import DNSLookupError
@@ -147,6 +148,25 @@ class TestUnavailableArticlesSpider:
         assert spider.repository_stats["repo_c"].checked == 1
         assert spider.repository_stats["repo_c"].unavailable == 1
         assert spider.repository_stats["repo_c"].request_errors == 1
+
+    def test_handle_ignore_request_does_not_mark_unavailable(
+        self, spider: UnavailableArticlesSpider
+    ) -> None:
+        article = CollectedArticleRecord(
+            article_id="id-ignore",
+            repository="repo_ignore",
+            reference="I1",
+            url="https://example.org/i1",
+        )
+        request = spider._build_request(article, method="HEAD")
+        failure = Failure(IgnoreRequest("filtered"))  # type: ignore[no-untyped-call]
+        failure.request = request  # type: ignore[attr-defined]
+
+        spider.handle_request_error(failure)
+
+        assert spider.repository_stats["repo_ignore"].checked == 0
+        assert spider.repository_stats["repo_ignore"].unavailable == 0
+        assert spider.repository_stats["repo_ignore"].request_errors == 0
 
     def test_csv_writes(self, spider: UnavailableArticlesSpider) -> None:
         article_a = CollectedArticleRecord(


### PR DESCRIPTION
This PR filters out false-positive error records triggered when the article tracking spider resumes from a previous state. Additionally, it adds a datestamp to the output CSV filename for better historic tracking