### PR TITLE
Rename "OA evidence" terminology to "deposit warrant"

### DIFF
--- a/src/open_ire/enums.py
+++ b/src/open_ire/enums.py
@@ -15,15 +15,15 @@ class DepositStatus(StrEnum):
     PARTIAL = "partial"
 
 
-class OAEvidenceKind(StrEnum):
-    """Categories of evidence used to determine Open Access (OA) compliance status.
+class DepositWarrant(StrEnum):
+    """Kinds of warrant that can support depositing an article in ResearchWorks.
 
-    Each kind represents a different source or method of establishing OA eligibility:
-    - LICENSE: Evidence from license information (e.g., Creative Commons licenses).
-    - EXTERNAL_OA: Evidence from external OA availability checks.
-    - VERSION: Evidence based on article version (e.g., accepted manuscript).
-    - MANUAL: Evidence from manual review processes.
-    - FACULTY_AUTHOR: Evidence based on faculty authorship status.
+    Each kind names a different source or method of establishing deposit eligibility:
+    - LICENSE: A redistribution-permitting license (e.g., Creative Commons).
+    - EXTERNAL_OA: External open-access availability checks.
+    - VERSION: Article version (e.g., accepted manuscript).
+    - MANUAL: Manual review.
+    - FACULTY_AUTHOR: Faculty authorship status.
     """
 
     LICENSE = "license"
@@ -36,12 +36,12 @@ class OAEvidenceKind(StrEnum):
 class DepositTransitionReason(StrEnum):
     """Standardized reasons for article deposit status transitions.
 
-    These values correspond logically to OAEvidenceKind:
-    - LICENSE_OA: Transition based on open access license evidence (OAEvidenceKind.LICENSE)
-    - EXTERNAL_OA: Transition based on external OA availability (OAEvidenceKind.EXTERNAL_OA)
-    - VERSION_AVAILABLE: Transition based on version evidence (OAEvidenceKind.VERSION)
-    - MANUAL_REVIEW: Transition based on manual review (OAEvidenceKind.MANUAL)
-    - FACULTY_AUTHOR: Transition based on faculty authorship (OAEvidenceKind.FACULTY_AUTHOR)
+    These values correspond logically to DepositWarrant:
+    - LICENSE_OA: Transition based on license warrant (DepositWarrant.LICENSE)
+    - EXTERNAL_OA: Transition based on external OA availability (DepositWarrant.EXTERNAL_OA)
+    - VERSION_AVAILABLE: Transition based on version warrant (DepositWarrant.VERSION)
+    - MANUAL_REVIEW: Transition based on manual review (DepositWarrant.MANUAL)
+    - FACULTY_AUTHOR: Transition based on faculty authorship (DepositWarrant.FACULTY_AUTHOR)
     """
 
     LICENSE_OA = "license_oa"

--- a/src/open_ire/models.py
+++ b/src/open_ire/models.py
@@ -6,7 +6,7 @@ from sqlalchemy import JSON, CheckConstraint, Column, ForeignKey, UniqueConstrai
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlmodel import Field, Relationship, SQLModel, select
 
-from open_ire.enums import ArticleType, DepositStatus, OAEvidenceKind
+from open_ire.enums import ArticleType, DepositStatus, DepositWarrant
 
 
 class ArticleBase(SQLModel):
@@ -57,7 +57,7 @@ class Article(ArticleBase, table=True):
     extra: dict[str, Any] = Field(sa_column=Column(JSON), default_factory=dict)
     files: list["ArticleFile"] = Relationship(back_populates="article")
     file_references: list["ArticleFileReference"] = Relationship(back_populates="article")
-    oa_evidence: list["ArticleOAEvidence"] = Relationship(back_populates="article")
+    deposit_warrants: list["ArticleDepositWarrant"] = Relationship(back_populates="article")
     deposit_status_transitions: list["ArticleDepositStatusTransition"] = Relationship(
         back_populates="article"
     )
@@ -159,30 +159,34 @@ class ArticleFileReference(ArticleFileBase, table=True):
     article: Article | None = Relationship(back_populates="file_references")
 
 
-class ArticleOAEvidence(SQLModel, table=True):
-    """SQLModel to store evidence used to determine OA status.
+class ArticleDepositWarrant(SQLModel, table=True):
+    """SQLModel to store warrants supporting an article's deposit eligibility.
 
     Attributes
     ----------
     id: Primary key for the database.
     article_id: Foreign key to the Article table.
-    created_at: Datetime when the evidence was recorded.
-    kind: Evidence category (license, external_oa, version, manual, faculty_author).
-    supports_oa: Whether this evidence supports OA status.
-    source: Origin of the evidence (e.g., "crossref", "openalex", "manual").
-    data: Source-specific payload for evidence details.
+    created_at: Datetime when the warrant was recorded.
+    kind: Which warrant this row pertains to (license, external_oa, version, manual, faculty_author).
+    supports_oa: Whether this warrant supports depositing the article.
+    source: Origin of the warrant (e.g., "crossref", "datacite", "doaj", "manual").
+    data: Source-specific payload for warrant details.
     """
+
+    # Table renaming is deferred to a follow-up PR; pin the existing name so the
+    # class rename is purely a code-level rename.
+    __tablename__ = "articleoaevidence"
 
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
     article_id: uuid.UUID = Field(foreign_key="article.id", index=True)
     created_at: datetime = Field(default_factory=datetime.now, index=True)
 
-    kind: OAEvidenceKind = Field(index=True)
+    kind: DepositWarrant = Field(index=True)
     supports_oa: bool
     source: str | None = None
     data: dict[str, Any] = Field(sa_column=Column(JSON), default_factory=dict)
 
-    article: Article | None = Relationship(back_populates="oa_evidence")
+    article: Article | None = Relationship(back_populates="deposit_warrants")
 
 
 class ArticleDepositStatusTransition(SQLModel, table=True):

--- a/src/open_ire/spiders/deposit_warrant.py
+++ b/src/open_ire/spiders/deposit_warrant.py
@@ -6,12 +6,12 @@ from sqlalchemy.engine import Engine
 from sqlmodel import Session, col, select
 
 from open_ire.db import create_db_engine
-from open_ire.enums import DepositStatus, DepositTransitionReason, OAEvidenceKind
-from open_ire.models import Article, ArticleDepositStatusTransition, ArticleOAEvidence
+from open_ire.enums import DepositStatus, DepositTransitionReason, DepositWarrant
+from open_ire.models import Article, ArticleDepositStatusTransition, ArticleDepositWarrant
 from open_ire.settings import OPEN_IRE_CONTACT_EMAIL
 
 
-class BaseOAEvidenceSpider(Spider):
+class BaseDepositWarrantSpider(Spider):
     custom_settings = {  # noqa: RUF012
         "AUTOTHROTTLE_TARGET_CONCURRENCY": 2.0,
         "DOWNLOAD_DELAY": 1,
@@ -40,39 +40,41 @@ class BaseOAEvidenceSpider(Spider):
         if self.engine:
             self.engine.dispose()
 
-    def has_oa_evidence(
+    def has_deposit_warrant(
         self,
         article_id: uuid.UUID,
         *,
-        kind: OAEvidenceKind,
+        kind: DepositWarrant,
         sources: list[str] | None = None,
     ) -> bool:
         if not self.engine:
             return False
 
         with Session(self.engine) as session:
-            statement = select(ArticleOAEvidence).where(
-                ArticleOAEvidence.article_id == article_id,
-                ArticleOAEvidence.kind == kind,
+            statement = select(ArticleDepositWarrant).where(
+                ArticleDepositWarrant.article_id == article_id,
+                ArticleDepositWarrant.kind == kind,
             )
             if sources:
-                statement = statement.where(col(ArticleOAEvidence.source).in_(sources))
+                statement = statement.where(col(ArticleDepositWarrant.source).in_(sources))
 
             return session.exec(statement).first() is not None
 
-    def has_any_oa_evidence(self, article_id: uuid.UUID) -> bool:
+    def has_any_deposit_warrant(self, article_id: uuid.UUID) -> bool:
         if not self.engine:
             return False
 
         with Session(self.engine) as session:
-            statement = select(ArticleOAEvidence).where(ArticleOAEvidence.article_id == article_id)
+            statement = select(ArticleDepositWarrant).where(
+                ArticleDepositWarrant.article_id == article_id
+            )
             return session.exec(statement).first() is not None
 
-    def save_oa_evidence(
+    def save_deposit_warrant(
         self,
         article_id: uuid.UUID,
         *,
-        kind: OAEvidenceKind,
+        kind: DepositWarrant,
         source: str,
         supports_oa: bool,
         data: dict[str, Any] | None = None,
@@ -91,14 +93,14 @@ class BaseOAEvidenceSpider(Spider):
 
             current_status = article.deposit_status
 
-            evidence = ArticleOAEvidence(
+            warrant = ArticleDepositWarrant(
                 article_id=article_id,
                 kind=kind,
                 supports_oa=supports_oa,
                 source=source,
                 data=data or {},
             )
-            session.add(evidence)
+            session.add(warrant)
 
             if (
                 supports_oa
@@ -114,7 +116,7 @@ class BaseOAEvidenceSpider(Spider):
                 )
                 session.add(transition)
                 self.logger.info(
-                    "Article %s transitioned to READY based on %s evidence from %s",
+                    "Article %s transitioned to READY based on %s warrant from %s",
                     article_id,
                     kind,
                     source,

--- a/src/open_ire/spiders/doaj.py
+++ b/src/open_ire/spiders/doaj.py
@@ -8,19 +8,19 @@ from urllib.parse import quote
 from scrapy.http import Request, Response
 from sqlmodel import Session, col, select
 
-from open_ire.enums import DepositTransitionReason, OAEvidenceKind
+from open_ire.enums import DepositTransitionReason, DepositWarrant
 from open_ire.models import Article
 from open_ire.pipelines import DOINormalizationPipeline
-from open_ire.spiders.oa_evidence import BaseOAEvidenceSpider
+from open_ire.spiders.deposit_warrant import BaseDepositWarrantSpider
 
 
 class LogMessages:
     ARTICLES_FOUND = "Found %d candidate articles for DOAJ lookup"
-    EVIDENCE_SAVED = "Saved DOAJ evidence for article %s (supports_oa=%s, strategy=%s)"
+    WARRANT_SAVED = "Saved DOAJ warrant for article %s (supports_oa=%s, strategy=%s)"
     SEARCH_ERROR = "DOAJ lookup failed for article %s (%s)"
     SEARCH_STATUS_ERROR = "DOAJ returned status %s for article %s"
     SEARCH_INVALID_JSON = "DOAJ returned invalid JSON for article %s"
-    SKIPPING_ARTICLE = "Skipping article %s - already has evidence"
+    SKIPPING_ARTICLE = "Skipping article %s with existing deposit warrant"
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,10 +29,10 @@ class _ArticleCandidate:
     doi: str
 
 
-class OADOAJSpider(BaseOAEvidenceSpider):
-    """Fetch OA evidence from DOAJ using DOI article matching."""
+class DOAJSpider(BaseDepositWarrantSpider):
+    """Establish an EXTERNAL_OA deposit warrant from DOAJ using DOI article matching."""
 
-    name = "oa_doaj"
+    name = "doaj"
     base_url = "https://doaj.org/api"
     search_endpoint = "articles"
     match_strategy = "article_doi"
@@ -46,8 +46,8 @@ class OADOAJSpider(BaseOAEvidenceSpider):
         bibjson = result.get("bibjson", {})
         return bibjson if isinstance(bibjson, dict) else None
 
-    def has_existing_evidence(self, article_id: uuid.UUID) -> bool:
-        return self.has_any_oa_evidence(article_id)
+    def has_existing_warrant(self, article_id: uuid.UUID) -> bool:
+        return self.has_any_deposit_warrant(article_id)
 
     def query_article_candidates(self) -> list[_ArticleCandidate]:
         if not self.engine:
@@ -139,26 +139,26 @@ class OADOAJSpider(BaseOAEvidenceSpider):
             },
         }
 
-    def save_doaj_evidence(
+    def save_doaj_warrant(
         self,
         article_id: uuid.UUID,
         *,
         supports_oa: bool,
         allow_transition: bool,
-        evidence_data: dict[str, Any],
+        warrant_data: dict[str, Any],
     ) -> None:
-        self.save_oa_evidence(
+        self.save_deposit_warrant(
             article_id,
-            kind=OAEvidenceKind.EXTERNAL_OA,
+            kind=DepositWarrant.EXTERNAL_OA,
             source="doaj",
             supports_oa=supports_oa,
-            data=evidence_data,
+            data=warrant_data,
             transition_reason=DepositTransitionReason.EXTERNAL_OA,
             allow_transition=allow_transition,
         )
 
     @classmethod
-    def build_evidence_data(
+    def build_warrant_data(
         cls,
         candidate: _ArticleCandidate,
         attempts: list[dict[str, Any]],
@@ -213,14 +213,14 @@ class OADOAJSpider(BaseOAEvidenceSpider):
 
         supports_oa = bool(match_data.get("supports_oa"))
         allow_transition = bool(match_data.get("allow_transition"))
-        self.save_doaj_evidence(
+        self.save_doaj_warrant(
             candidate.article_id,
             supports_oa=supports_oa,
             allow_transition=allow_transition,
-            evidence_data=self.build_evidence_data(candidate, attempts, match_data),
+            warrant_data=self.build_warrant_data(candidate, attempts, match_data),
         )
         self.logger.info(
-            LogMessages.EVIDENCE_SAVED, candidate.article_id, supports_oa, self.match_strategy
+            LogMessages.WARRANT_SAVED, candidate.article_id, supports_oa, self.match_strategy
         )
         return None
 
@@ -234,8 +234,9 @@ class OADOAJSpider(BaseOAEvidenceSpider):
         self.logger.info(LogMessages.ARTICLES_FOUND, len(candidates))
 
         for candidate in candidates:
-            if self.has_existing_evidence(candidate.article_id):
-                self.logger.debug(LogMessages.SKIPPING_ARTICLE, candidate.article_id)
+            if self.has_existing_warrant(candidate.article_id):
+                identifier = candidate.doi if candidate.doi else candidate.article_id
+                self.logger.debug(LogMessages.SKIPPING_ARTICLE, identifier)
                 continue
 
             yield self.build_search_request(candidate)

--- a/src/open_ire/spiders/doi_license.py
+++ b/src/open_ire/spiders/doi_license.py
@@ -7,10 +7,10 @@ from urllib.parse import quote
 from scrapy.http import Request, Response
 from sqlmodel import Session, col, select
 
-from open_ire.enums import DepositTransitionReason, OAEvidenceKind
+from open_ire.enums import DepositTransitionReason, DepositWarrant
 from open_ire.models import Article
 from open_ire.pipelines import DOINormalizationPipeline
-from open_ire.spiders.oa_evidence import BaseOAEvidenceSpider
+from open_ire.spiders.deposit_warrant import BaseDepositWarrantSpider
 
 
 class LogMessages:
@@ -19,25 +19,26 @@ class LogMessages:
     ARTICLES_FOUND = "Found %d articles with DOIs"
     FALLBACK_TO_DATACITE = "Crossref lookup failed for DOI %s, trying DataCite: %s"
     INVALID_JSON = "Invalid JSON from %s for DOI %s"
-    LICENSE_EVIDENCE_SAVED = "Saved license evidence for article %s from %s (supports_oa=%s)"
+    LICENSE_WARRANT_SAVED = "Saved license warrant for article %s from %s (supports_oa=%s)"
     NO_DATABASE_ENGINE = "No database engine available"
     NO_LICENSE_FOUND = "No license information found for DOI %s"
     NO_LICENSE_FOUND_WITH_DETAILS = "No license information found for DOI %s (%s)"
     NO_LICENSE_IN_CROSSREF = "No license info in Crossref for DOI %s, trying DataCite"
-    SKIPPING_ARTICLE = "Skipping article %s - already has license evidence"
+    SKIPPING_ARTICLE = "Skipping article %s - already has a license warrant"
 
 
-class OALicenseSpider(BaseOAEvidenceSpider):
+class DOILicenseSpider(BaseDepositWarrantSpider):
     """
-    Fetch license information from Crossref and DataCite APIs.
+    Establish a LICENSE deposit warrant from Crossref and DataCite license metadata.
+
     This spider queries the database for articles with DOIs, then:
     1. Requests license info from Crossref API.
     2. Falls back to DataCite API if Crossref has no license info.
-    3. Saves evidence to ArticleOAEvidence.
-    4. Creates ArticleOAStatusTransition if license indicates open access.
+    3. Saves an ArticleDepositWarrant row capturing what was found.
+    4. Creates an ArticleDepositStatusTransition if the license is OA-permitting.
     """
 
-    name = "oa_license"
+    name = "doi_license"
     crossref_base_url = "https://api.crossref.org/works"
     datacite_base_url = "https://api.datacite.org/dois"
 
@@ -86,7 +87,7 @@ class OALicenseSpider(BaseOAEvidenceSpider):
                 }
             )
 
-        supports_oa = any(OALicenseSpider.is_oa_license(url) for url in license_urls)
+        supports_oa = any(DOILicenseSpider.is_oa_license(url) for url in license_urls)
 
         return {
             "license_details": license_details,
@@ -124,7 +125,7 @@ class OALicenseSpider(BaseOAEvidenceSpider):
                 }
             )
 
-        supports_oa = any(OALicenseSpider.is_oa_license(url) for url in license_urls)
+        supports_oa = any(DOILicenseSpider.is_oa_license(url) for url in license_urls)
 
         return {
             "license_details": license_details,
@@ -144,10 +145,10 @@ class OALicenseSpider(BaseOAEvidenceSpider):
             results = session.exec(statement).all()
             return [(row[0], row[1]) for row in results if row[1]]
 
-    def has_license_evidence(self, article_id: uuid.UUID) -> bool:
-        return self.has_oa_evidence(
+    def has_license_warrant(self, article_id: uuid.UUID) -> bool:
+        return self.has_deposit_warrant(
             article_id,
-            kind=OAEvidenceKind.LICENSE,
+            kind=DepositWarrant.LICENSE,
             sources=["crossref", "datacite"],
         )
 
@@ -196,7 +197,7 @@ class OALicenseSpider(BaseOAEvidenceSpider):
             return self.build_datacite_request(article_id, doi)
 
         license_data = self.extract_crossref_license(licenses)
-        self.save_license_evidence(article_id, doi, "crossref", license_data)
+        self.save_license_warrant(article_id, doi, "crossref", license_data)
 
         return None
 
@@ -235,7 +236,7 @@ class OALicenseSpider(BaseOAEvidenceSpider):
             return
 
         license_data = self.extract_datacite_license(rights_list)
-        self.save_license_evidence(article_id, doi, "datacite", license_data)
+        self.save_license_warrant(article_id, doi, "datacite", license_data)
 
     def handle_datacite_error(self, failure: Any) -> None:
         request = failure.request
@@ -245,7 +246,7 @@ class OALicenseSpider(BaseOAEvidenceSpider):
             LogMessages.NO_LICENSE_FOUND_WITH_DETAILS, doi, f"DataCite error: {failure.value}"
         )
 
-    def save_license_evidence(
+    def save_license_warrant(
         self,
         article_id: uuid.UUID,
         doi: str,
@@ -253,9 +254,9 @@ class OALicenseSpider(BaseOAEvidenceSpider):
         license_data: dict[str, Any],
     ) -> None:
         supports_oa = license_data.get("supports_oa", False)
-        self.save_oa_evidence(
+        self.save_deposit_warrant(
             article_id,
-            kind=OAEvidenceKind.LICENSE,
+            kind=DepositWarrant.LICENSE,
             source=source,
             supports_oa=supports_oa,
             data={
@@ -265,14 +266,14 @@ class OALicenseSpider(BaseOAEvidenceSpider):
             },
             transition_reason=DepositTransitionReason.LICENSE_OA,
         )
-        self.logger.info(LogMessages.LICENSE_EVIDENCE_SAVED, article_id, source, supports_oa)
+        self.logger.info(LogMessages.LICENSE_WARRANT_SAVED, article_id, source, supports_oa)
 
     async def start(self) -> AsyncIterator[Request]:
         articles = self.query_articles_with_doi()
         self.logger.info(LogMessages.ARTICLES_FOUND, len(articles))
 
         for article_id, doi in articles:
-            if self.has_license_evidence(article_id):
+            if self.has_license_warrant(article_id):
                 self.logger.debug(LogMessages.SKIPPING_ARTICLE, article_id)
                 continue
 

--- a/tests/spiders/test_doaj.py
+++ b/tests/spiders/test_doaj.py
@@ -9,21 +9,21 @@ import pytest
 from scrapy.http import HtmlResponse
 from sqlmodel import Session, select
 
-from open_ire.enums import DepositStatus, DepositTransitionReason, OAEvidenceKind
-from open_ire.models import Article, ArticleDepositStatusTransition, ArticleOAEvidence
-from open_ire.spiders.oa_doaj import OADOAJSpider, _ArticleCandidate
+from open_ire.enums import DepositStatus, DepositTransitionReason, DepositWarrant
+from open_ire.models import Article, ArticleDepositStatusTransition, ArticleDepositWarrant
+from open_ire.spiders.doaj import DOAJSpider, _ArticleCandidate
 
 
 @pytest.fixture
-def spider() -> Generator[OADOAJSpider, None, None]:
-    with patch.object(OADOAJSpider, "logger", new_callable=MagicMock):
-        spider_instance = OADOAJSpider()
+def spider() -> Generator[DOAJSpider, None, None]:
+    with patch.object(DOAJSpider, "logger", new_callable=MagicMock):
+        spider_instance = DOAJSpider()
         yield spider_instance
 
 
 class TestCandidates:
     def test_query_article_candidates_filters_and_normalizes(
-        self, spider_with_db: OADOAJSpider
+        self, spider_with_db: DOAJSpider
     ) -> None:
         with Session(spider_with_db.engine) as session:
             session.add(
@@ -68,7 +68,7 @@ class TestCandidates:
 
 
 class TestRequests:
-    def test_build_search_request(self, spider: OADOAJSpider, article_id: uuid.UUID) -> None:
+    def test_build_search_request(self, spider: DOAJSpider, article_id: uuid.UUID) -> None:
         candidate = _ArticleCandidate(
             article_id=article_id,
             doi="10.1234/example",
@@ -81,7 +81,7 @@ class TestRequests:
 
 
 class TestMatching:
-    def test_match_article_by_doi(self, spider: OADOAJSpider) -> None:
+    def test_match_article_by_doi(self, spider: DOAJSpider) -> None:
         results: list[dict[str, Any]] = [
             {
                 "id": "article-1",
@@ -105,7 +105,7 @@ class TestMatching:
 
 class TestParseFlow:
     def test_parse_search_response_non_match_does_not_save_evidence(
-        self, spider: OADOAJSpider, article_id: uuid.UUID
+        self, spider: DOAJSpider, article_id: uuid.UUID
     ) -> None:
         candidate = _ArticleCandidate(
             article_id=article_id,
@@ -118,15 +118,15 @@ class TestParseFlow:
             body=json.dumps(response_data).encode(),
             encoding="utf-8",
         )
-        spider.save_doaj_evidence = MagicMock()  # type: ignore[method-assign]
+        spider.save_doaj_warrant = MagicMock()  # type: ignore[method-assign]
 
         result = spider.parse_search_response(response, candidate)
 
         assert result is None
-        spider.save_doaj_evidence.assert_not_called()
+        spider.save_doaj_warrant.assert_not_called()
 
     def test_parse_search_response_saves_match(
-        self, spider: OADOAJSpider, article_id: uuid.UUID
+        self, spider: DOAJSpider, article_id: uuid.UUID
     ) -> None:
         candidate = _ArticleCandidate(article_id=article_id, doi="10.1234/test.doi")
         response_data: dict[str, Any] = {
@@ -146,15 +146,15 @@ class TestParseFlow:
             body=json.dumps(response_data).encode(),
             encoding="utf-8",
         )
-        spider.save_doaj_evidence = MagicMock()  # type: ignore[method-assign]
+        spider.save_doaj_warrant = MagicMock()  # type: ignore[method-assign]
 
         result = spider.parse_search_response(response, candidate)
 
         assert result is None
-        spider.save_doaj_evidence.assert_called_once()
+        spider.save_doaj_warrant.assert_called_once()
 
     def test_parse_search_response_http_error_does_not_save(
-        self, spider: OADOAJSpider, article_id: uuid.UUID
+        self, spider: DOAJSpider, article_id: uuid.UUID
     ) -> None:
         candidate = _ArticleCandidate(article_id=article_id, doi="10.1234/test.doi")
         response = HtmlResponse(
@@ -163,33 +163,35 @@ class TestParseFlow:
             body=b"",
             encoding="utf-8",
         )
-        spider.save_doaj_evidence = MagicMock()  # type: ignore[method-assign]
+        spider.save_doaj_warrant = MagicMock()  # type: ignore[method-assign]
 
         result = spider.parse_search_response(response, candidate)
 
         assert result is None
-        spider.save_doaj_evidence.assert_not_called()
+        spider.save_doaj_warrant.assert_not_called()
 
 
-class TestSaveDOAJEvidence:
-    def test_save_supporting_evidence_creates_transition(
-        self, spider_with_db: OADOAJSpider, sample_article: Article
+class TestSaveDOAJWarrant:
+    def test_save_supporting_warrant_creates_transition(
+        self, spider_with_db: DOAJSpider, sample_article: Article
     ) -> None:
-        spider_with_db.save_doaj_evidence(
+        spider_with_db.save_doaj_warrant(
             sample_article.id,
             supports_oa=True,
             allow_transition=True,
-            evidence_data={"matched": True, "match_strategy": "article_doi"},
+            warrant_data={"matched": True, "match_strategy": "article_doi"},
         )
 
         with Session(spider_with_db.engine) as session:
-            evidence = session.exec(
-                select(ArticleOAEvidence).where(ArticleOAEvidence.article_id == sample_article.id)
+            warrant = session.exec(
+                select(ArticleDepositWarrant).where(
+                    ArticleDepositWarrant.article_id == sample_article.id
+                )
             ).first()
-            assert evidence is not None
-            assert evidence.kind == OAEvidenceKind.EXTERNAL_OA
-            assert evidence.source == "doaj"
-            assert evidence.supports_oa is True
+            assert warrant is not None
+            assert warrant.kind == DepositWarrant.EXTERNAL_OA
+            assert warrant.source == "doaj"
+            assert warrant.supports_oa is True
 
             transition = session.exec(
                 select(ArticleDepositStatusTransition).where(
@@ -200,22 +202,24 @@ class TestSaveDOAJEvidence:
             assert transition.to_status == DepositStatus.READY
             assert DepositTransitionReason.EXTERNAL_OA in transition.reasons
 
-    def test_save_non_supporting_evidence_without_transition(
-        self, spider_with_db: OADOAJSpider, sample_article: Article
+    def test_save_non_supporting_warrant_without_transition(
+        self, spider_with_db: DOAJSpider, sample_article: Article
     ) -> None:
-        spider_with_db.save_doaj_evidence(
+        spider_with_db.save_doaj_warrant(
             sample_article.id,
             supports_oa=False,
             allow_transition=False,
-            evidence_data={"matched": False},
+            warrant_data={"matched": False},
         )
 
         with Session(spider_with_db.engine) as session:
-            evidence = session.exec(
-                select(ArticleOAEvidence).where(ArticleOAEvidence.article_id == sample_article.id)
+            warrant = session.exec(
+                select(ArticleDepositWarrant).where(
+                    ArticleDepositWarrant.article_id == sample_article.id
+                )
             ).first()
-            assert evidence is not None
-            assert evidence.supports_oa is False
+            assert warrant is not None
+            assert warrant.supports_oa is False
 
             transition = session.exec(
                 select(ArticleDepositStatusTransition).where(
@@ -227,14 +231,14 @@ class TestSaveDOAJEvidence:
 
 class TestStart:
     @pytest.mark.asyncio
-    async def test_start_skips_article_with_existing_evidence(
-        self, spider_with_db: OADOAJSpider, sample_article: Article
+    async def test_start_skips_article_with_existing_warrant(
+        self, spider_with_db: DOAJSpider, sample_article: Article
     ) -> None:
         with Session(spider_with_db.engine) as session:
             session.add(
-                ArticleOAEvidence(
+                ArticleDepositWarrant(
                     article_id=sample_article.id,
-                    kind=OAEvidenceKind.LICENSE,
+                    kind=DepositWarrant.LICENSE,
                     supports_oa=True,
                     source="crossref",
                     data={},
@@ -247,8 +251,8 @@ class TestStart:
         assert requests == []
 
     @pytest.mark.asyncio
-    async def test_start_emits_request_when_no_existing_evidence(
-        self, spider_with_db: OADOAJSpider, sample_article: Article
+    async def test_start_emits_request_when_no_existing_warrant(
+        self, spider_with_db: DOAJSpider, sample_article: Article
     ) -> None:
         requests = [request async for request in spider_with_db.start()]
 

--- a/tests/spiders/test_doi_license.py
+++ b/tests/spiders/test_doi_license.py
@@ -8,15 +8,15 @@ import pytest
 from scrapy.http import HtmlResponse, Request
 from sqlmodel import Session, select
 
-from open_ire.enums import DepositStatus, DepositTransitionReason, OAEvidenceKind
-from open_ire.models import Article, ArticleDepositStatusTransition, ArticleOAEvidence
-from open_ire.spiders.oa_license import OALicenseSpider
+from open_ire.enums import DepositStatus, DepositTransitionReason, DepositWarrant
+from open_ire.models import Article, ArticleDepositStatusTransition, ArticleDepositWarrant
+from open_ire.spiders.doi_license import DOILicenseSpider
 
 
 @pytest.fixture
-def spider() -> Generator[OALicenseSpider, None, None]:
-    with patch.object(OALicenseSpider, "logger", new_callable=MagicMock):
-        spider_instance = OALicenseSpider()
+def spider() -> Generator[DOILicenseSpider, None, None]:
+    with patch.object(DOILicenseSpider, "logger", new_callable=MagicMock):
+        spider_instance = DOILicenseSpider()
         yield spider_instance
 
 
@@ -66,7 +66,7 @@ class TestIsOALicense:
         ],
     )
     def test_is_oa_license(self, license_url: str | None, expected: bool) -> None:
-        assert OALicenseSpider.is_oa_license(license_url) == expected
+        assert DOILicenseSpider.is_oa_license(license_url) == expected
 
 
 class TestExtractCrossrefLicense:
@@ -79,7 +79,7 @@ class TestExtractCrossrefLicense:
             }
         ]
 
-        result = OALicenseSpider.extract_crossref_license(licenses)
+        result = DOILicenseSpider.extract_crossref_license(licenses)
 
         assert result["supports_oa"] is True
         assert result["license_urls"] == ["https://creativecommons.org/licenses/by/4.0/"]
@@ -93,7 +93,7 @@ class TestExtractCrossrefLicense:
             }
         ]
 
-        result = OALicenseSpider.extract_crossref_license(licenses)
+        result = DOILicenseSpider.extract_crossref_license(licenses)
 
         assert result["supports_oa"] is False
 
@@ -109,7 +109,7 @@ class TestExtractDataciteLicense:
             }
         ]
 
-        result = OALicenseSpider.extract_datacite_license(rights_list)
+        result = DOILicenseSpider.extract_datacite_license(rights_list)
 
         assert result["supports_oa"] is True
         assert (
@@ -125,7 +125,7 @@ class TestExtractDataciteLicense:
             }
         ]
 
-        result = OALicenseSpider.extract_datacite_license(rights_list)
+        result = DOILicenseSpider.extract_datacite_license(rights_list)
 
         assert result["supports_oa"] is False
 
@@ -140,19 +140,23 @@ class TestLicenseSchemaConsistency:
             {"rightsUri": "https://creativecommons.org/licenses/by/4.0/", "rights": "CC BY 4.0"}
         ]
 
-        crossref_result = OALicenseSpider.extract_crossref_license(crossref_licenses)
-        datacite_result = OALicenseSpider.extract_datacite_license(datacite_rights)
+        crossref_result = DOILicenseSpider.extract_crossref_license(crossref_licenses)
+        datacite_result = DOILicenseSpider.extract_datacite_license(datacite_rights)
 
         assert set(crossref_result.keys()) == set(datacite_result.keys())
-        assert set(crossref_result.keys()) == {"license_details", "license_urls", "supports_oa"}
+        assert set(crossref_result.keys()) == {
+            "license_details",
+            "license_urls",
+            "supports_oa",
+        }
         assert crossref_result["supports_oa"] == datacite_result["supports_oa"]
 
 
 class TestParseCrossrefLicense:
     def test_parse_crossref_with_license(
-        self, spider: OALicenseSpider, article_id: uuid.UUID, crossref_oa_response: dict[str, Any]
+        self, spider: DOILicenseSpider, article_id: uuid.UUID, crossref_oa_response: dict[str, Any]
     ) -> None:
-        spider.save_license_evidence = MagicMock()  # type: ignore[method-assign]
+        spider.save_license_warrant = MagicMock()  # type: ignore[method-assign]
 
         response = HtmlResponse(
             url="https://api.crossref.org/works/10.1234/test",
@@ -163,13 +167,13 @@ class TestParseCrossrefLicense:
         result = spider.parse_crossref(response, article_id, "10.1234/test")
 
         assert result is None
-        spider.save_license_evidence.assert_called_once()
-        call_args = spider.save_license_evidence.call_args
+        spider.save_license_warrant.assert_called_once()
+        call_args = spider.save_license_warrant.call_args
         assert call_args[0][0] == article_id
         assert call_args[0][2] == "crossref"
 
     def test_parse_crossref_falls_back_to_datacite(
-        self, spider: OALicenseSpider, article_id: uuid.UUID
+        self, spider: DOILicenseSpider, article_id: uuid.UUID
     ) -> None:
         """Test fallback to DataCite when Crossref has no license."""
         response_data: dict[str, Any] = {"message": {"license": []}}
@@ -187,9 +191,9 @@ class TestParseCrossrefLicense:
 
 class TestParseDataciteLicense:
     def test_parse_datacite_with_license(
-        self, spider: OALicenseSpider, article_id: uuid.UUID, datacite_oa_response: dict[str, Any]
+        self, spider: DOILicenseSpider, article_id: uuid.UUID, datacite_oa_response: dict[str, Any]
     ) -> None:
-        spider.save_license_evidence = MagicMock()  # type: ignore[method-assign]
+        spider.save_license_warrant = MagicMock()  # type: ignore[method-assign]
 
         response = HtmlResponse(
             url="https://api.datacite.org/dois/10.1234/test",
@@ -199,14 +203,14 @@ class TestParseDataciteLicense:
 
         spider.parse_datacite(response, article_id, "10.1234/test")
 
-        spider.save_license_evidence.assert_called_once()
-        call_args = spider.save_license_evidence.call_args
+        spider.save_license_warrant.assert_called_once()
+        call_args = spider.save_license_warrant.call_args
         assert call_args[0][2] == "datacite"
 
     def test_parse_datacite_no_license(
-        self, spider: OALicenseSpider, article_id: uuid.UUID
+        self, spider: DOILicenseSpider, article_id: uuid.UUID
     ) -> None:
-        spider.save_license_evidence = MagicMock()  # type: ignore[method-assign]
+        spider.save_license_warrant = MagicMock()  # type: ignore[method-assign]
         response_data: dict[str, Any] = {"data": {"attributes": {"rightsList": []}}}
 
         response = HtmlResponse(
@@ -217,12 +221,12 @@ class TestParseDataciteLicense:
 
         spider.parse_datacite(response, article_id, "10.1234/test")
 
-        spider.save_license_evidence.assert_not_called()
+        spider.save_license_warrant.assert_not_called()
 
 
-class TestSaveLicenseEvidence:
+class TestSaveLicenseWarrant:
     def test_save_oa_license_creates_transition(
-        self, spider_with_db: OALicenseSpider, sample_article: Article
+        self, spider_with_db: DOILicenseSpider, sample_article: Article
     ) -> None:
         license_data = {
             "supports_oa": True,
@@ -230,21 +234,21 @@ class TestSaveLicenseEvidence:
             "license_details": [{"url": "https://creativecommons.org/licenses/by/4.0/"}],
         }
 
-        spider_with_db.save_license_evidence(
+        spider_with_db.save_license_warrant(
             sample_article.id, "10.1234/test", "crossref", license_data
         )
 
         with Session(spider_with_db.engine) as session:
-            # Check evidence was saved
-            evidence = session.exec(
-                select(ArticleOAEvidence).where(ArticleOAEvidence.article_id == sample_article.id)
+            warrant = session.exec(
+                select(ArticleDepositWarrant).where(
+                    ArticleDepositWarrant.article_id == sample_article.id
+                )
             ).first()
-            assert evidence is not None
-            assert evidence.kind == OAEvidenceKind.LICENSE
-            assert evidence.supports_oa is True
-            assert evidence.source == "crossref"
+            assert warrant is not None
+            assert warrant.kind == DepositWarrant.LICENSE
+            assert warrant.supports_oa is True
+            assert warrant.source == "crossref"
 
-            # Check transition was created
             transition = session.exec(
                 select(ArticleDepositStatusTransition).where(
                     ArticleDepositStatusTransition.article_id == sample_article.id
@@ -255,29 +259,29 @@ class TestSaveLicenseEvidence:
             assert DepositTransitionReason.LICENSE_OA in transition.reasons
 
     def test_save_non_oa_license_no_transition(
-        self, spider_with_db: OALicenseSpider, sample_article: Article
+        self, spider_with_db: DOILicenseSpider, sample_article: Article
     ) -> None:
-        """Test that non-OA license creates evidence but NO transition."""
+        """Test that non-OA license creates a warrant row but NO transition."""
         license_data = {
             "supports_oa": False,
             "license_urls": ["https://example.com/proprietary"],
             "license_details": [{"url": "https://example.com/proprietary"}],
         }
 
-        spider_with_db.save_license_evidence(
+        spider_with_db.save_license_warrant(
             sample_article.id, "10.1234/test", "datacite", license_data
         )
 
         with Session(spider_with_db.engine) as session:
-            # Check evidence was saved
-            evidence = session.exec(
-                select(ArticleOAEvidence).where(ArticleOAEvidence.article_id == sample_article.id)
+            warrant = session.exec(
+                select(ArticleDepositWarrant).where(
+                    ArticleDepositWarrant.article_id == sample_article.id
+                )
             ).first()
-            assert evidence is not None
-            assert evidence.supports_oa is False
-            assert evidence.source == "datacite"
+            assert warrant is not None
+            assert warrant.supports_oa is False
+            assert warrant.source == "datacite"
 
-            # Check NO transition was created
             transition = session.exec(
                 select(ArticleDepositStatusTransition).where(
                     ArticleDepositStatusTransition.article_id == sample_article.id


### PR DESCRIPTION
* Spiders: `oa_evidence` → `deposit_warrant`; `oa_doaj` → `doaj`; `oa_license` → `doi_license`
* ~~Enum values cleaned (now just `LICENSE`, `JOURNAL`, `MANUAL`, `FACULTY`)~~
* ~~Alembic migration folds `VERSION_AVAILABLE` and `FACULTY_AUTHOR` into `FACULTY`~~