### PR TITLE
Authoship pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,8 @@ warn_return_any = false
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
+markers = ["integration"]
+addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config", "-m", "not integration"]
 xfail_strict = false
 filterwarnings = ["error"]
 log_cli_level = "INFO"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ warn_return_any = false
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = ["-vvv", "-ra", "--showlocals", "--strict-markers", "--strict-config"]
+addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 xfail_strict = false
 filterwarnings = ["error"]
 log_cli_level = "INFO"

--- a/src/open_ire/author.py
+++ b/src/open_ire/author.py
@@ -36,6 +36,9 @@ class ParsedAuthor:
     def __hash__(self) -> int:
         return hash((self.canonical_name, self.email))
 
+    def __bool__(self) -> bool:
+        return bool(self.canonical_name)
+
     @property
     def email(self) -> str | None:
         return self._email

--- a/src/open_ire/author.py
+++ b/src/open_ire/author.py
@@ -37,7 +37,7 @@ class ParsedAuthor:
         return hash((self.canonical_name, self.email))
 
     def __bool__(self) -> bool:
-        return bool(self.canonical_name)
+        return bool(str(self._parsed_name).strip())
 
     @property
     def email(self) -> str | None:

--- a/src/open_ire/items.py
+++ b/src/open_ire/items.py
@@ -1,6 +1,8 @@
-from pydantic import BaseModel
+from dataclasses import dataclass
+
 from sqlmodel import Field, SQLModel
 
+from open_ire.author import ParsedAuthor
 from open_ire.models import ArticleBase
 
 
@@ -32,15 +34,13 @@ class UnavailableArticleItem(SQLModel):
     checked_at: str
 
 
-class AuthorItem(BaseModel):
+@dataclass
+class AuthorItem:
     """Author data with identifiers from a trusted source (e.g., OpenAlex).
 
     Used when a spider successfully disambiguates an author and discovers
     their canonical identifiers (OpenAlex ID, ORCID, etc.).
     """
 
-    full_name: str
-    first_name: str | None = None
-    middle_names: str | None = None
-    last_name: str | None = None
-    identifiers: list[dict[str, str]] = Field(default_factory=list)
+    author: ParsedAuthor
+    identifiers: list[dict[str, str]]

--- a/src/open_ire/migrations/versions/de4a71ae327c_articleauthor_becomes_authorship.py
+++ b/src/open_ire/migrations/versions/de4a71ae327c_articleauthor_becomes_authorship.py
@@ -1,0 +1,36 @@
+"""articleauthor becomes authorship
+
+Revision ID: de4a71ae327c
+Revises: 0f0e24e01947
+Create Date: 2026-04-08 09:38:34.630377
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "de4a71ae327c"
+down_revision: str | None = "0f0e24e01947"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.rename_table("articleauthor", "authorship")
+    with op.batch_alter_table("authorship", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "updated_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.text("(datetime('now'))"),
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("authorship", schema=None) as batch_op:
+        batch_op.drop_column("updated_at")
+    op.rename_table("authorship", "articleauthor")

--- a/src/open_ire/models.py
+++ b/src/open_ire/models.py
@@ -63,7 +63,7 @@ class Article(ArticleBase, table=True):
     )
 
     # New author relationships
-    article_authors: list["ArticleAuthor"] = Relationship(
+    authorships: list["Authorship"] = Relationship(
         back_populates="article", sa_relationship_kwargs={"passive_deletes": True}
     )
 
@@ -245,7 +245,7 @@ class Author(AuthorBase, table=True):
     id: int = Field(primary_key=True)
 
     # Relationships
-    article_authors: list["ArticleAuthor"] = Relationship(
+    authorships: list["Authorship"] = Relationship(
         back_populates="author", sa_relationship_kwargs={"passive_deletes": True}
     )
     identifiers: list["AuthorIdentifier"] = Relationship(
@@ -290,44 +290,6 @@ class AuthorAffiliation(AuthorAffiliationBase, table=True):
     )
 
 
-class ArticleAuthorBase(SQLModel):
-    """Base SQLModel for article-author relationship attributes.
-
-    Attributes
-    ----------
-    article_id: Foreign key to the Article table.
-    author_id: Foreign key to the Author table.
-    author_order: Position of author in the publication's author list.
-    created_at: Datetime when the relationship was created.
-    """
-
-    article_id: uuid.UUID | None = Field(default=None, foreign_key="article.id")
-    author_id: int | None = Field(default=None, foreign_key="author.id")
-    author_order: int | None = None
-    created_at: datetime = Field(default_factory=datetime.now)
-
-
-class ArticleAuthor(ArticleAuthorBase, table=True):
-    """SQLModel to store many-to-many relationships between articles and authors."""
-
-    article_id: uuid.UUID = Field(
-        sa_column=Column(
-            ForeignKey("article.id", ondelete="CASCADE"),
-            primary_key=True,
-        ),
-    )
-    author_id: int = Field(
-        sa_column=Column(
-            ForeignKey("author.id", ondelete="CASCADE"),
-            primary_key=True,
-        ),
-    )
-
-    # Relationships
-    article: "Article" = Relationship(back_populates="article_authors")
-    author: "Author" = Relationship(back_populates="article_authors")
-
-
 class AuthorIdentifierBase(SQLModel):
     """Base SQLModel for author identifier attributes.
 
@@ -360,3 +322,42 @@ class AuthorIdentifier(AuthorIdentifierBase, table=True):
     author: "Author" = Relationship(back_populates="identifiers")
 
     __table_args__ = (UniqueConstraint("authority", "identifier", name="uq_author_identifier"),)
+
+
+class AuthorshipBase(SQLModel):
+    """Base SQLModel to define common authorship attributes.
+
+    Attributes
+    ----------
+    article_id: Foreign key to the Article table.
+    author_id: Foreign key to the Author table.
+    author_order: Position of author in the publication's author list.
+    created_at: Datetime when the relationship was created.
+    """
+
+    article_id: uuid.UUID | None = Field(default=None, foreign_key="article.id")
+    author_id: int | None = Field(default=None, foreign_key="author.id")
+    author_order: int | None = None
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+
+class Authorship(AuthorshipBase, table=True):
+    """SQLModel to store many-to-many relationships between authors and articles."""
+
+    article_id: uuid.UUID = Field(
+        sa_column=Column(
+            ForeignKey("article.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+    )
+    author_id: int = Field(
+        sa_column=Column(
+            ForeignKey("author.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+    )
+
+    # Relationships
+    article: "Article" = Relationship(back_populates="authorships")
+    author: "Author" = Relationship(back_populates="authorships")

--- a/src/open_ire/pipelines/__init__.py
+++ b/src/open_ire/pipelines/__init__.py
@@ -1,4 +1,5 @@
 from .author_identifier_pipeline import AuthorIdentifierPipeline
+from .authorship_pipeline import AuthorshipPipeline
 from .base_sql_model_pipeline import BaseSQLModelPipeline
 from .doi_duplicates_pipeline import DOIDuplicatesPipeline
 from .doi_normalization_pipeline import DOINormalizationPipeline
@@ -11,6 +12,7 @@ from .sql_model_pipeline import SQLModelPipeline
 
 __all__ = [
     "AuthorIdentifierPipeline",
+    "AuthorshipPipeline",
     "BaseSQLModelPipeline",
     "DOIDuplicatesPipeline",
     "DOINormalizationPipeline",

--- a/src/open_ire/pipelines/author_identifier_pipeline.py
+++ b/src/open_ire/pipelines/author_identifier_pipeline.py
@@ -15,7 +15,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 class AuthorIdentifierPipeline(BaseSQLModelPipeline):
     """Store author identifiers discovered during crawling.
 
-    When a spider successfully disambiguates an author it yields an AuthorItem
+    When a spider successfully disambiguates an author, it yields an AuthorItem
     containing the author's canonical identifiers. This pipeline stores those
     identifiers, using them for deterministic author matching.
 
@@ -27,7 +27,7 @@ class AuthorIdentifierPipeline(BaseSQLModelPipeline):
 
         with Session(self.engine) as session:
             by_identifier = self._find_author_by_identifier(session, item.identifiers)
-            by_name = self._find_author_by_name(session, item)
+            by_name = self._find_author_by_name(session, item.author)
             candidates = [a for a in (by_identifier, by_name) if a is not None]
 
             if not candidates:
@@ -35,7 +35,9 @@ class AuthorIdentifierPipeline(BaseSQLModelPipeline):
             elif len(candidates) == 1 or (candidates[0].id == candidates[1].id):
                 self._update_author(session, candidates[0], item)
             else:
-                raise RuntimeError("Multiple existing authors found for " + item.full_name)
+                raise RuntimeError(
+                    "Multiple existing authors found for " + item.author.canonical_name
+                )
 
             session.commit()
 
@@ -55,27 +57,21 @@ class AuthorIdentifierPipeline(BaseSQLModelPipeline):
             if existing:
                 logger.info(
                     "Found existing author '%s' (id=%s) by identifier",
-                    existing.author.full_name,
+                    existing.author.canonical_name,
                     existing.author.id,
                 )
                 return existing.author
         return None
 
     @staticmethod
-    def _find_author_by_name(session: Session, item: AuthorItem) -> Author | None:
-        """Find an existing author by compatible parsed name."""
-        parsed = ParsedAuthor(item.full_name)
-        last_name = (item.last_name or parsed.last_name).strip()
-        if not last_name:
-            return None
-
-        candidates = session.exec(select(Author).where(Author.last_name == last_name)).all()
-        target = ParsedAuthor(item.full_name)
+    def _find_author_by_name(session: Session, author: ParsedAuthor) -> Author | None:
+        """Find an existing author by compatible name."""
+        candidates = session.exec(select(Author).where(Author.last_name == author.last_name)).all()
         for candidate in candidates:
-            if ParsedAuthor(candidate.canonical_name).likely_same(target):
+            if ParsedAuthor(candidate.canonical_name).likely_same(author):
                 logger.info(
                     "Found existing author '%s' (id=%s) by name",
-                    candidate.full_name,
+                    candidate.canonical_name,
                     candidate.id,
                 )
                 return candidate
@@ -91,21 +87,12 @@ class AuthorIdentifierPipeline(BaseSQLModelPipeline):
     @staticmethod
     def _create_author_with_identifiers(session: Session, item: AuthorItem) -> Author:
         """Create a new author with all provided identifiers."""
-        parsed = ParsedAuthor(item.full_name)
-        first_name = item.first_name or parsed.first_name or None
-        middle_names = item.middle_names or parsed.middle_names or None
-        last_name = item.last_name or parsed.last_name or None
-
-        canonical_name = ParsedAuthor(
-            " ".join(part for part in [first_name, middle_names, last_name] if part)
-        ).canonical_name
-
         author = Author(
-            canonical_name=canonical_name,
-            full_name=item.full_name,
-            first_name=first_name,
-            middle_names=middle_names,
-            last_name=last_name,
+            canonical_name=item.author.canonical_name,
+            full_name=item.author.full_name,
+            first_name=item.author.first_name,
+            middle_names=item.author.middle_names,
+            last_name=item.author.last_name,
             explicitly_searched=True,
         )
         session.add(author)

--- a/src/open_ire/pipelines/author_identifier_pipeline.py
+++ b/src/open_ire/pipelines/author_identifier_pipeline.py
@@ -12,6 +12,23 @@ from open_ire.pipelines.base_sql_model_pipeline import BaseSQLModelPipeline
 logger: logging.Logger = logging.getLogger(__name__)
 
 
+def find_author_by_name(session: Session, author: ParsedAuthor) -> Author | None:
+    """Return an existing author matched by name, or None.
+
+    Shared by AuthorIdentifierPipeline and AuthorshipPipeline.
+    """
+    candidates = session.exec(select(Author).where(Author.last_name == author.last_name)).all()
+    for candidate in candidates:
+        if ParsedAuthor(candidate.canonical_name).likely_same(author):
+            logger.debug(
+                "Found existing author '%s' (id=%s) by name",
+                candidate.canonical_name,
+                candidate.id,
+            )
+            return candidate
+    return None
+
+
 class AuthorIdentifierPipeline(BaseSQLModelPipeline):
     """Store author identifiers discovered during crawling.
 
@@ -27,7 +44,8 @@ class AuthorIdentifierPipeline(BaseSQLModelPipeline):
 
         with Session(self.engine) as session:
             by_identifier = self._find_author_by_identifier(session, item.identifiers)
-            by_name = self._find_author_by_name(session, item.author)
+            by_name = find_author_by_name(session, item.author)
+
             candidates = [a for a in (by_identifier, by_name) if a is not None]
 
             if not candidates:
@@ -61,20 +79,6 @@ class AuthorIdentifierPipeline(BaseSQLModelPipeline):
                     existing.author.id,
                 )
                 return existing.author
-        return None
-
-    @staticmethod
-    def _find_author_by_name(session: Session, author: ParsedAuthor) -> Author | None:
-        """Find an existing author by compatible name."""
-        candidates = session.exec(select(Author).where(Author.last_name == author.last_name)).all()
-        for candidate in candidates:
-            if ParsedAuthor(candidate.canonical_name).likely_same(author):
-                logger.info(
-                    "Found existing author '%s' (id=%s) by name",
-                    candidate.canonical_name,
-                    candidate.id,
-                )
-                return candidate
         return None
 
     def _update_author(self, session: Session, author: Author, item: AuthorItem) -> None:

--- a/src/open_ire/pipelines/authorship_pipeline.py
+++ b/src/open_ire/pipelines/authorship_pipeline.py
@@ -1,0 +1,72 @@
+import logging
+from datetime import datetime
+from typing import Any
+
+from sqlmodel import Session
+
+from open_ire.author import ParsedAuthor
+from open_ire.items import ArticleItem
+from open_ire.models import Article, Author, Authorship
+from open_ire.pipelines.author_identifier_pipeline import find_author_by_name
+from open_ire.pipelines.base_sql_model_pipeline import BaseSQLModelPipeline
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class AuthorshipPipeline(BaseSQLModelPipeline):
+    """Link author records to article records."""
+
+    def process_item(self, item: Any) -> Any:
+        if not isinstance(item, ArticleItem):
+            return item
+
+        with Session(self.engine) as session:
+            existing_article = self.find_existing_article(session, item)
+            if not existing_article:
+                msg = f"Article '{item.title}' not found in database"
+                raise RuntimeError(msg)
+
+            if not item.authors:
+                logger.warning("No authors found for article '%s'", item.title)
+                return item
+            authors = ParsedAuthor.parse_author_string(item.authors or "")
+
+            for i, author in enumerate(authors):
+                existing_author = find_author_by_name(session, author)
+                self._create_or_update_link(session, existing_article, existing_author, i)
+
+            session.commit()
+
+        return item
+
+    @staticmethod
+    def _create_or_update_link(
+        session: Session,
+        article: Article,
+        author: Author | None,
+        author_order: int,
+    ) -> None:
+        """Create or update an article-author record."""
+        if author is None:
+            return
+
+        link = session.get(Authorship, (article.id, author.id))
+        if link is None:
+            logger.debug(
+                "Linking article '%s' to author '%s'",
+                article.id,
+                author.canonical_name,
+            )
+            session.add(Authorship(article=article, author=author, author_order=author_order))
+            return
+
+        if link.author_order != author_order:
+            logger.debug(
+                "Updating author_order for article '%s' and author '%s' from %s to %s",
+                article.id,
+                author.canonical_name,
+                link.author_order,
+                author_order,
+            )
+            link.author_order = author_order
+            link.updated_at = datetime.now()

--- a/src/open_ire/settings/base.py
+++ b/src/open_ire/settings/base.py
@@ -36,6 +36,7 @@ ITEM_PIPELINES = {
     "open_ire.pipelines.FileReferencePipeline": 200,
     "open_ire.pipelines.SharePointPipeline": 300,
     "open_ire.pipelines.SQLModelPipeline": 400,
+    "open_ire.pipelines.AuthorshipPipeline": 410,
 }
 DOWNLOAD_HANDLERS = {
     "http": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",

--- a/src/open_ire/spiders/gsearch.py
+++ b/src/open_ire/spiders/gsearch.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode, urlparse
 from scrapy import Spider
 from scrapy.http import Request, Response
 
+from open_ire.author import ParsedAuthor
 from open_ire.items import ArticleItem
 from open_ire.settings import OPEN_IRE_DEFAULT_TERMS
 from open_ire.utils import parse_date
@@ -91,7 +92,8 @@ class GSearchSpider(Spider):
         if not authors_list:
             return None
 
-        return ", ".join(authors_list)
+        parsed_authors = [ParsedAuthor(a) for a in authors_list]
+        return ParsedAuthor.encode_author_string(parsed_authors)
 
     def _extract_reference(self, response: Response) -> str:
         url = urlparse(response.url)

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -162,13 +162,8 @@ class OpenAlexSpider(AuthorSearchSpider):
 
         # OpenAlex sometimes provides "parsed_longest_name", but that can
         # introduce surprises, so rely on "our" name.
-        parsed_name = ParsedAuthor(searched_author)
-
         return AuthorItem(
-            full_name=parsed_name.full_name,
-            first_name=parsed_name.first_name,
-            middle_names=parsed_name.middle_names,
-            last_name=parsed_name.last_name,
+            author=ParsedAuthor(searched_author),
             identifiers=identifiers,
         )
 

--- a/src/open_ire/spiders/search.py
+++ b/src/open_ire/spiders/search.py
@@ -8,7 +8,10 @@ from scrapy import Spider
 from scrapy.http import Request
 
 from open_ire.author import AuthorIndex, ParsedAuthor
+from open_ire.items import AuthorItem
 from open_ire.settings import OPEN_IRE_DEFAULT_TERMS
+
+type StartItem = Request | AuthorItem
 
 
 class SearchSpider[TSearchPhrase](Spider, metaclass=abc.ABCMeta):
@@ -21,11 +24,11 @@ class SearchSpider[TSearchPhrase](Spider, metaclass=abc.ABCMeta):
 
     search_phrases: list[TSearchPhrase]
 
-    async def start(self) -> AsyncIterator[Request]:
-        for term in self.search_phrases:
-            if not term:
+    async def start(self) -> AsyncIterator[StartItem]:
+        for phrase in self.search_phrases:
+            if not phrase:
                 continue
-            yield self.build_search_request(term)
+            yield self.build_search_request(phrase)
 
     @abc.abstractmethod
     def build_search_request(self, phrase: TSearchPhrase) -> Request:
@@ -89,6 +92,19 @@ class AuthorSearchSpider(SearchSpider[ParsedAuthor], ABC):
 
         if author_name:
             self.search_phrases.append(ParsedAuthor(author_name))
+
+    async def start(self) -> AsyncIterator[Request | AuthorItem]:
+        for author in self.search_phrases:
+            yield AuthorItem(
+                author=author,
+                identifiers=[{"authority": "email", "identifier": author.email}]
+                if author.email
+                else [],
+            )
+        for author in self.search_phrases:
+            if not author:
+                continue
+            yield self.build_search_request(author)
 
     @abc.abstractmethod
     def build_search_request(self, record: ParsedAuthor) -> Request:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,100 @@
+"""Shared fixtures for integration tests."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from sqlalchemy import event
+from sqlmodel import Session, SQLModel, create_engine
+
+# HTTPCACHE_DIR is relative to Scrapy's data dir (.scrapy/), not the project root.
+HTTPCACHE_DIR = "httpcache"
+HTTPCACHE_DIR_ON_DISK = Path(".scrapy/httpcache")
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--author-csv",
+        required=False,
+        help="Path to faculty CSV for integration tests",
+    )
+
+
+@pytest.fixture
+def author_csv(request):
+    csv = request.config.getoption("--author-csv")
+    if not csv:
+        pytest.skip("--author-csv not provided")
+    return Path(csv)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    """Return a temporary database file path."""
+    return tmp_path / "test.db"
+
+
+@pytest.fixture
+def db_engine(db_path: Path):
+    """Create an SQLite engine with foreign keys enabled."""
+    engine = create_engine(f"sqlite:///{db_path}")
+    event.listen(
+        engine,
+        "connect",
+        lambda dbapi_connection, _: dbapi_connection.execute("PRAGMA foreign_keys=ON"),
+    )
+    SQLModel.metadata.create_all(engine)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture
+def db_session(db_engine):
+    """Create a database session."""
+    with Session(db_engine) as session:
+        yield session
+
+
+def run_crawl(
+    spider: str, db_path: Path, author_csv: str, extra_args: list[str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Run a scrapy crawl as a subprocess with HTTP cache replay.
+
+    Requires cached responses in tests/fixtures/httpcache/.
+    Fails on cache miss (no network requests).
+    """
+    cmd = [
+        "python",
+        "-m",
+        "scrapy",
+        "crawl",
+        spider,
+        "-a",
+        f"author_csv={author_csv}",
+        "-s",
+        f"OPEN_IRE_DATABASE_FILE={db_path}",
+        "-s",
+        "HTTPCACHE_ENABLED=True",
+        "-s",
+        f"HTTPCACHE_DIR={HTTPCACHE_DIR}",
+        "-s",
+        "HTTPCACHE_POLICY=scrapy.extensions.httpcache.DummyPolicy",
+        "-s",
+        "HTTPCACHE_IGNORE_MISSING=True",
+        "-s",
+        "LOG_LEVEL=WARNING",
+        # Only pipelines that don't need external services:
+        "-s",
+        'ITEM_PIPELINES={"open_ire.pipelines.DuplicatesPipeline": 1, '
+        '"open_ire.pipelines.AuthorIdentifierPipeline": 5, '
+        '"open_ire.pipelines.DOINormalizationPipeline": 10, '
+        '"open_ire.pipelines.DOIDuplicatesPipeline": 20, '
+        '"open_ire.pipelines.SQLModelPipeline": 400, '
+        '"open_ire.pipelines.AuthorshipPipeline": 401}',
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+
+    return subprocess.run(cmd, check=False, capture_output=True, text=True, timeout=120)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,8 +4,9 @@ import subprocess
 from pathlib import Path
 
 import pytest
-from sqlalchemy import event
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import Session, create_engine
+
+from open_ire.db import create_db_engine
 
 # HTTPCACHE_DIR is relative to Scrapy's data dir (.scrapy/), not the project root.
 HTTPCACHE_DIR = "httpcache"
@@ -38,12 +39,7 @@ def db_path(tmp_path: Path) -> Path:
 def db_engine(db_path: Path):
     """Create an SQLite engine with foreign keys enabled."""
     engine = create_engine(f"sqlite:///{db_path}")
-    event.listen(
-        engine,
-        "connect",
-        lambda dbapi_connection, _: dbapi_connection.execute("PRAGMA foreign_keys=ON"),
-    )
-    SQLModel.metadata.create_all(engine)
+    engine = create_db_engine(str(db_path))
     try:
         yield engine
     finally:

--- a/tests/integration/test_oap_crawl.py
+++ b/tests/integration/test_oap_crawl.py
@@ -1,0 +1,86 @@
+"""Integration tests for OAP spiders (OpenAlex and WoS).
+
+These tests replay cached HTTP responses (no network access).
+To record/update the cache, run:
+
+    scrapy crawl openalex -a author_csv=<PATH TO AUTHOR CSV> \
+        -s HTTPCACHE_ENABLED=True \
+        -s HTTPCACHE_DIR=httpcache \
+        -s "HTTPCACHE_POLICY=scrapy.extensions.httpcache.DummyPolicy"
+
+HTTPCACHE_DIR is relative to Scrapy's data dir (.scrapy/), not the project root.
+"""
+
+from pathlib import Path
+
+import pytest
+from sqlmodel import func, select
+
+from open_ire.author import AuthorIndex
+from open_ire.models import Article, Author, AuthorIdentifier, Authorship
+
+from .conftest import HTTPCACHE_DIR_ON_DISK, run_crawl
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+def require_cache():
+    """Skip integration tests if the HTTP cache hasn't been recorded yet."""
+    if not HTTPCACHE_DIR_ON_DISK.exists() or not any(HTTPCACHE_DIR_ON_DISK.iterdir()):
+        pytest.skip(
+            f"HTTP cache not found at {HTTPCACHE_DIR_ON_DISK}. Run a real crawl first to record."
+        )
+
+
+class TestOAPCrawl:
+    """Test a full OAP crawl of provided list of authors using cached responses."""
+
+    @pytest.fixture(autouse=True)
+    def crawl(self, db_path: Path, db_engine, author_csv):
+        """Run the OAP crawl once for all tests in this class."""
+        openalex = run_crawl("openalex", db_path, author_csv)
+        if openalex.returncode != 0:
+            pytest.fail(
+                f"OpenAlex crawl failed:\nstdout: {openalex.stdout}\nstderr: {openalex.stderr}"
+            )
+        wos = run_crawl("wos", db_path, author_csv)
+        if wos.returncode != 0:
+            pytest.fail(f"WoS crawl failed:\nstdout: {wos.stdout}\nstderr: {wos.stderr}")
+        # db_engine fixture ensures tables exist and engine is available
+        self._db_engine = db_engine
+
+    def test_articles_collected(self, db_session):
+        """Verify that articles were collected."""
+        articles = db_session.exec(select(Article)).all()
+        assert len(articles) > 0, "No articles were collected"
+
+    def test_authors_created(self, db_session, author_csv: Path):
+        """Verify that author records were created for searched faculty."""
+        csv_authors = AuthorIndex(Path(author_csv)).records
+        db_authors = db_session.exec(select(Author)).all()
+        assert len(csv_authors) == len(db_authors), "No explicitly searched authors were created"
+
+    def test_author_identifiers_stored(self, db_session):
+        """Verify that identifiers were stored for disambiguated authors."""
+        counts = dict(
+            db_session.exec(
+                select(AuthorIdentifier.authority, func.count()).group_by(
+                    AuthorIdentifier.authority
+                )
+            ).all()
+        )
+        assert "openalex" in counts, "No OpenAlex identifiers stored"
+        assert "email" in counts, "No email addresses stored"
+        assert counts["openalex"] > 0
+        assert counts["email"] > 0
+
+    def test_all_articles_have_authorships(self, db_session):
+        """Verify that article-author links were created."""
+        article_count = db_session.exec(select(func.count()).select_from(Article)).one()
+        linked_article_count = db_session.exec(
+            select(func.count(func.distinct(Authorship.article_id)))
+        ).one()
+        assert linked_article_count == article_count, (
+            f"{article_count - linked_article_count} articles have no authorships"
+        )

--- a/tests/pipelines/test_author_identifier_pipeline.py
+++ b/tests/pipelines/test_author_identifier_pipeline.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 from sqlmodel import Session, select
 
+from open_ire.author import ParsedAuthor
 from open_ire.items import ArticleItem, AuthorItem
 from open_ire.models import Author
 from open_ire.pipelines.author_identifier_pipeline import AuthorIdentifierPipeline
@@ -13,7 +14,7 @@ from open_ire.pipelines.author_identifier_pipeline import AuthorIdentifierPipeli
 
 @pytest.fixture
 def pipeline(temp_db: str) -> Generator[AuthorIdentifierPipeline, None, None]:
-    """Create a pipeline instance with test database."""
+    """Create a pipeline instance with a test database."""
     db_path = temp_db.replace("sqlite:///", "")
     p = AuthorIdentifierPipeline(db_path)
     p.open_spider()
@@ -29,7 +30,7 @@ def mock_spider() -> MagicMock:
 
 
 class TestAuthorIdentifierPipeline:
-    """Tests for author identifier storage pipeline."""
+    """Tests for the author identifier pipeline."""
 
     def test_passes_through_non_author_items(self, pipeline) -> None:
         """Non-AuthorItem items are passed through unchanged."""
@@ -42,9 +43,7 @@ class TestAuthorIdentifierPipeline:
     def test_creates_author_with_identifiers(self, pipeline) -> None:
         """New author and identifiers are created."""
         item = AuthorItem(
-            full_name="Eunjung Kim",
-            first_name="Eunjung",
-            last_name="Kim",
+            author=ParsedAuthor("Eunjung Kim"),
             identifiers=[
                 {"authority": "openalex", "identifier": "A5073669402"},
                 {"authority": "orcid", "identifier": "0000-0002-4664-9847"},
@@ -69,18 +68,16 @@ class TestAuthorIdentifierPipeline:
 
     def test_finds_existing_author_by_identifier(self, pipeline) -> None:
         """Existing author is found by identifier, not duplicated."""
-        # Create author with first item
+        # Create an author with the first item
         item1 = AuthorItem(
-            full_name="Eunjung Kim",
-            first_name="Eunjung",
-            last_name="Kim",
+            author=ParsedAuthor("Eunjung Kim"),
             identifiers=[{"authority": "openalex", "identifier": "A5073669402"}],
         )
         pipeline.process_item(item1)
 
-        # Process second item with same OpenAlex ID but different name variant
+        # Process the second item with same OpenAlex ID but different name variant
         item2 = AuthorItem(
-            full_name="Eun-Jung Kim",  # Different name variant
+            author=ParsedAuthor("Eun-Jung Kim"),  # Different name variant
             identifiers=[
                 {"authority": "openalex", "identifier": "A5073669402"},
                 {"authority": "orcid", "identifier": "0000-0002-4664-9847"},
@@ -98,10 +95,16 @@ class TestAuthorIdentifierPipeline:
 
     def test_finds_existing_author_by_name(self, pipeline) -> None:
         """Existing author is found by name, not duplicated."""
-        item = AuthorItem(full_name="Test Author", identifiers=[])
+        item = AuthorItem(
+            author=ParsedAuthor("Test Author"),
+            identifiers=[],
+        )
         pipeline.process_item(item)
 
-        item = AuthorItem(full_name="Test Author", identifiers=[])
+        item = AuthorItem(
+            author=ParsedAuthor("Test Author"),
+            identifiers=[],
+        )
         pipeline.process_item(item)
 
         with Session(pipeline.engine) as session:

--- a/tests/pipelines/test_authorship_pipeline.py
+++ b/tests/pipelines/test_authorship_pipeline.py
@@ -1,0 +1,195 @@
+"""Tests for AuthorshipPipeline."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import select
+from sqlmodel import Session
+
+from open_ire.items import ArticleItem, AuthorItem
+from open_ire.models import Article, Author, Authorship
+from open_ire.pipelines import AuthorshipPipeline
+
+
+@pytest.fixture
+def pipeline(temp_db: str) -> Generator[AuthorshipPipeline, None, None]:
+    """Create a pipeline instance with a test database."""
+    db_path = temp_db.replace("sqlite:///", "")
+    p = AuthorshipPipeline(db_path)
+    p.open_spider()
+    yield p
+    p.close_spider()
+
+
+@pytest.fixture
+def article_item() -> ArticleItem:
+    return ArticleItem(
+        repository="imagination",
+        reference="the_article",
+        authors="hooks, bell; Collins, Patricia Hill; Crenshaw, Kimberlé Williams",
+        title="On the Uses of Test Articles",
+        publication_date="2005-01-01",
+        url="https://example.com/article",
+    )
+
+
+@pytest.fixture
+def article() -> Article:
+    return Article(
+        repository="imagination",
+        reference="the_article",
+        authors="hooks, bell; Collins, Patricia Hill; Crenshaw, Kimberlé Williams",
+        title="On the Uses of Test Articles",
+        url="https://example.com/article",
+    )
+
+
+@pytest.fixture
+def author() -> Author:
+    return Author(
+        canonical_name="hooks, bell",
+        full_name="bell hooks",
+        first_name="bell",
+        middle_names="",
+        last_name="hooks",
+    )
+
+
+class TestAuthorshipPipeline:
+    """Tests for the AuthorshipPipeline class."""
+
+    def test_passes_through_non_author_items(self, pipeline) -> None:
+        """Non-ArticleItem items are passed through unchanged."""
+        item = MagicMock(spec=AuthorItem)
+        result = pipeline.process_item(item)
+        assert result is item
+
+    def test_absent_article_raises_exception(self, pipeline, article_item):
+        """Non-existent article raises an exception."""
+        with pytest.raises(RuntimeError):
+            pipeline.process_item(article_item)
+
+    def test_unlinked_article_creates_link(self, pipeline, article_item, article, author):
+        """Existing article without an article-author link creates one."""
+        with Session(pipeline.engine) as session:
+            session.add(article)
+            session.add(author)
+            session.commit()
+            article_id = article.id
+            author_id = author.id
+
+        assert article_id is not None
+        assert author_id is not None
+
+        pipeline.process_item(article_item)
+
+        with Session(pipeline.engine) as session:
+            link = session.get(Authorship, (article_id, author_id))
+            assert link is not None
+            assert link.author_order == 0
+
+    def test_linked_article_doesnt_create_duplicate_link(
+        self, pipeline, article_item, article, author
+    ):
+        """Link is not duplicated for an existing article with an article-author link."""
+        with Session(pipeline.engine) as session:
+            session.add(article)
+            session.add(author)
+            session.commit()
+            article_id = article.id
+            author_id = author.id
+
+        assert article_id is not None
+        assert author_id is not None
+
+        pipeline.process_item(article_item)
+        pipeline.process_item(article_item)
+
+        with Session(pipeline.engine) as session:
+            links = session.exec(
+                select(Authorship).where(
+                    Authorship.article_id == article_id,
+                    Authorship.author_id == author_id,
+                )
+            ).all()
+            assert len(links) == 1
+
+    def test_authors_not_in_db_are_skipped(self, pipeline, article_item, article):
+        """Authors missing from DB are skipped without creating links."""
+        with Session(pipeline.engine) as session:
+            session.add(article)
+            session.commit()
+            article_id = article.id
+
+        assert article_id is not None
+
+        pipeline.process_item(article_item)
+
+        with Session(pipeline.engine) as session:
+            links = session.exec(
+                select(Authorship).where(Authorship.article_id == article_id)
+            ).all()
+            assert links == []
+
+    def test_only_matched_authors_linked_with_correct_author_order(
+        self, pipeline, article_item, article
+    ):
+        """Author order reflects source position among all parsed authors."""
+        with Session(pipeline.engine) as session:
+            first_author = Author(
+                canonical_name="hooks, bell",
+                full_name="bell hooks",
+                first_name="bell",
+                middle_names="",
+                last_name="hooks",
+            )
+            third_author = Author(
+                canonical_name="Crenshaw, Kimberle Williams",
+                full_name="Kimberlé Williams Crenshaw",
+                first_name="Kimberlé",
+                middle_names="Williams",
+                last_name="Crenshaw",
+            )
+            session.add(article)
+            session.add(first_author)
+            session.add(third_author)
+            session.commit()
+            article_id = article.id
+            first_author_id = first_author.id
+            third_author_id = third_author.id
+
+        assert article_id is not None
+        assert first_author_id is not None
+        assert third_author_id is not None
+
+        pipeline.process_item(article_item)
+
+        with Session(pipeline.engine) as session:
+            first_link = session.get(Authorship, (article_id, first_author_id))
+            third_link = session.get(Authorship, (article_id, third_author_id))
+            assert first_link is not None
+            assert third_link is not None
+            assert first_link.author_order == 0
+            assert third_link.author_order == 2
+
+    def test_existing_link_updates_author_order(self, pipeline, article_item, article, author):
+        """Existing links get author_order corrected when it differs."""
+        with Session(pipeline.engine) as session:
+            session.add(article)
+            session.add(author)
+            session.commit()
+            article_id = article.id
+            author_id = author.id
+            session.add(Authorship(article_id=article_id, author_id=author_id, author_order=99))
+            session.commit()
+
+        assert article_id is not None
+        assert author_id is not None
+
+        pipeline.process_item(article_item)
+
+        with Session(pipeline.engine) as session:
+            link = session.get(Authorship, (article_id, author_id))
+            assert link is not None
+            assert link.author_order == 0

--- a/tests/spiders/test_author_search.py
+++ b/tests/spiders/test_author_search.py
@@ -1,0 +1,126 @@
+from pathlib import Path
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import pytest
+from scrapy.http import Request
+
+from open_ire.author import ParsedAuthor
+from open_ire.items import AuthorItem
+from open_ire.spiders.search import AuthorSearchSpider
+
+
+class DummyAuthorSearchSpider(AuthorSearchSpider):
+    name = "dummy-author-search"
+
+    def build_search_request(self, record: ParsedAuthor) -> Request:
+        term = self.author_name_for_query(record)
+        return Request(
+            f"https://example.test/search?{urlencode({'search': term})}",
+            meta={"searched_author": self.canonical_author_name(record)},
+        )
+
+    def author_name_for_query(self, record: ParsedAuthor) -> str:
+        return record.full_name
+
+
+async def _collect_outputs(spider: DummyAuthorSearchSpider) -> list[Request | AuthorItem]:
+    return [output async for output in spider.start()]
+
+
+def _search_value(req: Request) -> str:
+    return parse_qs(urlparse(req.url).query)["search"][0]
+
+
+def _make_author_csv(path: Path, authors: list[ParsedAuthor]) -> Path:
+    lines = ["Full Name,FirstName,MiddleNames,LastName,Email"]
+    for author in authors:
+        lines.append(
+            f"{author.full_name},{author.first_name},{author.middle_names},{author.last_name},{author.email or ''}"
+        )
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+@pytest.fixture
+def sample_authors() -> list[ParsedAuthor]:
+    return [
+        ParsedAuthor("Luis Manuel Garcia-Mispireta"),
+        ParsedAuthor("E.V.S.S.K. Babu"),
+        ParsedAuthor("Ramón H. Rivera-Servera"),
+        ParsedAuthor("M. Elena Alvarez-Alvarez"),
+        ParsedAuthor("Kemi Adeyemi", email="kadeyemi@uw.edu"),
+    ]
+
+
+class TestAuthorSearchSpider:
+    """Tests for AuthorSearchSpider class."""
+
+    def test_no_arguments_raise_error(self) -> None:
+        with pytest.raises(ValueError, match="requires either"):
+            DummyAuthorSearchSpider()
+
+    @pytest.mark.asyncio
+    async def test_start_yields_author_items_then_requests(
+        self, tmp_path: Path, sample_authors: list[ParsedAuthor]
+    ) -> None:
+        csv_author = sample_authors[4]
+        name_author = sample_authors[1]
+        csv_path = _make_author_csv(tmp_path / "authors.csv", [csv_author])
+        spider = DummyAuthorSearchSpider(
+            author_csv=str(csv_path), author_name=name_author.full_name
+        )
+
+        outputs = await _collect_outputs(spider)
+        author_items = [output for output in outputs if isinstance(output, AuthorItem)]
+        requests = [output for output in outputs if isinstance(output, Request)]
+
+        assert len(outputs) == 4
+        assert isinstance(outputs[0], AuthorItem)
+        assert isinstance(outputs[1], AuthorItem)
+        assert isinstance(outputs[2], Request)
+        assert isinstance(outputs[3], Request)
+        assert [item.author for item in author_items] == [csv_author, name_author]
+        assert [item.identifiers for item in author_items] == [
+            [{"authority": "email", "identifier": csv_author.email}],
+            [],
+        ]
+        assert [_search_value(req) for req in requests] == [
+            csv_author.full_name,
+            name_author.full_name,
+        ]
+
+    @pytest.mark.asyncio
+    async def test_start_with_name_only_yields_empty_identifiers(
+        self, sample_authors: list[ParsedAuthor]
+    ) -> None:
+        author = sample_authors[0]
+        spider = DummyAuthorSearchSpider(author_name=author.full_name)
+
+        outputs = await _collect_outputs(spider)
+        author_items = [output for output in outputs if isinstance(output, AuthorItem)]
+        requests = [output for output in outputs if isinstance(output, Request)]
+
+        assert len(author_items) == 1
+        assert author_items[0].author == author
+        assert author_items[0].identifiers == []
+        assert len(requests) == 1
+
+    @pytest.mark.asyncio
+    async def test_old_csv_format_still_supported(
+        self, tmp_path: Path, sample_authors: list[ParsedAuthor]
+    ) -> None:
+        """CSVs with only FirstName and LastName columns are still supported."""
+        csv_author = sample_authors[0]
+        csv_path = tmp_path / "authors.csv"
+        csv_path.write_text(
+            "Full Name,FirstName,LastName,Email\n"
+            f"{csv_author.full_name},{csv_author.first_name},{csv_author.last_name},{csv_author.email}\n"
+        )
+
+        spider = DummyAuthorSearchSpider(author_csv=str(csv_path))
+        requests: list[Request] = []
+        async for output in spider.start():
+            if isinstance(output, Request):
+                requests.append(output)
+
+        assert _search_value(requests[0]) == f"{csv_author.first_name} {csv_author.last_name}"

--- a/tests/spiders/test_cdc_stacks.py
+++ b/tests/spiders/test_cdc_stacks.py
@@ -64,8 +64,8 @@ class TestCDCStacksSpider:
                 <meta name="citation_title" content="Unit Test Title">
                 <meta name="citation_abstract" content="Unit Test Abstract">
                 <meta name="citation_doi" content="10.1000/stackstest">
-                <meta name="citation_author" content="Unit Test Author 1">
-                <meta name="citation_author" content="Unit Test Author 2">
+                <meta name="citation_author" content="Jenny Hsin-Chun Tsai">
+                <meta name="citation_author" content="Daniel Suarez-Baquero">
                 <meta name="citation_publication_date" content="2025-09-15">
                 <meta name="citation_issn" content="1234-5678">
                 <meta name="citation_pdf_url" content="/documents/test.pdf">
@@ -90,7 +90,7 @@ class TestCDCStacksSpider:
         assert item.title == "Unit Test Title"
         assert item.abstract == "Unit Test Abstract"
         assert item.doi == "10.1000/stackstest"
-        assert item.authors == "Unit Test Author 1, Unit Test Author 2"
+        assert item.authors == "Tsai, Jenny Hsin-Chun; Suarez-Baquero, Daniel"
         assert str(item.publication_date) == "2025-09-15"
         assert item.issn == "1234-5678"
         assert item.reference == "1234"

--- a/tests/spiders/test_noaa.py
+++ b/tests/spiders/test_noaa.py
@@ -67,8 +67,8 @@ class TestNOAASpider:
                 <meta name="citation_title" content="Unit Test Title">
                 <meta name="citation_abstract" content="Unit Test Abstract">
                 <meta name="citation_doi" content="10.1000/1234">
-                <meta name="citation_author" content="Unit Test Author 1">
-                <meta name="citation_author" content="Unit Test Author 2">
+                <meta name="citation_author" content="M. Rebecca O'Connor">
+                <meta name="citation_author" content="Kaboni Whitney Gondwe">
                 <meta name="citation_publication_date" content="2025-07-25">
                 <meta name="citation_issn" content="1234-5678">
                 <meta name="citation_pdf_url" content="/documents/test.pdf">
@@ -90,7 +90,7 @@ class TestNOAASpider:
         assert item.title == "Unit Test Title"
         assert item.abstract == "Unit Test Abstract"
         assert item.doi == "10.1000/1234"
-        assert item.authors == "Unit Test Author 1, Unit Test Author 2"
+        assert item.authors == "O'Connor, M. Rebecca; Gondwe, Kaboni Whitney"
         assert str(item.publication_date) == "2025-07-25"
         assert item.issn == "1234-5678"
         assert item.reference == "1234"

--- a/tests/spiders/test_openalex.py
+++ b/tests/spiders/test_openalex.py
@@ -15,6 +15,10 @@ from open_ire.items import ArticleItem
 from open_ire.spiders.openalex import OpenAlexSpider
 
 
+def _search_value(req: Request) -> str:
+    return parse_qs(urlparse(req.url).query)["search"][0]
+
+
 @pytest.fixture
 def sample_authors() -> list[ParsedAuthor]:
     return [
@@ -78,77 +82,6 @@ class TestOpenAlexSpider:
     def test_no_arguments_raises_error(self) -> None:
         with pytest.raises(ValueError, match="requires either"):
             OpenAlexSpider()
-
-    @pytest.mark.asyncio
-    async def test_start_with_csv_file(
-        self,
-        make_spider_from_csv: Callable[[ParsedAuthor], OpenAlexSpider],
-        sample_authors: list[ParsedAuthor],
-    ) -> None:
-        requests = []
-        async for req in make_spider_from_csv(sample_authors[4]).start():
-            requests.append(req)
-        assert len(requests) == 1
-        assert isinstance(requests[0], Request)
-        query_params = parse_qs(urlparse(requests[0].url).query)
-        assert query_params["search"] == [sample_authors[4].full_name]
-
-    @pytest.mark.asyncio
-    async def test_start_with_author_name(
-        self,
-        make_spider_with_author_name: Callable[[ParsedAuthor], OpenAlexSpider],
-        sample_authors: list[ParsedAuthor],
-    ) -> None:
-        requests = []
-        author = sample_authors[1]
-        async for req in make_spider_with_author_name(author).start():
-            requests.append(req)
-        assert len(requests) == 1
-        assert isinstance(requests[0], Request)
-        parsed_url = urlparse(requests[0].url)
-        query_params = parse_qs(parsed_url.query)
-        assert query_params["search"] == [author.full_name]
-
-    @pytest.mark.asyncio
-    async def test_start_with_both_parameters(
-        self,
-        make_csv_for_author: Callable[[ParsedAuthor], Path],
-        sample_authors: list[ParsedAuthor],
-    ) -> None:
-        csv_author = sample_authors[0]
-        name_author = sample_authors[1]
-        spider = OpenAlexSpider(
-            author_csv=str(make_csv_for_author(csv_author)), author_name=name_author.full_name
-        )
-        requests = []
-        async for req in spider.start():
-            requests.append(req)
-        assert len(requests) == 2
-        assert all(isinstance(req, Request) for req in requests)
-        query_params0 = parse_qs(urlparse(requests[0].url).query)
-        assert query_params0["search"] == [csv_author.full_name]
-        query_params1 = parse_qs(urlparse(requests[1].url).query)
-        assert query_params1["search"] == [name_author.full_name]
-
-    @pytest.mark.asyncio
-    async def test_old_csv_format_still_supported(
-        self, tmp_path: Path, sample_authors: list[ParsedAuthor]
-    ) -> None:
-        """CSVs with only FirstName and LastName columns are still supported."""
-        csv_author = sample_authors[0]
-        csv_path = tmp_path / "authors.csv"
-        csv_path.write_text(
-            f"Full Name,FirstName,LastName,Email\n"
-            f"{csv_author.full_name},{csv_author.first_name},{csv_author.last_name},{csv_author.email}\n"
-        )
-        spider = OpenAlexSpider(author_csv=str(csv_path))
-        requests = []
-        async for req in spider.start():
-            requests.append(req)
-        assert len(requests) == 1
-        assert isinstance(requests[0], Request)
-        query_params = parse_qs(urlparse(requests[0].url).query)
-        assert query_params["search"] == [f"{csv_author.first_name} {csv_author.last_name}"]
 
     def test_author_name_parameter(self, sample_authors: list[ParsedAuthor]) -> None:
         author = sample_authors[2]

--- a/tests/spiders/test_search.py
+++ b/tests/spiders/test_search.py
@@ -1,0 +1,39 @@
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import pytest
+from scrapy.http import Request
+
+from open_ire.settings import OPEN_IRE_DEFAULT_TERMS
+from open_ire.spiders.search import TermSearchSpider
+
+
+class DummyTermSearchSpider(TermSearchSpider):
+    name = "dummy-term-search"
+
+    def build_search_request(self, term: str) -> Request:
+        return Request(f"https://example.test/search?{urlencode({'term': term})}")
+
+
+async def _collect_requests(spider: DummyTermSearchSpider) -> list[Request]:
+    outputs: list[Request] = []
+    async for output in spider.start():
+        assert isinstance(output, Request)
+        outputs.append(output)
+    return outputs
+
+
+class TestTermSearchSpider:
+    @pytest.mark.asyncio
+    async def test_start_skips_empty_terms(self) -> None:
+        spider = DummyTermSearchSpider(terms="alpha, ,beta,,")
+        requests = await _collect_requests(spider)
+
+        assert len(requests) == 2
+        assert [parse_qs(urlparse(req.url).query)["term"][0] for req in requests] == [
+            "alpha",
+            "beta",
+        ]
+
+    def test_uses_default_terms_when_no_input(self) -> None:
+        spider = DummyTermSearchSpider()
+        assert spider.search_phrases == [term.strip() for term in OPEN_IRE_DEFAULT_TERMS.split(",")]

--- a/tests/test_author_models.py
+++ b/tests/test_author_models.py
@@ -8,7 +8,7 @@ from sqlalchemy import event
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, SQLModel, create_engine, select
 
-from open_ire.models import Article, ArticleAuthor, Author, AuthorAffiliation, AuthorIdentifier
+from open_ire.models import Article, Author, AuthorAffiliation, AuthorIdentifier, Authorship
 
 
 @pytest.fixture
@@ -41,7 +41,7 @@ class TestAuthorModelRelationships:
         """Property 1: Many-to-many relationship integrity.
 
         For any article and author pair, when they are linked through the
-        ArticleAuthor junction table, both the article and author should be
+        Authorship junction table, both the article and author should be
         accessible through their respective relationship properties.
 
         **Feature: author-normalization, Property 1: Many-to-many relationship integrity**
@@ -72,21 +72,21 @@ class TestAuthorModelRelationships:
         session.refresh(author)
 
         # Create junction record
-        article_author = ArticleAuthor(article_id=article.id, author_id=author.id, author_order=1)
+        article_author = Authorship(article_id=article.id, author_id=author.id, author_order=1)
 
         session.add(article_author)
         session.commit()
 
         # Test forward relationship: article -> junction -> author
         session.refresh(article)
-        assert len(article.article_authors) == 1
-        assert article.article_authors[0].author_id == author.id
-        assert article.article_authors[0].author_order == 1
+        assert len(article.authorships) == 1
+        assert article.authorships[0].author_id == author.id
+        assert article.authorships[0].author_order == 1
 
         # Test backward relationship: author -> junction -> article
         session.refresh(author)
-        assert len(author.article_authors) == 1
-        assert author.article_authors[0].article_id == article.id
+        assert len(author.authorships) == 1
+        assert author.authorships[0].article_id == article.id
 
         # Test junction table relationships
         session.refresh(article_author)
@@ -126,16 +126,16 @@ class TestAuthorModelRelationships:
         session.refresh(author2)
 
         # Create junction records
-        junction1 = ArticleAuthor(article_id=article.id, author_id=author1.id, author_order=1)
-        junction2 = ArticleAuthor(article_id=article.id, author_id=author2.id, author_order=2)
+        junction1 = Authorship(article_id=article.id, author_id=author1.id, author_order=1)
+        junction2 = Authorship(article_id=article.id, author_id=author2.id, author_order=2)
 
         session.add_all([junction1, junction2])
         session.commit()
 
         # Verify relationships through junction table
         session.refresh(article)
-        assert len(article.article_authors) == 2
-        author_ids = {junction.author_id for junction in article.article_authors}
+        assert len(article.authorships) == 2
+        author_ids = {junction.author_id for junction in article.authorships}
         assert author_ids == {author1.id, author2.id}
 
     def test_multiple_articles_per_author(self, session: Session):
@@ -172,16 +172,16 @@ class TestAuthorModelRelationships:
         session.refresh(article2)
 
         # Create junction records
-        junction1 = ArticleAuthor(article_id=article1.id, author_id=author.id, author_order=1)
-        junction2 = ArticleAuthor(article_id=article2.id, author_id=author.id, author_order=1)
+        junction1 = Authorship(article_id=article1.id, author_id=author.id, author_order=1)
+        junction2 = Authorship(article_id=article2.id, author_id=author.id, author_order=1)
 
         session.add_all([junction1, junction2])
         session.commit()
 
         # Verify relationships through junction table
         session.refresh(author)
-        assert len(author.article_authors) == 2
-        article_ids = {junction.article_id for junction in author.article_authors}
+        assert len(author.authorships) == 2
+        article_ids = {junction.article_id for junction in author.authorships}
         assert article_ids == {article1.id, article2.id}
 
     def test_author_identifiers_relationship(self, session: Session):
@@ -279,19 +279,19 @@ class TestAuthorModelRelationships:
         session.refresh(author)
 
         # Create junction record
-        junction = ArticleAuthor(article_id=article.id, author_id=author.id, author_order=1)
+        junction = Authorship(article_id=article.id, author_id=author.id, author_order=1)
         session.add(junction)
         session.commit()
 
         # Verify initial state
-        assert len(session.exec(select(ArticleAuthor)).all()) == 1
+        assert len(session.exec(select(Authorship)).all()) == 1
 
         # Delete the junction record directly
         session.delete(junction)
         session.commit()
 
         # Verify junction record is gone but article and author remain
-        assert len(session.exec(select(ArticleAuthor)).all()) == 0
+        assert len(session.exec(select(Authorship)).all()) == 0
         assert session.get(Article, article.id) is not None
         assert session.get(Author, author.id) is not None
 
@@ -316,14 +316,14 @@ class TestAuthorModelRelationships:
         session.refresh(article)
         session.refresh(author)
 
-        session.add(ArticleAuthor(article_id=article.id, author_id=author.id, author_order=1))
+        session.add(Authorship(article_id=article.id, author_id=author.id, author_order=1))
         session.commit()
-        assert len(session.exec(select(ArticleAuthor)).all()) == 1
+        assert len(session.exec(select(Authorship)).all()) == 1
 
         session.delete(article)
         session.commit()
 
-        assert len(session.exec(select(ArticleAuthor)).all()) == 0
+        assert len(session.exec(select(Authorship)).all()) == 0
         assert session.get(Author, author.id) is not None
 
     def test_delete_author_removes_junction_records(self, session: Session):
@@ -347,14 +347,14 @@ class TestAuthorModelRelationships:
         session.refresh(article)
         session.refresh(author)
 
-        session.add(ArticleAuthor(article_id=article.id, author_id=author.id, author_order=1))
+        session.add(Authorship(article_id=article.id, author_id=author.id, author_order=1))
         session.commit()
-        assert len(session.exec(select(ArticleAuthor)).all()) == 1
+        assert len(session.exec(select(Authorship)).all()) == 1
 
         session.delete(author)
         session.commit()
 
-        assert len(session.exec(select(ArticleAuthor)).all()) == 0
+        assert len(session.exec(select(Authorship)).all()) == 0
         assert session.get(Article, article.id) is not None
 
 

--- a/tests/test_author_models.py
+++ b/tests/test_author_models.py
@@ -1,6 +1,7 @@
 """Tests for author normalization models."""
 
 from datetime import date
+from uuid import uuid4
 
 import pytest
 from pydantic import ValidationError
@@ -34,8 +35,8 @@ def session(engine):
         yield session
 
 
-class TestAuthorModelRelationships:
-    """Test the many-to-many relationship integrity between articles and authors."""
+class TestAuthorship:
+    """Tests for article-author junction relationships and constraints."""
 
     def test_many_to_many_relationship_integrity(self, session: Session):
         """Property 1: Many-to-many relationship integrity.
@@ -184,76 +185,6 @@ class TestAuthorModelRelationships:
         article_ids = {junction.article_id for junction in author.authorships}
         assert article_ids == {article1.id, article2.id}
 
-    def test_author_identifiers_relationship(self, session: Session):
-        """Test that author identifiers are properly linked to authors."""
-        author = Author(
-            full_name="Identified Author",
-            first_name="Identified",
-            last_name="Author",
-            canonical_name="Author, Identified",
-        )
-
-        session.add(author)
-        session.commit()
-        session.refresh(author)
-
-        # Add identifiers
-        orcid = AuthorIdentifier(
-            author_id=author.id, authority="ORCID", identifier="0000-0000-0000-0001"
-        )
-
-        institutional_id = AuthorIdentifier(
-            author_id=author.id, authority="UW", identifier="uw123456"
-        )
-
-        session.add_all([orcid, institutional_id])
-        session.commit()
-
-        # Verify relationship
-        session.refresh(author)
-        assert len(author.identifiers) == 2
-
-        identifier_pairs = {(id.authority, id.identifier) for id in author.identifiers}
-        expected_pairs = {("ORCID", "0000-0000-0000-0001"), ("UW", "uw123456")}
-        assert identifier_pairs == expected_pairs
-
-    def test_delete_author_removes_identifiers(self, session: Session):
-        """Deleting an author should remove related identifier rows."""
-        author = Author(
-            full_name="Identified Author",
-            first_name="Identified",
-            last_name="Author",
-            canonical_name="Author, Identified",
-        )
-        session.add(author)
-        session.commit()
-        session.refresh(author)
-
-        session.add_all(
-            [
-                AuthorIdentifier(
-                    author_id=author.id, authority="ORCID", identifier="0000-0000-0000-0002"
-                ),
-                AuthorIdentifier(author_id=author.id, authority="UW", identifier="uw654321"),
-            ]
-        )
-        session.commit()
-        assert len(session.exec(select(AuthorIdentifier)).all()) == 2
-
-        session.delete(author)
-        session.commit()
-
-        assert len(session.exec(select(AuthorIdentifier)).all()) == 0
-
-    def test_author_requires_canonical_name(self, session: Session):
-        """Creating an author without canonical_name should fail at commit time."""
-        author = Author(full_name="Missing Canonical", first_name="Missing", last_name="Canonical")
-        session.add(author)
-
-        with pytest.raises(IntegrityError):
-            session.commit()
-        session.rollback()
-
     def test_delete_junction_keeps_article_and_author(self, session: Session):
         """Test that relationships are maintained when objects are deleted."""
         # Create test data
@@ -356,6 +287,101 @@ class TestAuthorModelRelationships:
 
         assert len(session.exec(select(Authorship)).all()) == 0
         assert session.get(Article, article.id) is not None
+
+    def test_authorship_rejects_missing_article(self, session: Session):
+        """Verify SQLite foreign key constraints are active (PRAGMA foreign_keys=ON)."""
+        author = Author(
+            full_name="Test Author",
+            first_name="Test",
+            last_name="Author",
+            canonical_name="Author, Test",
+        )
+        session.add(author)
+        session.commit()
+        session.refresh(author)
+
+        session.add(Authorship(article_id=uuid4(), author_id=author.id, author_order=1))
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+
+
+class TestAuthorIdentifiers:
+    """Tests for author identifier relationships and constraints."""
+
+    def test_author_identifiers_relationship(self, session: Session):
+        """Test that author identifiers are properly linked to authors."""
+        author = Author(
+            full_name="Identified Author",
+            first_name="Identified",
+            last_name="Author",
+            canonical_name="Author, Identified",
+        )
+
+        session.add(author)
+        session.commit()
+        session.refresh(author)
+
+        # Add identifiers
+        orcid = AuthorIdentifier(
+            author_id=author.id, authority="ORCID", identifier="0000-0000-0000-0001"
+        )
+
+        institutional_id = AuthorIdentifier(
+            author_id=author.id, authority="UW", identifier="uw123456"
+        )
+
+        session.add_all([orcid, institutional_id])
+        session.commit()
+
+        # Verify relationship
+        session.refresh(author)
+        assert len(author.identifiers) == 2
+
+        identifier_pairs = {(id.authority, id.identifier) for id in author.identifiers}
+        expected_pairs = {("ORCID", "0000-0000-0000-0001"), ("UW", "uw123456")}
+        assert identifier_pairs == expected_pairs
+
+    def test_delete_author_removes_identifiers(self, session: Session):
+        """Deleting an author should remove related identifier rows."""
+        author = Author(
+            full_name="Identified Author",
+            first_name="Identified",
+            last_name="Author",
+            canonical_name="Author, Identified",
+        )
+        session.add(author)
+        session.commit()
+        session.refresh(author)
+
+        session.add_all(
+            [
+                AuthorIdentifier(
+                    author_id=author.id, authority="ORCID", identifier="0000-0000-0000-0002"
+                ),
+                AuthorIdentifier(author_id=author.id, authority="UW", identifier="uw654321"),
+            ]
+        )
+        session.commit()
+        assert len(session.exec(select(AuthorIdentifier)).all()) == 2
+
+        session.delete(author)
+        session.commit()
+
+        assert len(session.exec(select(AuthorIdentifier)).all()) == 0
+
+
+class TestAuthorConstraints:
+    """Tests for constraints on the Author model itself."""
+
+    def test_author_requires_canonical_name(self, session: Session):
+        """Creating an author without canonical_name should fail at commit time."""
+        author = Author(full_name="Missing Canonical", first_name="Missing", last_name="Canonical")
+        session.add(author)
+
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
 
 
 class TestAuthorAffiliations:


### PR DESCRIPTION
The pipeline creates appropriate entries in `authorship` table (née `articleauthor`) for existing authors in `author`, matching by name against `article.authors`.