### PR TITLE
Quieter dropped item logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,10 @@ follow_imports = "skip"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+module = "open_ire.settings.*"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
 module = "tests.*"
 check_untyped_defs = false
 disallow_incomplete_defs = false

--- a/src/open_ire/logging.py
+++ b/src/open_ire/logging.py
@@ -1,7 +1,30 @@
 import logging
-from typing import Self
+from typing import Any, Self
 
 from scrapy.crawler import Crawler
+from scrapy.logformatter import LogFormatter, LogFormatterResult
+from scrapy.spiders import Spider
+
+
+class OpenIRELogFormatter(LogFormatter):
+    """Scrapy log formatter with optional dropped-item suppression."""
+
+    def dropped(
+        self,
+        item: Any,
+        exception: BaseException,
+        response: Any,
+        spider: Spider,
+    ) -> LogFormatterResult:
+        result = super().dropped(item, exception, response, spider)
+        show_item = spider.crawler.settings.getbool("OPEN_IRE_LOG_DROPPED_ITEMS", True)
+        if show_item:
+            return result
+        return {
+            "level": result["level"],
+            "msg": "Dropped: %(exception)s",
+            "args": {"exception": exception},
+        }
 
 
 class OpenIRELogger:
@@ -38,5 +61,11 @@ class OpenIRELogger:
         # Capture spider logs emitted via self.logger (named after spider).
         if crawler.spider:
             attach(crawler.spider.name)
+
+        # Override levels based on the OPEN_IRE_LOG_LEVELS setting
+        log_levels: dict[str, str] = crawler.settings.getdict("OPEN_IRE_LOG_LEVELS", {})
+        for logger_name, override_name in log_levels.items():
+            override_level = getattr(logging, str(override_name).upper(), logging.INFO)
+            logging.getLogger(logger_name).setLevel(override_level)
 
         return cls(level_name)

--- a/src/open_ire/pipelines/doi_duplicates_pipeline.py
+++ b/src/open_ire/pipelines/doi_duplicates_pipeline.py
@@ -81,7 +81,7 @@ class DOIDuplicatesPipeline(BaseSQLModelPipeline):
             cached.reference,
             cached.repository,
         )
-        msg = "Article DOI already exists in database."
+        msg = f"Article with DOI {doi} already exists in database."
         raise DropItem(msg)
 
     @staticmethod

--- a/src/open_ire/settings/base.py
+++ b/src/open_ire/settings/base.py
@@ -85,6 +85,16 @@ OPEN_IRE_DEFAULT_TERMS = ",".join(OPEN_IRE_SEARCH_TERMS)
 OPEN_IRE_SKIP_EXISTING = False
 OPEN_IRE_CONTACT_EMAIL = "uwtextmine@uw.edu"
 
+# Default log level for `open_ire` logger
+OPEN_IRE_LOG_LEVEL = "INFO"
+OPEN_IRE_LOG_DROPPED_ITEMS = True
+LOG_FORMATTER = "open_ire.logging.OpenIRELogFormatter"
+# Override log levels for specific modules. For example:
+# OPEN_IRE_LOG_LEVELS = {
+#   "open_ire.pipelines.sharepoint_pipeline": "WARNING"
+# }
+OPEN_IRE_LOG_LEVELS = {}
+
 OPEN_IRE_OPENALEX_INSTITUTION_ID = "i201448701"
 OPEN_IRE_OPENALEX_AMBIGUOUS_AUTHORS_FILE = f"{FILES_STORE}/openalex_ambiguous_authors.csv"
 OPEN_IRE_WOS_ORGANIZATION = "University of Washington"

--- a/src/open_ire/settings/development.py
+++ b/src/open_ire/settings/development.py
@@ -4,6 +4,7 @@ from .base import ITEM_PIPELINES
 EXTENSIONS = {"open_ire.logging.OpenIRELogger": 100}
 LOG_LEVEL = "WARNING"
 OPEN_IRE_LOG_LEVEL = "DEBUG"
+OPEN_IRE_LOG_DROPPED_ITEMS = False
 
 SHAREPOINT_BASE_PATH = "open_ire_dev"
 


### PR DESCRIPTION
By default, Scrapy dumps the full dropped item into the log, which quickly obscures any other log lines if there are multiple dropped items (as happens frequently during development). Setting `OPEN_IRE_LOG_DROPPED_ITEMS` to False filters out those logs though OpenIRELogFormatter set in `LOG_FORMATTER` (Scrapy setting).

OPEN_IRE_LOG_LEVELS allows setting per-module log levels.