### PR TITLE
OpenAlex author disambiguation

### DIFF
--- a/src/open_ire/errors.py
+++ b/src/open_ire/errors.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from scrapy.exceptions import DropItem
 
 
@@ -44,14 +42,3 @@ class DatabaseDuplicateItemError(OpenIRError, DropItem):
 
     def __init__(self, message: str | None = None) -> None:
         super().__init__(message or "Duplicate item found in database.")
-
-
-class AmbiguousAuthorError(OpenIRError):
-    """Raised when author disambiguation fails."""
-
-    def __init__(self, author_name: str, candidates: list[dict[str, Any]], reason: str) -> None:
-        message = f"Cannot disambiguate '{author_name}': {reason} ({len(candidates)} candidates)"
-        super().__init__(message)
-        self.author_name = author_name
-        self.candidates = candidates
-        self.reason = reason

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -563,15 +563,9 @@ class OpenAlexSpider(AuthorSearchSpider):
             cb_kwargs={"author_id": author_id},
         )
 
-    def _build_author_item(self, searched_author: str, author: OpenAlexAuthor) -> AuthorItem:
-        """Build an AuthorItem from our data and OpenAlex author data."""
-        return AuthorItem(
-            author=ParsedAuthor(searched_author),
-            identifiers=author.identifiers(),
-        )
-
+    @staticmethod
     def _build_author_item_from_choices(
-        self, searched_author: str, choices: list[dict[str, str]]
+        searched_author: str, choices: list[dict[str, str]]
     ) -> AuthorItem:
         """Build an AuthorItem from pre-resolved CSV choices (may include multiple OpenAlex IDs)."""
         identifiers: list[dict[str, str]] = []

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -393,9 +393,9 @@ class OpenAlexSpider(AuthorSearchSpider):
         """Parse author search results and yield AuthorItems and publications requests."""
         searched_author = response.meta["searched_author"]
         raw = json.loads(response.text or "{}")
-        authors = [OpenAlexAuthor.from_api(result) for result in raw.get("results", [])]
+        found_authors = [OpenAlexAuthor.from_api(result) for result in raw.get("results", [])]
 
-        if not authors:
+        if not found_authors:
             self.logger.warning("No authors found matching '%s'", searched_author)
             return
 
@@ -404,14 +404,20 @@ class OpenAlexSpider(AuthorSearchSpider):
             yield from self._resolved_author_search_results(searched_author)
             return
 
-        # Single result or disambiguate among multiple.
-        the_author = self._disambiguate_authors(searched_author, authors)
-        if the_author is None:
+        authors_to_use = self._disambiguated_authors(searched_author, found_authors)
+        if not authors_to_use:
             return
 
+        # Build AuthorItem with identifiers from all the disambiguated candidates.
+        combined_identifiers: list[dict[str, str]] = []
+        for au in authors_to_use:
+            combined_identifiers.extend(au.identifiers())
         self.items_generated["AuthorItem"] += 1
-        yield self._build_author_item(searched_author, the_author)
-        yield self._build_publications_request(the_author.id, searched_author)
+        yield AuthorItem(author=ParsedAuthor(searched_author), identifiers=combined_identifiers)
+
+        # Request publications for each distinct OpenAlex ID.
+        for au in authors_to_use:
+            yield self._build_publications_request(au.id, searched_author)
 
     def _resolved_author_search_results(
         self, searched_author: str
@@ -429,10 +435,10 @@ class OpenAlexSpider(AuthorSearchSpider):
             if openalex_id:
                 yield self._build_publications_request(openalex_id, searched_author)
 
-    def _disambiguate_authors(
-        self, searched_author: str, authors: list[OpenAlexAuthor]
-    ) -> OpenAlexAuthor | None:
-        """Try to identify a single author from multiple OpenAlex results.
+    def _disambiguated_authors(
+        self, searched_author: str, found_authors: list[OpenAlexAuthor]
+    ) -> list[OpenAlexAuthor]:
+        """Try to identify one or more authors from multiple OpenAlex results.
 
         Applies two filters in sequence:
         1. Name match — discard candidates whose display_name doesn't plausibly
@@ -440,18 +446,27 @@ class OpenAlexSpider(AuthorSearchSpider):
         2. Institutional affiliation — among name matches, keep only those
            affiliated with our institution.
 
-        Returns the author if unambiguous, or None if the search is ambiguous
-        (in which case the author is recorded for manual resolution).
+        Returns a non-empty list of authors to use, or an empty list if the
+        search is truly ambiguous (in which case the author is recorded for
+        manual resolution). Multiple results indicate likely-fragmented
+        OpenAlex records for the same person.
         """
-        if len(authors) == 1:
-            return authors[0]
+        if len(found_authors) == 1:
+            return found_authors
 
-        self.logger.info("Found %s authors matching '%s'", len(authors), searched_author)
+        self.logger.info("Found %s authors matching '%s'", len(found_authors), searched_author)
 
         parsed_searched = ParsedAuthor(searched_author)
         name_matches = [
-            au for au in authors if ParsedAuthor(au.display_name).likely_same(parsed_searched)
+            au for au in found_authors if ParsedAuthor(au.display_name).likely_same(parsed_searched)
         ]
+        if not name_matches:
+            self.ambiguous_authors.append(
+                AmbiguousAuthor(
+                    searched_author, found_authors, "no candidates with matching display name"
+                )
+            )
+            return []
         if len(name_matches) == 1:
             self.logger.info(
                 "Disambiguated '%s' to '%s' (ID: %s) based on name match",
@@ -459,16 +474,19 @@ class OpenAlexSpider(AuthorSearchSpider):
                 name_matches[0].display_name,
                 name_matches[0].id,
             )
-            return name_matches[0]
-        if not name_matches:
-            self.ambiguous_authors.append(
-                AmbiguousAuthor(
-                    searched_author, authors, "no candidates with matching display name"
-                )
-            )
-            return None
+            return name_matches
 
         affiliated = [au for au in name_matches if au.years_at_institution(self.our_institution_id)]
+
+        if not affiliated:
+            self.ambiguous_authors.append(
+                AmbiguousAuthor(
+                    searched_author,
+                    name_matches,
+                    "no name-matched authors with institutional affiliation",
+                )
+            )
+            return []
 
         if len(affiliated) == 1:
             self.logger.info(
@@ -477,18 +495,15 @@ class OpenAlexSpider(AuthorSearchSpider):
                 affiliated[0].display_name,
                 affiliated[0].id,
             )
-            return affiliated[0]
-
-        self.ambiguous_authors.append(
-            AmbiguousAuthor(
+        else:
+            self.logger.warning(
+                "Auto-merging %s name-matched, affiliated candidates for '%s' "
+                "(likely fragmented OpenAlex records)",
+                len(affiliated),
                 searched_author,
-                affiliated or name_matches,
-                "no name-matched authors with institutional affiliation"
-                if not affiliated
-                else "multiple name-matched authors with institutional affiliation",
             )
-        )
-        return None
+
+        return affiliated
 
     def _build_publications_request(
         self, author_id: str, searched_author: str, cursor: str = "*"

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -8,13 +8,16 @@ from typing import Any, ClassVar
 from urllib.parse import urlencode
 
 from scrapy.http import Request, Response
+from sqlmodel import Session, create_engine
 
 from open_ire.author import ParsedAuthor
 from open_ire.enums import ArticleType
 from open_ire.errors import AmbiguousAuthorError
 from open_ire.items import ArticleItem, AuthorItem
+from open_ire.pipelines.author_identifier_pipeline import find_author_by_name
 from open_ire.settings import (
     OPEN_IRE_CONTACT_EMAIL,
+    OPEN_IRE_DATABASE_FILE,
     OPEN_IRE_OPENALEX_AMBIGUOUS_AUTHORS_FILE,
     OPEN_IRE_OPENALEX_INSTITUTION_ID,
 )
@@ -46,6 +49,8 @@ class OpenAlexSpider(AuthorSearchSpider):
         self.request_headers: dict[str, str] = {"User-Agent": f"mailto:{OPEN_IRE_CONTACT_EMAIL}"}
         self.ambiguous_authors_file = Path(OPEN_IRE_OPENALEX_AMBIGUOUS_AUTHORS_FILE)
         self._ambiguous_authors: list[dict[str, Any]] = []
+        self._resolved_choices: dict[str, list[dict[str, str]]] = {}
+        self._load_resolved_choices()
 
     def author_name_for_query(self, record: ParsedAuthor) -> str:
         return " ".join(
@@ -53,9 +58,25 @@ class OpenAlexSpider(AuthorSearchSpider):
         )
 
     def build_search_request(self, record: ParsedAuthor) -> Request:
-        """Build the initial search request for a given author record."""
-        term = self.author_name_for_query(record)
+        """Build a request for a given author record.
+
+        If the author already has known OpenAlex IDs in the database, skip the
+        author search and go straight to fetching publications. Otherwise, search
+        for the author via the OpenAlex API.
+        """
         searched_author = self.canonical_author_name(record)
+
+        known_ids = self._find_known_openalex_ids(record)
+        if known_ids:
+            author_id_filter = "|".join(known_ids)
+            self.logger.info(
+                "Found %s known OpenAlex ID(s) for '%s'; skipping author search",
+                len(known_ids),
+                searched_author,
+            )
+            return self._build_publications_request(author_id_filter, searched_author)
+
+        term = self.author_name_for_query(record)
         params = {
             "search": term,
             "filter": f"affiliations.institution.id:{self.our_institution_id}",
@@ -103,6 +124,21 @@ class OpenAlexSpider(AuthorSearchSpider):
                 author.get("relevance_score"),
             )
 
+        # Use pre-resolved choices from the ambiguous authors CSV, if available.
+        if searched_author in self._resolved_choices:
+            chosen = self._resolved_choices[searched_author]
+            self.logger.info(
+                "Using %s pre-resolved choice(s) for '%s'",
+                len(chosen),
+                searched_author,
+            )
+            yield self._build_author_item_from_choices(searched_author, chosen)
+            for choice in chosen:
+                openalex_id = choice["openalex_id"]
+                if openalex_id:
+                    yield self._build_publications_request(openalex_id, searched_author)
+            return
+
         the_author = authors[0] if len(authors) == 1 else None
         if not the_author:
             try:
@@ -115,12 +151,12 @@ class OpenAlexSpider(AuthorSearchSpider):
         yield self._build_author_item(searched_author, the_author)
 
         author_id = self._extract_author_id(the_author, searched_author)
-        yield from self._request_author_publications(author_id, searched_author)
+        yield self._build_publications_request(author_id, searched_author)
 
-    def _request_author_publications(
+    def _build_publications_request(
         self, author_id: str, searched_author: str, cursor: str = "*"
-    ) -> Generator[Request, None, None]:
-        """Generate a request for an author's publications with pagination support."""
+    ) -> Request:
+        """Build a request for an author's publications."""
         params = {
             "filter": f"author.id:{author_id},from_publication_date:{self.start_date}",
             "per_page": str(self.page_size),
@@ -137,7 +173,7 @@ class OpenAlexSpider(AuthorSearchSpider):
         )
         self.logger.debug("Publication request URL: %s", url)
 
-        yield Request(
+        return Request(
             url,
             headers=self.request_headers,
             callback=self._parse_publications,
@@ -162,6 +198,29 @@ class OpenAlexSpider(AuthorSearchSpider):
 
         # OpenAlex sometimes provides "parsed_longest_name", but that can
         # introduce surprises, so rely on "our" name.
+        return AuthorItem(
+            author=ParsedAuthor(searched_author),
+            identifiers=identifiers,
+        )
+
+    def _build_author_item_from_choices(
+        self, searched_author: str, choices: list[dict[str, str]]
+    ) -> AuthorItem:
+        """Build an AuthorItem from pre-resolved CSV choices (may include multiple OpenAlex IDs)."""
+        identifiers: list[dict[str, str]] = []
+        seen: set[str] = set()
+
+        for choice in choices:
+            openalex_id = self._id_from_uri(choice.get("openalex_id", ""))
+            if openalex_id and openalex_id not in seen:
+                identifiers.append({"authority": "openalex", "identifier": openalex_id})
+                seen.add(openalex_id)
+
+            orcid = self._id_from_uri(choice.get("orcid", ""))
+            if orcid and orcid not in seen:
+                identifiers.append({"authority": "orcid", "identifier": orcid})
+                seen.add(orcid)
+
         return AuthorItem(
             author=ParsedAuthor(searched_author),
             identifiers=identifiers,
@@ -210,9 +269,7 @@ class OpenAlexSpider(AuthorSearchSpider):
                 yield item
 
         if next_cursor := meta.get("next_cursor"):
-            yield from self._request_author_publications(
-                author_id, searched_author, cursor=next_cursor
-            )
+            yield self._build_publications_request(author_id, searched_author, cursor=next_cursor)
 
     def _build_article_item(
         self, publication_record: dict[str, Any], searched_author: str
@@ -258,6 +315,63 @@ class OpenAlexSpider(AuthorSearchSpider):
         )
 
     # === AUTHOR DISAMBIGUATION ===
+
+    @staticmethod
+    def _find_known_openalex_ids(author: ParsedAuthor) -> list[str]:
+        """Look up existing OpenAlex IDs for an author in the database."""
+        db_path = Path(OPEN_IRE_DATABASE_FILE)
+        if not db_path.exists():
+            return []
+
+        engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+        try:
+            with Session(engine) as session:
+                db_author = find_author_by_name(session, author)
+                if not db_author:
+                    return []
+
+                openalex_ids = []
+                for ident in db_author.identifiers:
+                    if ident.authority == "openalex":
+                        openalex_ids.append(ident.identifier)
+                return openalex_ids
+        finally:
+            engine.dispose()
+
+    TRUTHY_CHOICES = frozenset({"yes", "y", "1", "true"})
+
+    def _load_resolved_choices(self) -> None:
+        """Read the ambiguous authors CSV and extract rows where the user filled in a choice."""
+        if not self.ambiguous_authors_file.exists():
+            return
+
+        with self.ambiguous_authors_file.open(newline="", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            for row in reader:
+                choice = (row.get("choice") or "").strip().lower()
+                if choice not in self.TRUTHY_CHOICES:
+                    continue
+
+                searched_author = row.get("searched_author", "")
+                if not searched_author:
+                    continue
+
+                if searched_author not in self._resolved_choices:
+                    self._resolved_choices[searched_author] = []
+
+                self._resolved_choices[searched_author].append(
+                    {
+                        "openalex_id": row.get("openalex_id", ""),
+                        "orcid": row.get("orcid", ""),
+                    }
+                )
+
+        if self._resolved_choices:
+            self.logger.info(
+                "Loaded pre-resolved choices for %s author(s) from %s",
+                len(self._resolved_choices),
+                self.ambiguous_authors_file,
+            )
 
     Institution = namedtuple("Institution", ["id", "name"])
     Affiliation = namedtuple("Affiliation", ["institution", "years"])
@@ -314,11 +428,18 @@ class OpenAlexSpider(AuthorSearchSpider):
 
     def _write_ambiguous_authors_file(self) -> None:
         """Write a CSV file of ambiguous author records to disk."""
-        if not self._ambiguous_authors:
+        # Filter out authors that have already been resolved via CSV choices.
+        unresolved = [
+            a
+            for a in self._ambiguous_authors
+            if a.get("searched_author") not in self._resolved_choices
+        ]
+        if not unresolved:
+            self._ambiguous_authors.clear()
             return
 
         rows: list[dict[str, str]] = []
-        for ambiguous_author in self._ambiguous_authors:
+        for ambiguous_author in unresolved:
             searched_author = str(ambiguous_author.get("searched_author") or "")
             reason = str(ambiguous_author.get("reason") or "")
 
@@ -379,6 +500,7 @@ class OpenAlexSpider(AuthorSearchSpider):
         ]
 
         return {
+            "choice": "",
             "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             "searched_author": searched_author,
             "candidate_rank": str(rank),
@@ -386,7 +508,7 @@ class OpenAlexSpider(AuthorSearchSpider):
             "ambiguity_reason": ambiguity_reason,
             "openalex_id": openalex_id,
             "display_name": str(author_record.get("display_name", "")),
-            "orcid": self._id_from_uri(str(author_record.get("orcid", ""))),
+            "orcid": self._id_from_uri(str(author_record.get("orcid") or "")),
             "relevance_score": str(author_record.get("relevance_score", -1)),
             "works_count": str(author_record.get("works_count", -1)),
             "cited_by_count": str(author_record.get("cited_by_count", -1)),

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -327,6 +327,11 @@ class OpenAlexSpider(AuthorSearchSpider):
         self.start_date = start_date
         self.our_institution_id = OPEN_IRE_OPENALEX_INSTITUTION_ID.strip().upper()
         self.request_headers: dict[str, str] = {"User-Agent": f"mailto:{OPEN_IRE_CONTACT_EMAIL}"}
+
+        self.items_generated = {
+            "ArticleItem": 0,
+            "AuthorItem": 0,
+        }
         self.ambiguous_authors = AmbiguousAuthorList(Path(OPEN_IRE_OPENALEX_AMBIGUOUS_AUTHORS_FILE))
 
     def author_name_for_query(self, record: ParsedAuthor) -> str:
@@ -373,6 +378,12 @@ class OpenAlexSpider(AuthorSearchSpider):
 
     def closed(self, _reason: str | None = None) -> None:
         self.ambiguous_authors.write(self.our_institution_id)
+
+        logger.info(
+            "Generated %s ArticleItem(s) and %s AuthorItem(s)",
+            self.items_generated["ArticleItem"],
+            self.items_generated["AuthorItem"],
+        )
 
     # === HIGH-LEVEL WORKFLOW METHODS ===
 
@@ -432,6 +443,7 @@ class OpenAlexSpider(AuthorSearchSpider):
                 )
                 return
 
+        self.items_generated["AuthorItem"] += 1
         yield self._build_author_item(searched_author, the_author)
         yield self._build_publications_request(the_author.id, searched_author)
 
@@ -447,13 +459,12 @@ class OpenAlexSpider(AuthorSearchSpider):
         }
         url = f"{self.base_url}/works?{urlencode(params)}"
 
-        self.logger.info(
+        self.logger.debug(
             "Requesting %spublications for %s (ID: %s)",
             "" if cursor == "*" else "next page of ",
             searched_author,
             id_from_uri(author_id),
         )
-        self.logger.debug("Publication request URL: %s", url)
 
         return Request(
             url,
@@ -527,12 +538,7 @@ class OpenAlexSpider(AuthorSearchSpider):
                 continue
 
             if item := self._build_article_item(publication, searched_author):
-                self.logger.info(
-                    "%s: '%s' (%s)",
-                    searched_author,
-                    item.title[:50],
-                    item.publication_date,
-                )
+                self.items_generated["ArticleItem"] += 1
                 yield item
 
         if next_cursor := meta.get("next_cursor"):

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -391,7 +391,6 @@ class OpenAlexSpider(AuthorSearchSpider):
         self, response: Response
     ) -> Generator[Request | AuthorItem, None, None]:
         searched_author = response.meta["searched_author"]
-        the_author = None
         raw = json.loads(response.text or "{}")
         authors = [OpenAlexAuthor.from_api(result) for result in raw.get("results", [])]
 
@@ -399,53 +398,69 @@ class OpenAlexSpider(AuthorSearchSpider):
             self.logger.warning("No authors found matching '%s'", searched_author)
             return
 
-        if len(authors) == 1:
-            the_author = authors[0]
-        elif searched_author in self.ambiguous_authors.resolved_choices:
-            # Use pre-resolved choices from the ambiguous authors CSV.
-            chosen = self.ambiguous_authors.resolved_choices[searched_author]
-            self.logger.info(
-                "Using %s pre-resolved choice(s) for '%s'",
-                len(chosen),
-                searched_author,
-            )
-            yield self._build_author_item_from_choices(searched_author, chosen)
-            for choice in chosen:
-                openalex_id = choice[AmbiguousAuthor.FIELD_OPENALEX_ID]
-                if openalex_id:
-                    yield self._build_publications_request(openalex_id, searched_author)
+        # Pre-resolved ambiguous authors take priority.
+        if searched_author in self.ambiguous_authors.resolved_choices:
+            yield from self._items_for_resolved_author(searched_author)
             return
-        else:
-            self.logger.info("Found %s authors matching '%s'", len(authors), searched_author)
-            affiliated = [au for au in authors if au.years_at_institution(self.our_institution_id)]
-            if len(affiliated) == 1:
-                the_author = affiliated[0]
-                self.logger.info(
-                    "Disambiguated '%s' to '%s' (ID: %s) based on institutional affiliation",
-                    searched_author,
-                    the_author.display_name,
-                    the_author.id,
-                )
-            elif not affiliated:
-                self.ambiguous_authors.append(
-                    AmbiguousAuthor(
-                        searched_author, authors, "no authors with institutional affiliation"
-                    )
-                )
-                return
-            else:
-                self.ambiguous_authors.append(
-                    AmbiguousAuthor(
-                        searched_author,
-                        affiliated,
-                        "multiple authors with institutional affiliation",
-                    )
-                )
-                return
+
+        # Single result or disambiguate among multiple.
+        the_author = self._disambiguate_authors(searched_author, authors)
+        if the_author is None:
+            return
 
         self.items_generated["AuthorItem"] += 1
         yield self._build_author_item(searched_author, the_author)
         yield self._build_publications_request(the_author.id, searched_author)
+
+    def _items_for_resolved_author(
+        self, searched_author: str
+    ) -> Generator[Request | AuthorItem, None, None]:
+        """Yield items for a pre-resolved ambiguous author from the CSV."""
+        chosen = self.ambiguous_authors.resolved_choices[searched_author]
+        self.logger.info(
+            "Using %s pre-resolved choice(s) for '%s'",
+            len(chosen),
+            searched_author,
+        )
+        yield self._build_author_item_from_choices(searched_author, chosen)
+        for choice in chosen:
+            openalex_id = choice[AmbiguousAuthor.FIELD_OPENALEX_ID]
+            if openalex_id:
+                yield self._build_publications_request(openalex_id, searched_author)
+
+    def _disambiguate_authors(
+        self, searched_author: str, authors: list[OpenAlexAuthor]
+    ) -> OpenAlexAuthor | None:
+        """Try to identify a single author from multiple OpenAlex results.
+
+        Returns the author if unambiguous, or None if the search is ambiguous
+        (in which case the author is recorded for manual resolution).
+        """
+        if len(authors) == 1:
+            return authors[0]
+
+        self.logger.info("Found %s authors matching '%s'", len(authors), searched_author)
+        affiliated = [au for au in authors if au.years_at_institution(self.our_institution_id)]
+
+        if len(affiliated) == 1:
+            self.logger.info(
+                "Disambiguated '%s' to '%s' (ID: %s) based on institutional affiliation",
+                searched_author,
+                affiliated[0].display_name,
+                affiliated[0].id,
+            )
+            return affiliated[0]
+
+        self.ambiguous_authors.append(
+            AmbiguousAuthor(
+                searched_author,
+                affiliated or authors,
+                "no authors with institutional affiliation"
+                if not affiliated
+                else "multiple authors with institutional affiliation",
+            )
+        )
+        return None
 
     def _build_publications_request(
         self, author_id: str, searched_author: str, cursor: str = "*"

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -1,7 +1,8 @@
 import csv
 import json
-from collections import namedtuple
+import logging
 from collections.abc import Generator
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, ClassVar
@@ -12,7 +13,6 @@ from sqlmodel import Session, create_engine
 
 from open_ire.author import ParsedAuthor
 from open_ire.enums import ArticleType
-from open_ire.errors import AmbiguousAuthorError
 from open_ire.items import ArticleItem, AuthorItem
 from open_ire.pipelines.author_identifier_pipeline import find_author_by_name
 from open_ire.settings import (
@@ -23,6 +23,286 @@ from open_ire.settings import (
 )
 from open_ire.spiders.search import AuthorSearchSpider
 from open_ire.utils import parse_date
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+# === MODULE-LEVEL UTILITIES ===
+
+
+def id_from_uri(uri: str) -> str:
+    """Extract the ID part from a full URI (e.g., OpenAlex or ORCID).
+
+    Examples:
+        https://openalex.org/A5077779935 => A5077779935
+        https://orcid.org/0000-0002-4664-9847 => 0000-0002-4664-9847
+
+    Returns:
+         Upcased ID string, or input string if the string is not a URI."""
+    if not uri.startswith(("https://", "http://")):
+        return uri
+    return uri.split("/")[-1].upper()
+
+
+# === OPENALEX API DATACLASSES ===
+
+
+@dataclass(frozen=True, slots=True)
+class OpenAlexInstitution:
+    """
+    Institution object from OpenAlex API.
+
+    See https://docs.openalex.org/api-entities/institutions/institution-object
+    """
+
+    id: str
+    display_name: str
+    raw: dict[str, Any]
+
+    @classmethod
+    def from_api(cls, record: dict[str, Any]) -> "OpenAlexInstitution":
+        return cls(
+            id=record["id"],
+            display_name=record["display_name"],
+            raw=record,
+        )
+
+    def matches_institution(self, institution_id: str) -> bool:
+        """Check if this institution matches the given ID (case-insensitive, URI-tolerant)."""
+        return id_from_uri(self.id).casefold() == id_from_uri(institution_id).casefold()
+
+
+@dataclass(frozen=True, slots=True)
+class OpenAlexAffiliation:
+    """
+    Affiliation dictionary from OpenAlex API.
+
+    See https://docs.openalex.org/api-entities/authors/author-object#affiliations
+    """
+
+    institution: OpenAlexInstitution
+    years: list[int]
+    raw: dict[str, Any]
+
+    @classmethod
+    def from_api(cls, record: dict[str, Any]) -> "OpenAlexAffiliation":
+        return cls(
+            institution=OpenAlexInstitution.from_api(record["institution"]),
+            years=record["years"],
+            raw=record,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class OpenAlexAuthor:
+    """
+    Author object from OpenAlex API.
+
+    See https://docs.openalex.org/api-entities/authors/author-object
+    """
+
+    id: str
+    display_name: str
+    orcid: str | None
+    relevance_score: float
+    works_count: int
+    cited_by_count: int
+    last_known_institutions: list[OpenAlexInstitution]
+    affiliations: list[OpenAlexAffiliation]
+    raw: dict[str, Any]
+
+    @classmethod
+    def from_api(cls, record: dict[str, Any]) -> "OpenAlexAuthor":
+        return cls(
+            id=record["id"],
+            display_name=record["display_name"],
+            orcid=record.get("orcid") or None,
+            relevance_score=record.get("relevance_score") or 0.0,
+            works_count=record.get("works_count") or 0,
+            cited_by_count=record.get("cited_by_count") or 0,
+            last_known_institutions=[
+                OpenAlexInstitution.from_api(inst)
+                for inst in record.get("last_known_institutions") or []
+            ],
+            affiliations=[
+                OpenAlexAffiliation.from_api(affiliation)
+                for affiliation in record.get("affiliations") or []
+            ],
+            raw=record,
+        )
+
+    def years_at_institution(self, institution_id: str) -> set[int]:
+        """Extract the years of affiliation with an institution."""
+        years: set[int] = set()
+        for affiliation in self.affiliations:
+            if not affiliation.institution.matches_institution(institution_id):
+                continue
+            years.update(affiliation.years)
+        return years
+
+    def identifiers(self) -> list[dict[str, str]]:
+        """Return all known identifiers for this author from the OpenAlex `ids` dict."""
+        result: list[dict[str, str]] = []
+        for authority, identifier in (self.raw.get("ids") or {}).items():
+            if identifier:
+                result.append({"authority": authority, "identifier": identifier})
+        return result
+
+
+# === AMBIGUOUS AUTHOR TRACKING ===
+
+
+@dataclass(frozen=True, slots=True)
+class AmbiguousAuthor:
+    """An author search that returned multiple candidates requiring manual disambiguation."""
+
+    searched_author: str
+    candidates: list[OpenAlexAuthor]
+    ambiguity_reason: str
+
+    FIELD_CHOICE: ClassVar[str] = "choice"
+    FIELD_SEARCHED_AUTHOR: ClassVar[str] = "searched_author_name"
+    FIELD_OPENALEX_ID: ClassVar[str] = "openalex_id"
+    FIELD_ORCID: ClassVar[str] = "orcid"
+
+    CSV_FIELDNAMES: ClassVar[list[str]] = [
+        "choice",
+        "timestamp",
+        "searched_author_name",
+        "candidate_rank",
+        "candidate_count",
+        "display_name",
+        "openalex_id",
+        "orcid",
+        "relevance_score",
+        "works_count",
+        "cited_by_count",
+        "years_affiliated_with_us",
+        "last_known_institutions",
+    ]
+
+    def to_csv_rows(self, institution_id: str) -> list[dict[str, str]]:
+        """Build CSV rows for all candidates."""
+        rows: list[dict[str, str]] = []
+        for rank, candidate in enumerate(self.candidates, start=1):
+            our_years = candidate.years_at_institution(institution_id)
+            row = {
+                self.FIELD_CHOICE: "",
+                "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                self.FIELD_SEARCHED_AUTHOR: self.searched_author,
+                "candidate_rank": str(rank),
+                "candidate_count": str(len(self.candidates)),
+                "display_name": candidate.display_name,
+                self.FIELD_OPENALEX_ID: candidate.id,
+                self.FIELD_ORCID: candidate.orcid or "",
+                "relevance_score": str(candidate.relevance_score),
+                "works_count": str(candidate.works_count),
+                "cited_by_count": str(candidate.cited_by_count),
+                "years_affiliated_with_us": ",".join([str(y) for y in sorted(our_years)]),
+                "last_known_institutions": ";".join(
+                    inst.display_name for inst in candidate.last_known_institutions
+                ),
+            }
+            rows.append(row)
+        return rows
+
+
+class AmbiguousAuthorList:
+    """Manages the list of ambiguous authors and their CSV persistence."""
+
+    TRUTHY_CHOICES: ClassVar[frozenset[str]] = frozenset({"yes", "y", "1", "true"})
+
+    def __init__(self, file_path: Path) -> None:
+        self.file_path = file_path
+        self.entries: list[AmbiguousAuthor] = []
+        self.existing_csv_entries: set[tuple[str, str]] = set()
+        self.resolved_choices: dict[str, list[dict[str, str]]] = {}
+        self._load_resolved_choices()
+
+    def append(self, entry: AmbiguousAuthor) -> None:
+        self.entries.append(entry)
+
+    def write(self, institution_id: str) -> None:
+        """Append new ambiguous author rows to the CSV file."""
+        unresolved = [aa for aa in self.entries if aa.searched_author not in self.resolved_choices]
+        if not unresolved:
+            self.entries.clear()
+            return
+
+        rows: list[dict[str, str]] = []
+        for aa in unresolved:
+            for row in aa.to_csv_rows(institution_id):
+                key = (
+                    row[AmbiguousAuthor.FIELD_SEARCHED_AUTHOR],
+                    row[AmbiguousAuthor.FIELD_OPENALEX_ID],
+                )
+                if key in self.existing_csv_entries:
+                    continue
+                rows.append(row)
+
+        if not rows:
+            self.entries.clear()
+            return
+
+        self.file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_exists = self.file_path.exists()
+
+        with self.file_path.open("a", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, AmbiguousAuthor.CSV_FIELDNAMES)
+            if not file_exists:
+                writer.writeheader()
+            writer.writerows(rows)
+
+        unique_searched_authors = {
+            row[AmbiguousAuthor.FIELD_SEARCHED_AUTHOR]
+            for row in rows
+            if row.get(AmbiguousAuthor.FIELD_SEARCHED_AUTHOR)
+        }
+        logger.warning(
+            "Added %s ambiguous OpenAlex author(s) to %s",
+            len(unique_searched_authors),
+            self.file_path,
+        )
+        self.entries.clear()
+
+    def _load_resolved_choices(self) -> None:
+        """Read the ambiguous authors CSV and extract rows where the user filled in a choice."""
+        if not self.file_path.exists():
+            return
+
+        with self.file_path.open(newline="", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            for row in reader:
+                searched_author = row.get(AmbiguousAuthor.FIELD_SEARCHED_AUTHOR, "")
+                openalex_id = row.get(AmbiguousAuthor.FIELD_OPENALEX_ID, "")
+                if not searched_author:
+                    continue
+
+                self.existing_csv_entries.add((searched_author, openalex_id))
+
+                choice = (row.get(AmbiguousAuthor.FIELD_CHOICE) or "").strip().lower()
+                if choice not in self.TRUTHY_CHOICES:
+                    continue
+
+                if searched_author not in self.resolved_choices:
+                    self.resolved_choices[searched_author] = []
+
+                self.resolved_choices[searched_author].append(
+                    {
+                        AmbiguousAuthor.FIELD_OPENALEX_ID: openalex_id,
+                        AmbiguousAuthor.FIELD_ORCID: row.get(AmbiguousAuthor.FIELD_ORCID, ""),
+                    }
+                )
+
+        if self.resolved_choices:
+            logger.info(
+                "Loaded pre-resolved choices for %s author(s) from %s",
+                len(self.resolved_choices),
+                self.file_path,
+            )
+
+
+# === SPIDER ===
 
 
 class OpenAlexSpider(AuthorSearchSpider):
@@ -47,10 +327,7 @@ class OpenAlexSpider(AuthorSearchSpider):
         self.start_date = start_date
         self.our_institution_id = OPEN_IRE_OPENALEX_INSTITUTION_ID.strip().upper()
         self.request_headers: dict[str, str] = {"User-Agent": f"mailto:{OPEN_IRE_CONTACT_EMAIL}"}
-        self.ambiguous_authors_file = Path(OPEN_IRE_OPENALEX_AMBIGUOUS_AUTHORS_FILE)
-        self._ambiguous_authors: list[dict[str, Any]] = []
-        self._resolved_choices: dict[str, list[dict[str, str]]] = {}
-        self._load_resolved_choices()
+        self.ambiguous_authors = AmbiguousAuthorList(Path(OPEN_IRE_OPENALEX_AMBIGUOUS_AUTHORS_FILE))
 
     def author_name_for_query(self, record: ParsedAuthor) -> str:
         return " ".join(
@@ -90,43 +367,32 @@ class OpenAlexSpider(AuthorSearchSpider):
         return Request(
             url,
             headers=self.request_headers,
-            callback=self._search_for_authors,
+            callback=self._parse_author_search_results,
             meta={"searched_author": searched_author},
         )
 
     def closed(self, _reason: str | None = None) -> None:
-        self._write_ambiguous_authors_file()
+        self.ambiguous_authors.write(self.our_institution_id)
 
     # === HIGH-LEVEL WORKFLOW METHODS ===
 
-    def _search_for_authors(
+    def _parse_author_search_results(
         self, response: Response
     ) -> Generator[Request | AuthorItem, None, None]:
-        """Parse author search results and generate publication requests."""
         searched_author = response.meta["searched_author"]
-        data = json.loads(response.text or "{}")
-        authors = data.get("results", [])
+        the_author = None
+        raw = json.loads(response.text or "{}")
+        authors = [OpenAlexAuthor.from_api(result) for result in raw.get("results", [])]
 
         if not authors:
-            self.logger.info("No authors found matching '%s'", searched_author)
+            self.logger.warning("No authors found matching '%s'", searched_author)
             return
 
-        self.logger.info("Found %s authors matching '%s':", len(authors), searched_author)
-        for i, author in enumerate(authors):
-            author_id = self._extract_author_id(author, searched_author)
-
-            self.logger.info(
-                "%s) '%s' (ID: %s, ORCID: %s, relevance: %s)",
-                f"{i + 1:2d}",
-                author.get("display_name"),
-                self._id_from_uri(author_id),
-                author.get("orcid"),
-                author.get("relevance_score"),
-            )
-
-        # Use pre-resolved choices from the ambiguous authors CSV, if available.
-        if searched_author in self._resolved_choices:
-            chosen = self._resolved_choices[searched_author]
+        if len(authors) == 1:
+            the_author = authors[0]
+        elif searched_author in self.ambiguous_authors.resolved_choices:
+            # Use pre-resolved choices from the ambiguous authors CSV.
+            chosen = self.ambiguous_authors.resolved_choices[searched_author]
             self.logger.info(
                 "Using %s pre-resolved choice(s) for '%s'",
                 len(chosen),
@@ -134,24 +400,40 @@ class OpenAlexSpider(AuthorSearchSpider):
             )
             yield self._build_author_item_from_choices(searched_author, chosen)
             for choice in chosen:
-                openalex_id = choice["openalex_id"]
+                openalex_id = choice[AmbiguousAuthor.FIELD_OPENALEX_ID]
                 if openalex_id:
                     yield self._build_publications_request(openalex_id, searched_author)
             return
-
-        the_author = authors[0] if len(authors) == 1 else None
-        if not the_author:
-            try:
-                the_author = self._disambiguate_authors(authors, searched_author)
-            except AmbiguousAuthorError as e:
-                self.logger.warning("%s", e)
-                self._add_to_ambiguous_authors(searched_author, e.candidates, e.reason)
+        else:
+            self.logger.info("Found %s authors matching '%s'", len(authors), searched_author)
+            affiliated = [au for au in authors if au.years_at_institution(self.our_institution_id)]
+            if len(affiliated) == 1:
+                the_author = affiliated[0]
+                self.logger.info(
+                    "Disambiguated '%s' to '%s' (ID: %s) based on institutional affiliation",
+                    searched_author,
+                    the_author.display_name,
+                    the_author.id,
+                )
+            elif not affiliated:
+                self.ambiguous_authors.append(
+                    AmbiguousAuthor(
+                        searched_author, authors, "no authors with institutional affiliation"
+                    )
+                )
+                return
+            else:
+                self.ambiguous_authors.append(
+                    AmbiguousAuthor(
+                        searched_author,
+                        affiliated,
+                        "multiple authors with institutional affiliation",
+                    )
+                )
                 return
 
         yield self._build_author_item(searched_author, the_author)
-
-        author_id = self._extract_author_id(the_author, searched_author)
-        yield self._build_publications_request(author_id, searched_author)
+        yield self._build_publications_request(the_author.id, searched_author)
 
     def _build_publications_request(
         self, author_id: str, searched_author: str, cursor: str = "*"
@@ -169,7 +451,7 @@ class OpenAlexSpider(AuthorSearchSpider):
             "Requesting %spublications for %s (ID: %s)",
             "" if cursor == "*" else "next page of ",
             searched_author,
-            self._id_from_uri(author_id),
+            id_from_uri(author_id),
         )
         self.logger.debug("Publication request URL: %s", url)
 
@@ -181,26 +463,11 @@ class OpenAlexSpider(AuthorSearchSpider):
             cb_kwargs={"author_id": author_id},
         )
 
-    def _build_author_item(self, searched_author: str, author_record: dict[str, Any]) -> AuthorItem:
+    def _build_author_item(self, searched_author: str, author: OpenAlexAuthor) -> AuthorItem:
         """Build an AuthorItem from our data and OpenAlex author data."""
-        identifiers = []
-
-        if openalex_id := author_record.get("id"):
-            identifiers.append(
-                {
-                    "authority": "openalex",
-                    "identifier": self._id_from_uri(openalex_id),
-                }
-            )
-
-        if orcid_url := author_record.get("orcid"):
-            identifiers.append({"authority": "orcid", "identifier": self._id_from_uri(orcid_url)})
-
-        # OpenAlex sometimes provides "parsed_longest_name", but that can
-        # introduce surprises, so rely on "our" name.
         return AuthorItem(
             author=ParsedAuthor(searched_author),
-            identifiers=identifiers,
+            identifiers=author.identifiers(),
         )
 
     def _build_author_item_from_choices(
@@ -211,12 +478,12 @@ class OpenAlexSpider(AuthorSearchSpider):
         seen: set[str] = set()
 
         for choice in choices:
-            openalex_id = self._id_from_uri(choice.get("openalex_id", ""))
+            openalex_id = id_from_uri(choice.get(AmbiguousAuthor.FIELD_OPENALEX_ID, ""))
             if openalex_id and openalex_id not in seen:
                 identifiers.append({"authority": "openalex", "identifier": openalex_id})
                 seen.add(openalex_id)
 
-            orcid = self._id_from_uri(choice.get("orcid", ""))
+            orcid = id_from_uri(choice.get(AmbiguousAuthor.FIELD_ORCID, ""))
             if orcid and orcid not in seen:
                 identifiers.append({"authority": "orcid", "identifier": orcid})
                 seen.add(orcid)
@@ -245,14 +512,14 @@ class OpenAlexSpider(AuthorSearchSpider):
                 self.logger.info(
                     "No publications found for %s (ID: %s)",
                     searched_author,
-                    self._id_from_uri(author_id),
+                    id_from_uri(author_id),
                 )
             else:
                 self.logger.info(
                     "Found %s publications for %s (ID: %s):",
                     total_count,
                     searched_author,
-                    self._id_from_uri(author_id),
+                    id_from_uri(author_id),
                 )
 
         for _i, publication in enumerate(results):
@@ -338,223 +605,6 @@ class OpenAlexSpider(AuthorSearchSpider):
         finally:
             engine.dispose()
 
-    TRUTHY_CHOICES = frozenset({"yes", "y", "1", "true"})
-
-    def _load_resolved_choices(self) -> None:
-        """Read the ambiguous authors CSV and extract rows where the user filled in a choice."""
-        if not self.ambiguous_authors_file.exists():
-            return
-
-        with self.ambiguous_authors_file.open(newline="", encoding="utf-8") as handle:
-            reader = csv.DictReader(handle)
-            for row in reader:
-                choice = (row.get("choice") or "").strip().lower()
-                if choice not in self.TRUTHY_CHOICES:
-                    continue
-
-                searched_author = row.get("searched_author", "")
-                if not searched_author:
-                    continue
-
-                if searched_author not in self._resolved_choices:
-                    self._resolved_choices[searched_author] = []
-
-                self._resolved_choices[searched_author].append(
-                    {
-                        "openalex_id": row.get("openalex_id", ""),
-                        "orcid": row.get("orcid", ""),
-                    }
-                )
-
-        if self._resolved_choices:
-            self.logger.info(
-                "Loaded pre-resolved choices for %s author(s) from %s",
-                len(self._resolved_choices),
-                self.ambiguous_authors_file,
-            )
-
-    Institution = namedtuple("Institution", ["id", "name"])
-    Affiliation = namedtuple("Affiliation", ["institution", "years"])
-
-    def _disambiguate_authors(
-        self, author_records: list[dict[str, Any]], searched_author: str
-    ) -> dict[str, Any]:
-        """Attempt to disambiguate multiple author matches by recent institutional affiliation.
-
-        Returns a single-element list if disambiguation succeeds.
-        Raises AmbiguousAuthorError if disambiguation fails.
-        """
-        affiliated_authors = []
-
-        for author_record in author_records:
-            affiliations = self._extract_affiliations(author_record)
-            institution_years = self._years_at_institution(self.our_institution_id, affiliations)
-            if not institution_years:
-                continue
-            affiliated_authors.append(author_record)
-
-        if not affiliated_authors or len(affiliated_authors) > 1:
-            rough_number = "no" if not affiliated_authors else "multiple"
-            raise AmbiguousAuthorError(
-                author_name=searched_author,
-                candidates=affiliated_authors,
-                reason=f"{rough_number} authors with institutional affiliation",
-            )
-
-        the_author = affiliated_authors[0]
-        self.logger.info(
-            "Disambiguated '%s' to '%s' (ID: %s) based on recent institutional affiliation",
-            searched_author,
-            the_author.get("display_name"),
-            self._id_from_uri(self._extract_author_id(the_author, searched_author)),
-        )
-        return the_author
-
-    def _add_to_ambiguous_authors(
-        self,
-        searched_author: str,
-        author_records: list[dict[str, Any]],
-        reason: str,
-    ) -> None:
-        """Store one structured ambiguous-author record for the matched author."""
-        self._ambiguous_authors.append(
-            {
-                "searched_author": searched_author,
-                "reason": reason,
-                "start_year": int(self.start_date.split("-")[0]),
-                "candidates": author_records,
-            }
-        )
-
-    def _write_ambiguous_authors_file(self) -> None:
-        """Write a CSV file of ambiguous author records to disk."""
-        # Filter out authors that have already been resolved via CSV choices.
-        unresolved = [
-            a
-            for a in self._ambiguous_authors
-            if a.get("searched_author") not in self._resolved_choices
-        ]
-        if not unresolved:
-            self._ambiguous_authors.clear()
-            return
-
-        rows: list[dict[str, str]] = []
-        for ambiguous_author in unresolved:
-            searched_author = str(ambiguous_author.get("searched_author") or "")
-            reason = str(ambiguous_author.get("reason") or "")
-
-            raw_candidates = ambiguous_author.get("candidates") or []
-            candidates = [c for c in raw_candidates if isinstance(c, dict)]
-            candidate_count = len(candidates)
-
-            for rank, author in enumerate(candidates, start=1):
-                row = self._build_ambiguous_authors_file_row(
-                    searched_author=searched_author,
-                    author_record=author,
-                    rank=rank,
-                    candidate_count=candidate_count,
-                    ambiguity_reason=reason,
-                )
-                rows.append(row)
-
-        if not rows:
-            self._ambiguous_authors.clear()
-            return
-
-        fieldnames = list(rows[0].keys())
-        self.ambiguous_authors_file.parent.mkdir(parents=True, exist_ok=True)
-        file_exists = self.ambiguous_authors_file.exists()
-
-        with self.ambiguous_authors_file.open("a", newline="", encoding="utf-8") as handle:
-            writer = csv.DictWriter(handle, fieldnames)
-            if not file_exists:
-                writer.writeheader()
-            writer.writerows(rows)
-
-        unique_searched_authors = {
-            row["searched_author"] for row in rows if row.get("searched_author")
-        }
-        self.logger.warning(
-            "Added %s ambiguous OpenAlex author(s) to %s",
-            len(unique_searched_authors),
-            self.ambiguous_authors_file,
-        )
-        self._ambiguous_authors.clear()
-
-    def _build_ambiguous_authors_file_row(
-        self,
-        searched_author: str,
-        author_record: dict[str, Any],
-        rank: int,
-        candidate_count: int,
-        ambiguity_reason: str,
-    ) -> dict[str, str]:
-        """Build a single CSV row for manual disambiguation review."""
-        openalex_id = str(author_record.get("id") or "")
-        affiliations = self._extract_affiliations(author_record)
-        our_institution_years = self._years_at_institution(self.our_institution_id, affiliations)
-        last_known_institutions = [
-            self._extract_institution(lki).name
-            for lki in (author_record.get("last_known_institutions", []) or [])
-            if lki is not None
-        ]
-
-        return {
-            "choice": "",
-            "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-            "searched_author": searched_author,
-            "candidate_rank": str(rank),
-            "candidate_count": str(candidate_count),
-            "ambiguity_reason": ambiguity_reason,
-            "openalex_id": openalex_id,
-            "display_name": str(author_record.get("display_name", "")),
-            "orcid": self._id_from_uri(str(author_record.get("orcid") or "")),
-            "relevance_score": str(author_record.get("relevance_score", -1)),
-            "works_count": str(author_record.get("works_count", -1)),
-            "cited_by_count": str(author_record.get("cited_by_count", -1)),
-            "our_institution_years": ",".join([str(y) for y in sorted(our_institution_years)]),
-            "last_known_institutions": ";".join(last_known_institutions),
-        }
-
-    @staticmethod
-    def _years_at_institution(institution_id: str, affiliations: list[Affiliation]) -> set[int]:
-        """Extract the years of affiliation with an institution."""
-        years: set[int] = set()
-        for affiliation in affiliations:
-            if not OpenAlexSpider._same_institution(affiliation.institution.id, institution_id):
-                continue
-            years.update(affiliation.years)
-        return years
-
-    @staticmethod
-    def _extract_affiliations(author_record: dict[str, Any]) -> list[Affiliation]:
-        """Extract institutional affiliation details from an author record."""
-        affiliations: list[OpenAlexSpider.Affiliation] = []
-
-        affiliation_records = author_record.get("affiliations") or []
-        for record in affiliation_records:
-            if not isinstance(record, dict):
-                continue
-
-            institution_record = record.get("institution") or {}
-            if not isinstance(institution_record, dict):
-                continue
-
-            affiliations.append(
-                OpenAlexSpider.Affiliation(
-                    OpenAlexSpider._extract_institution(institution_record), record.get("years", [])
-                )
-            )
-
-        return affiliations
-
-    @staticmethod
-    def _extract_institution(institution_record: dict[str, Any]) -> Institution:
-        """Extract Institution from the institution record."""
-        institution_id = institution_record.get("id", "")
-        institution_name = institution_record.get("display_name", "")
-        return OpenAlexSpider.Institution(institution_id, institution_name)
-
     # === HELPER METHODS ===
 
     @staticmethod
@@ -571,16 +621,6 @@ class OpenAlexSpider(AuthorSearchSpider):
                 authors.append(ParsedAuthor(display_name))
 
         return authors
-
-    @staticmethod
-    def _extract_author_id(author_record: dict[str, Any], searched_author: str) -> str:
-        """Ensure that the author record has an ID and return it."""
-        author_id = author_record.get("id")
-        if not author_id:
-            msg = f"Author match for '{searched_author}' has no ID: {author_record}"
-            raise ValueError(msg)
-        assert isinstance(author_id, str)
-        return author_id
 
     @staticmethod
     def _extract_journal_name(publication_record: dict[str, Any]) -> str | None:
@@ -601,35 +641,6 @@ class OpenAlexSpider(AuthorSearchSpider):
                 return str(display_name)
 
         return None
-
-    @staticmethod
-    def _id_from_uri(uri: str) -> str:
-        """Extract the ID part from a full URI (e.g., OpenAlex or ORCID).
-
-        Examples:
-            https://openalex.org/A5077779935 => A5077779935
-            https://orcid.org/0000-0002-4664-9847 => 0000-0002-4664-9847
-
-        Returns:
-             Upcased ID string, or input string if the string is not a URI."""
-        if not uri.startswith(("https://", "http://")):
-            return uri
-        return uri.split("/")[-1].upper()
-
-    @staticmethod
-    def _same_institution(id_a: str | None, id_b: str | None) -> bool:
-        """Check if two institution IDs are the same.
-
-        Returns:
-            True if the institution IDs are the same, False otherwise. If either ID is None,
-            returns False.
-        """
-        if not id_a or not id_b:
-            return False
-        return (
-            OpenAlexSpider._id_from_uri(id_a).casefold()
-            == OpenAlexSpider._id_from_uri(id_b).casefold()
-        )
 
     # OpenAlex publication type mappings
     # See https://docs.openalex.org/api-entities/works/work-object#type

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -371,7 +371,7 @@ class OpenAlexSpider(AuthorSearchSpider):
         """Build a single CSV row for manual disambiguation review."""
         openalex_id = str(author_record.get("id") or "")
         affiliations = self._extract_affiliations(author_record)
-        institution_years = self._years_at_institution(self.our_institution_id, affiliations)
+        our_institution_years = self._years_at_institution(self.our_institution_id, affiliations)
         last_known_institutions = [
             self._extract_institution(lki).name
             for lki in (author_record.get("last_known_institutions", []) or [])
@@ -390,7 +390,7 @@ class OpenAlexSpider(AuthorSearchSpider):
             "relevance_score": str(author_record.get("relevance_score", -1)),
             "works_count": str(author_record.get("works_count", -1)),
             "cited_by_count": str(author_record.get("cited_by_count", -1)),
-            "years_affiliated": ",".join([str(y) for y in sorted(institution_years)]),
+            "our_institution_years": ",".join([str(y) for y in sorted(our_institution_years)]),
             "last_known_institutions": ";".join(last_known_institutions),
         }
 

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -5,10 +5,11 @@ from collections.abc import Generator
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Self
 from urllib.parse import urlencode
 
 from scrapy.http import Request, Response
+from sqlalchemy.engine import Engine
 from sqlmodel import Session, create_engine
 
 from open_ire.author import ParsedAuthor
@@ -17,7 +18,6 @@ from open_ire.items import ArticleItem, AuthorItem
 from open_ire.pipelines.author_identifier_pipeline import find_author_by_name
 from open_ire.settings import (
     OPEN_IRE_CONTACT_EMAIL,
-    OPEN_IRE_DATABASE_FILE,
     OPEN_IRE_OPENALEX_AMBIGUOUS_AUTHORS_FILE,
     OPEN_IRE_OPENALEX_INSTITUTION_ID,
 )
@@ -334,6 +334,19 @@ class OpenAlexSpider(AuthorSearchSpider):
         }
         self.ambiguous_authors = AmbiguousAuthorList(Path(OPEN_IRE_OPENALEX_AMBIGUOUS_AUTHORS_FILE))
 
+        self.db_engine: Engine | None = None
+
+    @classmethod
+    def from_crawler(cls, crawler: Any, *args: Any, **kwargs: Any) -> Self:
+        spider = super().from_crawler(crawler, *args, **kwargs)
+
+        db_path = crawler.settings.get("OPEN_IRE_DATABASE_FILE")
+        if db_path and Path(db_path).exists():
+            spider.db_engine = create_engine(
+                f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+            )
+        return spider
+
     def author_name_for_query(self, record: ParsedAuthor) -> str:
         return " ".join(
             part for part in [record.first_name, record.middle_names, record.last_name] if part
@@ -384,6 +397,9 @@ class OpenAlexSpider(AuthorSearchSpider):
             self.items_generated["ArticleItem"],
             self.items_generated["AuthorItem"],
         )
+
+        if self.db_engine:
+            self.db_engine.dispose()
 
     # === HIGH-LEVEL WORKFLOW METHODS ===
 
@@ -662,27 +678,21 @@ class OpenAlexSpider(AuthorSearchSpider):
 
     # === AUTHOR DISAMBIGUATION ===
 
-    @staticmethod
-    def _find_known_openalex_ids(author: ParsedAuthor) -> list[str]:
+    def _find_known_openalex_ids(self, author: ParsedAuthor) -> list[str]:
         """Look up existing OpenAlex IDs for an author in the database."""
-        db_path = Path(OPEN_IRE_DATABASE_FILE)
-        if not db_path.exists():
+        if not self.db_engine:
             return []
 
-        engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
-        try:
-            with Session(engine) as session:
-                db_author = find_author_by_name(session, author)
-                if not db_author:
-                    return []
+        with Session(self.db_engine) as session:
+            db_author = find_author_by_name(session, author)
+            if not db_author:
+                return []
 
-                openalex_ids = []
-                for ident in db_author.identifiers:
-                    if ident.authority == "openalex":
-                        openalex_ids.append(ident.identifier)
-                return openalex_ids
-        finally:
-            engine.dispose()
+            openalex_ids = []
+            for ident in db_author.identifiers:
+                if ident.authority == "openalex":
+                    openalex_ids.append(ident.identifier)
+            return openalex_ids
 
     # === HELPER METHODS ===
 

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -495,14 +495,29 @@ class OpenAlexSpider(AuthorSearchSpider):
                 affiliated[0].display_name,
                 affiliated[0].id,
             )
-        else:
-            self.logger.warning(
-                "Auto-merging %s name-matched, affiliated candidates for '%s' "
-                "(likely fragmented OpenAlex records)",
-                len(affiliated),
-                searched_author,
-            )
+            return affiliated
 
+        # Multiple affiliated, name-matched candidates. Use ORCIDs to decide
+        # whether they are likely different people or fragmented records.
+        distinct_orcids = {au.orcid for au in affiliated if au.orcid}
+
+        if len(distinct_orcids) > 1:
+            self.ambiguous_authors.append(
+                AmbiguousAuthor(
+                    searched_author,
+                    affiliated,
+                    "multiple affiliated authors with different ORCIDs",
+                )
+            )
+            return []
+
+        # Zero or one distinct ORCID → likely fragmented records for one person.
+        self.logger.warning(
+            "Auto-merging %s name-matched, affiliated candidates for '%s' "
+            "(likely fragmented OpenAlex records)",
+            len(affiliated),
+            searched_author,
+        )
         return affiliated
 
     def _build_publications_request(

--- a/src/open_ire/spiders/openalex.py
+++ b/src/open_ire/spiders/openalex.py
@@ -390,6 +390,7 @@ class OpenAlexSpider(AuthorSearchSpider):
     def _parse_author_search_results(
         self, response: Response
     ) -> Generator[Request | AuthorItem, None, None]:
+        """Parse author search results and yield AuthorItems and publications requests."""
         searched_author = response.meta["searched_author"]
         raw = json.loads(response.text or "{}")
         authors = [OpenAlexAuthor.from_api(result) for result in raw.get("results", [])]
@@ -398,9 +399,9 @@ class OpenAlexSpider(AuthorSearchSpider):
             self.logger.warning("No authors found matching '%s'", searched_author)
             return
 
-        # Pre-resolved ambiguous authors take priority.
+        # If ambiguous authors were manually resolved, just go with those results.
         if searched_author in self.ambiguous_authors.resolved_choices:
-            yield from self._items_for_resolved_author(searched_author)
+            yield from self._resolved_author_search_results(searched_author)
             return
 
         # Single result or disambiguate among multiple.
@@ -412,10 +413,10 @@ class OpenAlexSpider(AuthorSearchSpider):
         yield self._build_author_item(searched_author, the_author)
         yield self._build_publications_request(the_author.id, searched_author)
 
-    def _items_for_resolved_author(
+    def _resolved_author_search_results(
         self, searched_author: str
     ) -> Generator[Request | AuthorItem, None, None]:
-        """Yield items for a pre-resolved ambiguous author from the CSV."""
+        """Yield results for a manually resolved ambiguous author from the CSV."""
         chosen = self.ambiguous_authors.resolved_choices[searched_author]
         self.logger.info(
             "Using %s pre-resolved choice(s) for '%s'",
@@ -433,6 +434,12 @@ class OpenAlexSpider(AuthorSearchSpider):
     ) -> OpenAlexAuthor | None:
         """Try to identify a single author from multiple OpenAlex results.
 
+        Applies two filters in sequence:
+        1. Name match — discard candidates whose display_name doesn't plausibly
+           match the searched author (catches composite OpenAlex records).
+        2. Institutional affiliation — among name matches, keep only those
+           affiliated with our institution.
+
         Returns the author if unambiguous, or None if the search is ambiguous
         (in which case the author is recorded for manual resolution).
         """
@@ -440,7 +447,28 @@ class OpenAlexSpider(AuthorSearchSpider):
             return authors[0]
 
         self.logger.info("Found %s authors matching '%s'", len(authors), searched_author)
-        affiliated = [au for au in authors if au.years_at_institution(self.our_institution_id)]
+
+        parsed_searched = ParsedAuthor(searched_author)
+        name_matches = [
+            au for au in authors if ParsedAuthor(au.display_name).likely_same(parsed_searched)
+        ]
+        if len(name_matches) == 1:
+            self.logger.info(
+                "Disambiguated '%s' to '%s' (ID: %s) based on name match",
+                searched_author,
+                name_matches[0].display_name,
+                name_matches[0].id,
+            )
+            return name_matches[0]
+        if not name_matches:
+            self.ambiguous_authors.append(
+                AmbiguousAuthor(
+                    searched_author, authors, "no candidates with matching display name"
+                )
+            )
+            return None
+
+        affiliated = [au for au in name_matches if au.years_at_institution(self.our_institution_id)]
 
         if len(affiliated) == 1:
             self.logger.info(
@@ -454,10 +482,10 @@ class OpenAlexSpider(AuthorSearchSpider):
         self.ambiguous_authors.append(
             AmbiguousAuthor(
                 searched_author,
-                affiliated or authors,
-                "no authors with institutional affiliation"
+                affiliated or name_matches,
+                "no name-matched authors with institutional affiliation"
                 if not affiliated
-                else "multiple authors with institutional affiliation",
+                else "multiple name-matched authors with institutional affiliation",
             )
         )
         return None

--- a/tests/spiders/test_openalex.py
+++ b/tests/spiders/test_openalex.py
@@ -389,10 +389,6 @@ class TestAuthorDisambiguation:
         # Should yield nothing; authors are ambiguous
         assert len(emitted) == 0
         assert len(spider.ambiguous_authors.entries) == 1
-        assert (
-            spider.ambiguous_authors.entries[0].ambiguity_reason
-            == "multiple authors with institutional affiliation"
-        )
 
     def test_disambiguate_no_affiliation(self, spider: OpenAlexSpider) -> None:
         authors = [
@@ -405,10 +401,6 @@ class TestAuthorDisambiguation:
         # Should yield nothing; no authors with our affiliation
         assert len(emitted) == 0
         assert len(spider.ambiguous_authors.entries) == 1
-        assert (
-            spider.ambiguous_authors.entries[0].ambiguity_reason
-            == "no authors with institutional affiliation"
-        )
 
     def test_ambiguous_authors_stored_as_structured_records(self, spider: OpenAlexSpider) -> None:
         authors = [

--- a/tests/spiders/test_openalex.py
+++ b/tests/spiders/test_openalex.py
@@ -134,13 +134,12 @@ class TestOpenAlexSpider:
     ) -> None:
         author = sample_authors[0]
         spider = make_spider_with_author_name(author)
-        requests = list(spider._request_author_publications(author_id, author.full_name, cursor))
-        assert len(requests) == 1
-        assert requests[0].url.startswith(spider.base_url + "/works")
-        assert requests[0].cb_kwargs["author_id"] == author_id
-        assert requests[0].meta["searched_author"] == author.full_name
+        request = spider._build_publications_request(author_id, author.full_name, cursor)
+        assert request.url.startswith(spider.base_url + "/works")
+        assert request.cb_kwargs["author_id"] == author_id
+        assert request.meta["searched_author"] == author.full_name
 
-        parsed_url = urlparse(requests[0].url)
+        parsed_url = urlparse(request.url)
         query_params = parse_qs(parsed_url.query)
         assert query_params["cursor"] == [cursor]
 
@@ -189,16 +188,14 @@ class TestOpenAlexSpider:
                 "count": 2,
             },
         }
-        initial_requests = list(
-            spider._request_author_publications(
-                author_id="A1234567890", searched_author=author.full_name, cursor="*"
-            )
+        initial_request = spider._build_publications_request(
+            author_id="A1234567890", searched_author=author.full_name, cursor="*"
         )
         response = HtmlResponse(
-            url=initial_requests[0].url,
+            url=initial_request.url,
             body=json.dumps(publication_data),
             encoding="utf-8",
-            request=initial_requests[0],
+            request=initial_request,
         )
 
         emitted = list(spider._parse_publications(response, author_id="A1234567890"))

--- a/tests/spiders/test_openalex.py
+++ b/tests/spiders/test_openalex.py
@@ -330,7 +330,12 @@ class TestAuthorDisambiguation:
             ]
         return OpenAlexAuthor.from_api(raw)
 
-    def _make_response(self, spider: OpenAlexSpider, authors: list[OpenAlexAuthor]) -> HtmlResponse:
+    def _make_response(
+        self,
+        spider: OpenAlexSpider,
+        authors: list[OpenAlexAuthor],
+        searched_author: str = "Eunjung Kim",
+    ) -> HtmlResponse:
         """Build a fake author-search response from a list of OpenAlexAuthor objects."""
         raw_results = []
         for au in authors:
@@ -351,7 +356,7 @@ class TestAuthorDisambiguation:
         request = Request(
             url="https://api.openalex.org/authors?search=test",
             callback=spider._parse_author_search_results,
-            meta={"searched_author": "Eunjung Kim"},
+            meta={"searched_author": searched_author},
         )
         return HtmlResponse(
             url=request.url,
@@ -378,7 +383,7 @@ class TestAuthorDisambiguation:
         assert isinstance(pub_request, Request)
         assert "A2" in pub_request.url
 
-    def test_disambiguate_multiple_affiliations(self, spider: OpenAlexSpider) -> None:
+    def test_disambiguate_multiple_affiliations_auto_merges(self, spider: OpenAlexSpider) -> None:
         authors = [
             self._make_author("A1", "Eunjung Kim", self.INSTITUTION_ID, [2015, 2016]),
             self._make_author("A2", "Eunjung Kim", self.INSTITUTION_ID, [2010, 2012]),
@@ -386,9 +391,35 @@ class TestAuthorDisambiguation:
         ]
         response = self._make_response(spider, authors)
         emitted = list(spider._parse_author_search_results(response))
-        # Should yield nothing; authors are ambiguous
-        assert len(emitted) == 0
-        assert len(spider.ambiguous_authors.entries) == 1
+        # A1 and A2 are name-matched and affiliated; A3 is affiliated elsewhere.
+        # Should auto-merge A1+A2: one AuthorItem + two publication Requests.
+        assert len(emitted) == 3
+
+        author_item = emitted[0]
+        assert isinstance(author_item, AuthorItem)
+        assert author_item.author.canonical_name == "Kim, Eunjung"
+
+        pub_requests = [r for r in emitted[1:] if isinstance(r, Request)]
+        assert len(pub_requests) == 2
+        requested_urls = {r.url for r in pub_requests}
+        assert any("A1" in url for url in requested_urls)
+        assert any("A2" in url for url in requested_urls)
+
+    def test_disambiguate_filters_mismatched_display_names(self, spider: OpenAlexSpider) -> None:
+        """Candidates with unrelated display names (composite OpenAlex records) are filtered out."""
+        authors = [
+            self._make_author("A1", "Completely Different Person", self.INSTITUTION_ID, [2019]),
+            self._make_author("A2", "Eunjung Kim", self.INSTITUTION_ID, [2021, 2022]),
+        ]
+        response = self._make_response(spider, authors)
+        emitted = list(spider._parse_author_search_results(response))
+        # Only A2 matches the searched name "Eunjung Kim".
+        assert len(emitted) == 2
+        author_item = emitted[0]
+        assert isinstance(author_item, AuthorItem)
+        pub_request = emitted[1]
+        assert isinstance(pub_request, Request)
+        assert "A2" in pub_request.url
 
     def test_disambiguate_no_affiliation(self, spider: OpenAlexSpider) -> None:
         authors = [

--- a/tests/spiders/test_openalex.py
+++ b/tests/spiders/test_openalex.py
@@ -10,9 +10,15 @@ from scrapy.http import HtmlResponse, Request
 
 from open_ire.author import ParsedAuthor
 from open_ire.enums import ArticleType
-from open_ire.errors import AmbiguousAuthorError
-from open_ire.items import ArticleItem
-from open_ire.spiders.openalex import OpenAlexSpider
+from open_ire.items import ArticleItem, AuthorItem
+from open_ire.spiders.openalex import (
+    AmbiguousAuthor,
+    AmbiguousAuthorList,
+    OpenAlexAffiliation,
+    OpenAlexAuthor,
+    OpenAlexInstitution,
+    OpenAlexSpider,
+)
 
 
 def _search_value(req: Request) -> str:
@@ -152,8 +158,8 @@ class TestOpenAlexSpider:
         spider = make_spider_with_author_name(author)
         response_data = {
             "results": [
-                {"id": "https://openalex.org/A1234567890"},
-                {"id": "https://openalex.org/A1234567891"},
+                {"id": "https://openalex.org/A1234567890", "display_name": "Author A"},
+                {"id": "https://openalex.org/A1234567891", "display_name": "Author B"},
             ]
         }
         request = spider.build_search_request(author)
@@ -164,7 +170,9 @@ class TestOpenAlexSpider:
             request=request,
         )
 
-        assert not list(spider._search_for_authors(response))
+        emitted = list(spider._parse_author_search_results(response))
+        assert not emitted
+        assert len(spider.ambiguous_authors.entries) == 1
 
     def test_parse_publications_yields_items_and_pagination_request(
         self,
@@ -308,163 +316,176 @@ class TestAuthorDisambiguation:
         display_name: str,
         institution_id: str | None = None,
         years: list[int] | None = None,
-    ) -> dict[str, Any]:
-        author: dict[str, Any] = {"id": author_id, "display_name": display_name}
+    ) -> OpenAlexAuthor:
+        raw: dict[str, Any] = {"id": author_id, "display_name": display_name}
         if institution_id and years:
-            author["affiliations"] = [
+            raw["affiliations"] = [
                 {
-                    "institution": {"id": f"https://openalex.org/{institution_id}"},
+                    "institution": {
+                        "id": f"https://openalex.org/{institution_id}",
+                        "display_name": "Test Institution",
+                    },
                     "years": years,
                 }
             ]
-        return author
+        return OpenAlexAuthor.from_api(raw)
+
+    def _make_response(self, spider: OpenAlexSpider, authors: list[OpenAlexAuthor]) -> HtmlResponse:
+        """Build a fake author-search response from a list of OpenAlexAuthor objects."""
+        raw_results = []
+        for au in authors:
+            raw: dict[str, Any] = {"id": au.id, "display_name": au.display_name}
+            if au.affiliations:
+                raw["affiliations"] = [
+                    {
+                        "institution": {
+                            "id": f"https://openalex.org/{aff.institution.id}",
+                            "display_name": aff.institution.display_name,
+                        },
+                        "years": aff.years,
+                    }
+                    for aff in au.affiliations
+                ]
+            raw_results.append(raw)
+
+        request = Request(
+            url="https://api.openalex.org/authors?search=test",
+            callback=spider._parse_author_search_results,
+            meta={"searched_author": "Eunjung Kim"},
+        )
+        return HtmlResponse(
+            url=request.url,
+            body=json.dumps({"results": raw_results}),
+            encoding="utf-8",
+            request=request,
+        )
 
     def test_disambiguate_single_affiliation(self, spider: OpenAlexSpider) -> None:
-        # Only one author has affiliation with our institution
         authors = [
             self._make_author("A1", "Eunjung Kim", "I999999999", [2015, 2016]),
             self._make_author("A2", "Eunjung Kim", self.INSTITUTION_ID, [2020, 2021]),
             self._make_author("A3", "Eun-Jung Kim", "I888888888", [2022, 2023]),
         ]
-        result = spider._disambiguate_authors(authors, "Eunjung Kim")
-        assert isinstance(result, dict)
-        assert result["id"] == "A2"
+        response = self._make_response(spider, authors)
+        emitted = list(spider._parse_author_search_results(response))
+        # Should yield an AuthorItem + a publications Request
+        assert len(emitted) == 2
+
+        author_item = emitted[0]
+        assert isinstance(author_item, AuthorItem)
+        assert author_item.author.canonical_name == "Kim, Eunjung"
+        pub_request = emitted[1]
+        assert isinstance(pub_request, Request)
+        assert "A2" in pub_request.url
 
     def test_disambiguate_multiple_affiliations(self, spider: OpenAlexSpider) -> None:
-        # Multiple authors have affiliation with our institution (ambiguous)
         authors = [
             self._make_author("A1", "Eunjung Kim", self.INSTITUTION_ID, [2015, 2016]),
             self._make_author("A2", "Eunjung Kim", self.INSTITUTION_ID, [2010, 2012]),
             self._make_author("A3", "Eun-Jung Kim", "I999999999", [2022, 2023]),
         ]
-        with pytest.raises(AmbiguousAuthorError) as exc_info:
-            spider._disambiguate_authors(authors, "Eunjung Kim")
-        assert exc_info.value.author_name == "Eunjung Kim"
-        # The candidate count is the number of affiliated authors (2)
-        assert len(exc_info.value.candidates) == 2
+        response = self._make_response(spider, authors)
+        emitted = list(spider._parse_author_search_results(response))
+        # Should yield nothing; authors are ambiguous
+        assert len(emitted) == 0
+        assert len(spider.ambiguous_authors.entries) == 1
+        assert (
+            spider.ambiguous_authors.entries[0].ambiguity_reason
+            == "multiple authors with institutional affiliation"
+        )
 
     def test_disambiguate_no_affiliation(self, spider: OpenAlexSpider) -> None:
-        # No authors have affiliation with our institution
         authors = [
             self._make_author("A1", "Eunjung Kim", "I999999999", [2020, 2021]),
             self._make_author("A2", "Eunjung Kim", "I888888888", [2019, 2022]),
-            self._make_author("A3", "Eunjung Kim"),  # No affiliation at all
+            self._make_author("A3", "Eunjung Kim"),
         ]
-        with pytest.raises(AmbiguousAuthorError) as exc_info:
-            spider._disambiguate_authors(authors, "Eunjung Kim")
-        assert exc_info.value.author_name == "Eunjung Kim"
-        # No affiliated authors
-        assert len(exc_info.value.candidates) == 0
+        response = self._make_response(spider, authors)
+        emitted = list(spider._parse_author_search_results(response))
+        # Should yield nothing; no authors with our affiliation
+        assert len(emitted) == 0
+        assert len(spider.ambiguous_authors.entries) == 1
+        assert (
+            spider.ambiguous_authors.entries[0].ambiguity_reason
+            == "no authors with institutional affiliation"
+        )
 
-    def test_add_to_ambiguous_authors_stores_structured_records(
-        self, spider: OpenAlexSpider
-    ) -> None:
+    def test_ambiguous_authors_stored_as_structured_records(self, spider: OpenAlexSpider) -> None:
         authors = [
             self._make_author("A1", "Eunjung Kim", self.INSTITUTION_ID, [2015, 2016]),
             self._make_author("A2", "Eunjung Kim", self.INSTITUTION_ID, [2010, 2012]),
         ]
 
-        spider._add_to_ambiguous_authors(
-            searched_author="Eunjung Kim",
-            author_records=authors,
-            reason="no authors with recent institutional affiliation (>=2018)",
+        spider.ambiguous_authors.append(
+            AmbiguousAuthor(
+                searched_author="Eunjung Kim",
+                candidates=authors,
+                ambiguity_reason="multiple authors with institutional affiliation",
+            )
         )
 
-        assert len(spider._ambiguous_authors) == 1
-        ambiguous_author = spider._ambiguous_authors[0]
-        assert ambiguous_author["searched_author"] == "Eunjung Kim"
-        assert ambiguous_author["start_year"] == 2018
-        assert ambiguous_author["candidates"] == authors
+        assert len(spider.ambiguous_authors.entries) == 1
+        aa = spider.ambiguous_authors.entries[0]
+        assert aa.searched_author == "Eunjung Kim"
+        assert aa.candidates == authors
+        assert aa.ambiguity_reason == "multiple authors with institutional affiliation"
 
     @pytest.mark.parametrize(
-        ("institution_a", "institution_b", "expected"),
+        ("institution_id", "compare_to", "expected"),
         [
-            (
-                "https://openalex.org/I201448701",
-                "https://openalex.org/I201448701",
-                True,
-            ),
-            (
-                "https://openalex.org/i201448701",
-                "https://openalex.org/I201448701",
-                True,
-            ),
-            (
-                "https://openalex.org/I201448701",
-                "https://openalex.org/I999999999",
-                False,
-            ),
-            (None, "https://openalex.org/I201448701", False),
-            (None, None, False),
+            ("https://openalex.org/I201448701", "https://openalex.org/I201448701", True),
+            ("https://openalex.org/i201448701", "https://openalex.org/I201448701", True),
+            ("https://openalex.org/I201448701", "https://openalex.org/I999999999", False),
             ("I201448701", "https://openalex.org/I201448701", True),
         ],
     )
-    def test_same_institution(
-        self, institution_a: str | None, institution_b: str | None, expected: bool
+    def test_matches_institution(
+        self, institution_id: str, compare_to: str, expected: bool
     ) -> None:
-        assert OpenAlexSpider._same_institution(institution_a, institution_b) is expected
+        inst = OpenAlexInstitution(id=institution_id, display_name="Test", raw={})
+        assert inst.matches_institution(compare_to) is expected
 
     def test_write_ambiguous_authors_file_creates_csv_with_expected_rows(
-        self, spider: OpenAlexSpider, tmp_path: Path
+        self, tmp_path: Path
     ) -> None:
-        spider.ambiguous_authors_file = tmp_path / "ambiguous_authors.csv"
+        ambiguous_authors = AmbiguousAuthorList(tmp_path / "ambiguous_authors.csv")
 
-        ambiguous_authors = [
+        candidates = [
             self._make_author("https://openalex.org/A1", "Eunjung Kim"),
             self._make_author("https://openalex.org/A2", "Eunjung Kim"),
             self._make_author("https://openalex.org/A3", "Eunjung Kim"),
         ]
-        spider._add_to_ambiguous_authors(
-            searched_author="Eunjung Kim",
-            author_records=ambiguous_authors,
-            reason="no authors with recent institutional affiliation (>=2018)",
+        ambiguous_authors.append(
+            AmbiguousAuthor(
+                searched_author="Eunjung Kim",
+                candidates=candidates,
+                ambiguity_reason="multiple authors with institutional affiliation",
+            )
         )
 
-        spider._write_ambiguous_authors_file()
+        ambiguous_authors.write(self.INSTITUTION_ID)
 
-        assert spider.ambiguous_authors_file.exists()
-        with spider.ambiguous_authors_file.open(newline="", encoding="utf-8") as handle:
+        assert ambiguous_authors.file_path.exists()
+        with ambiguous_authors.file_path.open(newline="", encoding="utf-8") as handle:
             rows = list(csv.DictReader(handle))
-        assert len(rows) == len(ambiguous_authors)
-        assert spider._ambiguous_authors == []
+        assert len(rows) == len(candidates)
+        assert ambiguous_authors.entries == []
 
-    def test_extract_affiliations(self) -> None:
-        author_record = {
-            "affiliations": [
-                {
-                    "institution": {
-                        "id": "https://openalex.org/I1234567890",
-                        "display_name": "Test University",
-                    },
-                    "years": [2020, 2021],
-                },
-                "invalid",
-                {"institution": "invalid"},
-                {
-                    "institution": {
-                        "id": "https://openalex.org/I9999999999",
-                        "display_name": "Other",
-                    }
-                },
-            ]
+    def test_openalex_affiliation_from_api(self) -> None:
+        raw = {
+            "institution": {
+                "id": "https://openalex.org/I1234567890",
+                "display_name": "Test University",
+            },
+            "years": [2020, 2021],
         }
+        affiliation = OpenAlexAffiliation.from_api(raw)
+        assert affiliation.institution.id == "https://openalex.org/I1234567890"
+        assert affiliation.institution.display_name == "Test University"
+        assert affiliation.years == [2020, 2021]
 
-        affiliations = OpenAlexSpider._extract_affiliations(author_record)
-
-        assert len(affiliations) == 2
-        assert affiliations[0].institution.id == "https://openalex.org/I1234567890"
-        assert affiliations[0].institution.name == "Test University"
-        assert affiliations[0].years == [2020, 2021]
-        assert affiliations[1].institution.id == "https://openalex.org/I9999999999"
-        assert affiliations[1].institution.name == "Other"
-        assert affiliations[1].years == []
-
-    def test_extract_institution(self) -> None:
-        record = {"id": "https://openalex.org/I1234567890", "display_name": "Test University"}
-        institution = OpenAlexSpider._extract_institution(record)
+    def test_openalex_institution_from_api(self) -> None:
+        raw = {"id": "https://openalex.org/I1234567890", "display_name": "Test University"}
+        institution = OpenAlexInstitution.from_api(raw)
         assert institution.id == "https://openalex.org/I1234567890"
-        assert institution.name == "Test University"
-
-        institution = OpenAlexSpider._extract_institution({})
-        assert institution.id == ""
-        assert institution.name == ""
+        assert institution.display_name == "Test University"


### PR DESCRIPTION
This is the culmination of all the author-based crawling.

## Author Disambiguation

For each author in the input CSV, the spider first checks whether we already have OpenAlex IDs for that person in the database (via `_find_known_openalex_ids`). If so, it skips the author search entirely and goes straight to fetching their publications. Otherwise, it queries the OpenAlex `/authors` endpoint, filtering by our institutional affiliation.

When the author search returns multiple candidates, the spider runs a disambiguation pipeline (`_disambiguated_authors`):

* It filters out candidates whose display name doesn't plausibly match the searched name --- this catches composite OpenAlex records that bundle unrelated people.

* Among the remaining name-matched candidates, it keeps only those with an institutional affiliation.

* If multiple affiliated candidates remain, it uses ORCIDs as a tiebreaker: distinct ORCIDs mean genuinely different people (flagged for manual resolution in the ambiguous authors CSV), while zero or one shared ORCID suggests fragmented OpenAlex records for the same person, which are auto-merged.

For each disambiguated author, the spider yields an AuthorItem (carrying identifiers like OpenAlex ID, ORCID, and email) and one or more publication requests. Authors that were previously flagged as ambiguous can be resolved by editing the CSV file. On the next crawl, the spider picks up those choices and skips disambiguation.