### PR TITLE
Lowercase DOIs

### DIFF
--- a/src/open_ire/pipelines/doi_normalization_pipeline.py
+++ b/src/open_ire/pipelines/doi_normalization_pipeline.py
@@ -32,7 +32,8 @@ class DOINormalizationPipeline:
             while doi.lower().startswith(prefix.lower()):
                 doi = doi[len(prefix) :].strip()
 
-        doi = doi.strip().lstrip("/")
+        # DOIs are case-insensitive, so might as well keep them uniform
+        doi = doi.strip().lstrip("/").lower()
 
         if doi.startswith("10.") and "/" in doi:
             return doi

--- a/tests/pipelines/test_doi_normalization_pipeline.py
+++ b/tests/pipelines/test_doi_normalization_pipeline.py
@@ -101,7 +101,7 @@ class TestDOINormalizationPipeline:
 
         result = pipeline.process_item(item)
 
-        assert result.doi == "10.1214/17-BA1056R"
+        assert result.doi == "10.1214/17-ba1056r"
 
     def test_normalize_embedded_doi_with_leading_slash(
         self, pipeline: DOINormalizationPipeline, item: ArticleItem


### PR DESCRIPTION
DOIs are case-insensitive, so storing them as lowercase just makes them more uniform and easier to work with.