### PR TITLE
feat: add full-text file checks and GET fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,16 @@ For example:
 pixi run resume eric --skip-existing
 ```
 
+### Tracking Deleted Articles
+
+To detect previously collected article metadata and downloaded files that are no
+longer available, run the `unavailable_articles` spider. It reads from
+`OPEN_IRE_DATABASE_FILE` and writes a CSV report under `output/`.
+
+```bash
+pixi run resume unavailable_articles
+```
+
 ### Search by Keyword
 
 To run a spider with a custom list of search terms, use the `search-terms`

--- a/src/open_ire/items.py
+++ b/src/open_ire/items.py
@@ -24,6 +24,7 @@ class UnavailableArticleItem(SQLModel):
     article_id: str
     repository: str
     reference: str
+    kind: str
     url: str
     status_code: int | None = None
     error: str

--- a/src/open_ire/spiders/unavailable_articles.py
+++ b/src/open_ire/spiders/unavailable_articles.py
@@ -14,7 +14,7 @@ from sqlmodel import asc, create_engine, select
 from twisted.python.failure import Failure
 
 from open_ire.items import UnavailableArticleItem
-from open_ire.models import Article
+from open_ire.models import Article, ArticleFile
 
 
 @dataclass(frozen=True, slots=True)
@@ -22,6 +22,7 @@ class _CollectedArticleRecord:
     article_id: str
     repository: str
     reference: str
+    kind: str
     url: str
 
 
@@ -97,7 +98,7 @@ class UnavailableArticleExporter:
 
 class UnavailableArticlesSpider(Spider):
     """
-    Track previously collected articles that are no longer available at source URL.
+    Track previously collected article metadata and downloaded-file URLs that are no longer available.
     """
 
     name = "unavailable_articles"
@@ -125,7 +126,7 @@ class UnavailableArticlesSpider(Spider):
         self.db_batch_size = 5000
         self.exporter = UnavailableArticleExporter(self.output_csv)
 
-        self._scheduled_articles = 0
+        self._scheduled_checks = 0
         self._unavailable_items = 0
 
         self.repository_stats: dict[str, _RepositoryAvailabilityStats] = defaultdict(
@@ -153,20 +154,9 @@ class UnavailableArticlesSpider(Spider):
 
         return spider
 
-    def _iter_articles(self) -> Iterator[_CollectedArticleRecord]:
+    def _iter_db_records(self, statement: Any, *, kind: str) -> Iterator[_CollectedArticleRecord]:
         if not self.engine:
             return
-
-        statement = (
-            select(
-                Article.id,
-                Article.repository,
-                Article.reference,
-                Article.url,
-            )
-            .where(Article.url != "")
-            .order_by(asc(Article.created_at))
-        )
 
         with self.engine.connect() as connection:
             result = connection.execution_options(stream_results=True).execute(statement)
@@ -186,8 +176,35 @@ class UnavailableArticlesSpider(Spider):
                         article_id=str(article_id),
                         repository=str(repository),
                         reference=str(reference),
+                        kind=kind,
                         url=normalized_url,
                     )
+
+    def _iter_articles(self) -> Iterator[_CollectedArticleRecord]:
+        article_statement = (
+            select(
+                Article.id,
+                Article.repository,
+                Article.reference,
+                Article.url,
+            )
+            .where(Article.url != "")
+            .order_by(asc(Article.created_at))
+        )
+        file_statement = (
+            select(
+                Article.id,
+                Article.repository,
+                Article.reference,
+                ArticleFile.url,
+            )
+            .join(ArticleFile, cast(Any, ArticleFile.article_id == Article.id))
+            .where(ArticleFile.url != "")
+            .order_by(asc(ArticleFile.created_at))
+        )
+
+        yield from self._iter_db_records(article_statement, kind="article_metadata")
+        yield from self._iter_db_records(file_statement, kind="downloaded_file")
 
     def _build_request(self, article: _CollectedArticleRecord, method: str) -> Request:
         return Request(
@@ -223,6 +240,7 @@ class UnavailableArticlesSpider(Spider):
             article_id=article.article_id,
             repository=article.repository,
             reference=article.reference,
+            kind=article.kind,
             url=article.url,
             status_code=status_code,
             error=error,
@@ -261,14 +279,14 @@ class UnavailableArticlesSpider(Spider):
 
         self.logger.info(
             "Unavailable-article check completed (reason=%s). "
-            "Articles checked=%d, available=%d, unavailable=%d",
+            "URLs checked=%d, available=%d, unavailable=%d",
             reason,
             totals.checked,
             totals.available,
             totals.unavailable,
         )
         self.logger.info(
-            "Unavailable article CSV: %s (%d rows)",
+            "Unavailable URL CSV: %s (%d rows)",
             self.output_csv,
             self._unavailable_items,
         )
@@ -307,7 +325,7 @@ class UnavailableArticlesSpider(Spider):
         self.exporter.open()
 
         for article in self._iter_articles():
-            self._scheduled_articles += 1
+            self._scheduled_checks += 1
 
             try:
                 yield self._build_request(article, method="HEAD")
@@ -321,8 +339,8 @@ class UnavailableArticlesSpider(Spider):
                 )
 
         self.logger.info(
-            "Scheduled availability checks for %d articles",
-            self._scheduled_articles,
+            "Scheduled availability checks for %d URLs",
+            self._scheduled_checks,
         )
 
     def parse_article_availability(
@@ -331,7 +349,7 @@ class UnavailableArticlesSpider(Spider):
         article: _CollectedArticleRecord,
         request_method: str,
     ) -> Request | None:
-        if request_method == "HEAD" and response.status in {405, 501}:
+        if request_method == "HEAD" and response.status in {404, 405, 501}:
             return self._build_request(article, method="GET")
 
         if response.status >= 400:

--- a/tests/spiders/test_unavailable_articles.py
+++ b/tests/spiders/test_unavailable_articles.py
@@ -82,12 +82,13 @@ class TestUnavailableArticlesSpider:
             article_id="id-1",
             repository="repo_a",
             reference="A1",
+            kind="article_metadata",
             url="https://example.org/a1",
         )
         request = Request(url=article.url)
         response = HtmlResponse(url=article.url, status=404, body=b"", request=request)
 
-        result = spider.parse_article_availability(response, article, "HEAD")
+        result = spider.parse_article_availability(response, article, "GET")
 
         assert result is None
         assert spider.repository_stats["repo_a"].checked == 1
@@ -102,6 +103,7 @@ class TestUnavailableArticlesSpider:
             article_id="id-success",
             repository="repo_success",
             reference="S1",
+            kind="article_metadata",
             url="https://example.org/s1",
         )
         request = Request(url=article.url)
@@ -121,10 +123,11 @@ class TestUnavailableArticlesSpider:
             article_id="id-2",
             repository="repo_b",
             reference="B1",
+            kind="article_metadata",
             url="https://example.org/b1",
         )
         request = Request(url=article.url)
-        response = HtmlResponse(url=article.url, status=405, body=b"", request=request)
+        response = HtmlResponse(url=article.url, status=404, body=b"", request=request)
 
         fallback_request = spider.parse_article_availability(response, article, "HEAD")
 
@@ -137,6 +140,7 @@ class TestUnavailableArticlesSpider:
             article_id="id-3",
             repository="repo_c",
             reference="C1",
+            kind="article_metadata",
             url="https://example.org/c1",
         )
         request = spider._build_request(article, method="GET")
@@ -156,6 +160,7 @@ class TestUnavailableArticlesSpider:
             article_id="id-ignore",
             repository="repo_ignore",
             reference="I1",
+            kind="article_metadata",
             url="https://example.org/i1",
         )
         request = spider._build_request(article, method="HEAD")
@@ -173,12 +178,14 @@ class TestUnavailableArticlesSpider:
             article_id="id-4",
             repository="repo_d",
             reference="D1",
+            kind="article_metadata",
             url="https://example.org/d1",
         )
         article_b = _CollectedArticleRecord(
             article_id="id-5",
             repository="repo_d",
             reference="D2",
+            kind="article_metadata",
             url="https://example.org/d2",
         )
 
@@ -188,7 +195,7 @@ class TestUnavailableArticlesSpider:
         response_a = HtmlResponse(url=article_a.url, status=404, body=b"", request=request_a)
         response_b = HtmlResponse(url=article_b.url, status=500, body=b"", request=request_b)
 
-        spider.parse_article_availability(response_a, article_a, "HEAD")
+        spider.parse_article_availability(response_a, article_a, "GET")
         spider.parse_article_availability(response_b, article_b, "HEAD")
 
         spider.close(spider, "finished")


### PR DESCRIPTION
This PR adds full-text file URL checks to the `unavailable_articles` spider. With these changes, we now verify both article metadata and file availability.