### PR TITLE
Link existing articles to newly-added authors

### DIFF
--- a/src/open_ire/pipelines/author_identifier_pipeline.py
+++ b/src/open_ire/pipelines/author_identifier_pipeline.py
@@ -6,7 +6,7 @@ from sqlmodel import Session, select
 
 from open_ire.author import ParsedAuthor
 from open_ire.items import AuthorItem
-from open_ire.models import Author, AuthorIdentifier
+from open_ire.models import Article, Author, AuthorIdentifier, Authorship
 from open_ire.pipelines.base_sql_model_pipeline import BaseSQLModelPipeline
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -49,7 +49,8 @@ class AuthorIdentifierPipeline(BaseSQLModelPipeline):
             candidates = [a for a in (by_identifier, by_name) if a is not None]
 
             if not candidates:
-                self._create_author_with_identifiers(session, item)
+                author = self._create_author_with_identifiers(session, item)
+                self._link_author_to_existing_articles(session, author, item.author)
             elif len(candidates) == 1 or (candidates[0].id == candidates[1].id):
                 self._update_author(session, candidates[0], item)
             else:
@@ -124,6 +125,35 @@ class AuthorIdentifierPipeline(BaseSQLModelPipeline):
             )
 
         return author
+
+    @staticmethod
+    def _link_author_to_existing_articles(
+        session: Session, author: Author, parsed: ParsedAuthor
+    ) -> None:
+        """Retroactively link a newly-created author to articles already in the DB.
+
+        When an author is first added to the database, articles that list them
+        may already exist (ingested earlier when this author was not yet a person
+        of interest).  This method finds those articles and creates the missing
+        Authorship links so the relationship is not lost.
+        """
+        articles = session.exec(
+            select(Article).where(Article.authors.contains(parsed.last_name))  # type: ignore[union-attr]
+        ).all()
+
+        for article in articles:
+            article_authors = ParsedAuthor.parse_author_string(article.authors or "")
+            for i, article_author in enumerate(article_authors):
+                if article_author.likely_same(parsed):
+                    existing_link = session.get(Authorship, (article.id, author.id))
+                    if existing_link is None:
+                        session.add(Authorship(article=article, author=author, author_order=i))
+                        logger.info(
+                            "Retroactively linked author '%s' to article '%s'",
+                            author.canonical_name,
+                            article.id,
+                        )
+                    break
 
     @staticmethod
     def _add_missing_identifiers(

--- a/tests/pipelines/test_author_identifier_pipeline.py
+++ b/tests/pipelines/test_author_identifier_pipeline.py
@@ -8,7 +8,7 @@ from sqlmodel import Session, select
 
 from open_ire.author import ParsedAuthor
 from open_ire.items import ArticleItem, AuthorItem
-from open_ire.models import Author
+from open_ire.models import Article, Author, Authorship
 from open_ire.pipelines.author_identifier_pipeline import AuthorIdentifierPipeline
 
 
@@ -110,3 +110,34 @@ class TestAuthorIdentifierPipeline:
         with Session(pipeline.engine) as session:
             authors = session.exec(select(Author)).all()
             assert len(authors) == 1
+
+    def test_links_new_author_to_existing_articles(self, pipeline) -> None:
+        """A newly-created author is retroactively linked to articles already in the DB."""
+        # Pre-populate an article that lists "Hsieh" among its authors.
+        with Session(pipeline.engine) as session:
+            article = Article(
+                title="Existing Article",
+                authors="Smith, John; Hsieh, Wei-Lin",
+                repository="test_repo",
+                reference="EXIST001",
+                url="https://example.com/article/exist001",
+            )
+            session.add(article)
+            session.commit()
+            article_id = article.id
+
+        # Now create the author Hsieh via the pipeline.
+        item = AuthorItem(
+            author=ParsedAuthor("Wei-Lin Hsieh"),
+            identifiers=[{"authority": "openalex", "identifier": "A9999999999"}],
+        )
+        pipeline.process_item(item)
+
+        # The pipeline should have retroactively created an Authorship link.
+        with Session(pipeline.engine) as session:
+            author = session.exec(select(Author).where(Author.last_name == "Hsieh")).first()
+            assert author is not None
+
+            link = session.get(Authorship, (article_id, author.id))
+            assert link is not None
+            assert link.author_order == 1  # second author (0-indexed)


### PR DESCRIPTION
AuthorshipPipeline currently only cares about the authors present in the `author` table, ignoring other article authors. With this PR, when `AuthorItem` for a new author is processed, the authors of existing articles are checked in case the articles need to be linked to the new `author` record.

There is some danger of false positives, since we're only comparing the author's name and not institutional affiliations, but hopefully that shouldn't be a big issue. Since the end goal is emailing the authors with a list of their publications, they can flag any false positives a that point.