### PR TITLE
feat: add journal name/title parsing fallback

### DIFF
--- a/src/open_ire/spiders/gsearch.py
+++ b/src/open_ire/spiders/gsearch.py
@@ -46,6 +46,36 @@ class GSearchSpider(Spider):
         return response.xpath(f"//meta[@name='{name}']/@content").get()
 
     @staticmethod
+    def _normalize_description_label(label: str) -> str:
+        normalized_label = " ".join(label.split())
+        return normalized_label.rstrip(":").strip().casefold()
+
+    @staticmethod
+    def _normalize_extracted_value(value: str) -> str | None:
+        normalized_value = " ".join(value.split()).strip()
+        return normalized_value or None
+
+    @staticmethod
+    def _extract_from_details_list(response: Response, label: str) -> str | None:
+        expected_label = GSearchSpider._normalize_description_label(label)
+
+        for row in response.xpath("//li[contains(@class, 'bookDetails-row')]"):
+            label_text = " ".join(
+                row.xpath(".//div[contains(@class, 'bookDetailsLabel')]//text()").getall()
+            )
+            normalized_label_text = GSearchSpider._normalize_description_label(label_text)
+            if normalized_label_text != expected_label:
+                continue
+
+            value_text = " ".join(
+                row.xpath(".//div[contains(@class, 'bookDetailsData')]//text()").getall()
+            )
+            if normalized_value := GSearchSpider._normalize_extracted_value(value_text):
+                return normalized_value
+
+        return None
+
+    @staticmethod
     def _extract_file_urls(response: Response) -> list[str]:
         file_hrefs = response.xpath('//meta[@name="citation_pdf_url"]/@content').getall()
 
@@ -82,7 +112,14 @@ class GSearchSpider(Spider):
         if publisher := self._extract_from_meta(response, "citation_publisher"):
             extra["publisher"] = publisher
 
-        if journal_title := self._extract_from_meta(response, "citation_journal_title"):
+        journal_title = self._extract_from_meta(response, "citation_journal_title")
+        if not journal_title:
+            for label in ("Journal Title", "Journal Article", "Source"):
+                journal_title = self._extract_from_details_list(response, label)
+                if journal_title:
+                    break
+
+        if journal_title:
             extra["journal_title"] = journal_title
 
         if conference := self._extract_from_meta(response, "citation_conference"):

--- a/tests/spiders/test_cdc_stacks.py
+++ b/tests/spiders/test_cdc_stacks.py
@@ -111,3 +111,29 @@ class TestCDCStacksSpider:
 
         reference = spider._extract_reference(response)
         assert reference == url
+
+    def test_extract_journal_from_details_list(self) -> None:
+        """Test journal article fallback from details list rows."""
+        html = """
+        <html>
+            <head></head>
+            <body>
+                <ul class="bookDetailsList">
+                    <li class="bookDetails-row">
+                        <div class="bookDetailsLabel">
+                            <b>Journal Article:</b>
+                        </div>
+                        <div class="bookDetailsData pt-3">
+                            <div>CDC Journal Article Details</div>
+                        </div>
+                    </li>
+                </ul>
+            </body>
+        </html>
+        """
+        response = HtmlResponse(url="https://stacks.cdc.gov/", body=html.encode("utf-8"))
+        spider = CDCStacksSpider()
+
+        extra = spider._extract_extra_details(response)
+
+        assert extra["journal_title"] == "CDC Journal Article Details"

--- a/tests/spiders/test_noaa.py
+++ b/tests/spiders/test_noaa.py
@@ -167,3 +167,31 @@ class TestNOAASpider:
         extra = spider._extract_extra_details(response)
 
         assert extra == {}
+
+    def test_extract_journal_title_from_details_list(self) -> None:
+        """Test journal title fallback from details list rows."""
+        html = """
+        <html>
+            <head></head>
+            <body>
+                <ul class="bookDetailsList">
+                    <li class="bookDetails-row">
+                        <div class="bookDetailsLabel">
+                            <b>Journal Title:</b>
+                        </div>
+                        <div class="bookDetailsData pt-3">
+                            <div>NOAA Details Journal</div>
+                        </div>
+                    </li>
+                </ul>
+            </body>
+        </html>
+        """
+        response = HtmlResponse(
+            url="https://repository.library.noaa.gov/", body=html.encode("utf-8")
+        )
+        spider = NOAASpider()
+
+        extra = spider._extract_extra_details(response)
+
+        assert extra["journal_title"] == "NOAA Details Journal"


### PR DESCRIPTION
This PR addresses issue #82 by adding a fallback for parsing the journal name/title from the page's content when the `citation_journal_title` metadata property is unavailable