### PR TITLE
Add GitHub issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ labels: bug
 
 ## Description
 
-A clear and concise description of what went wrong.
+<!-- A clear and concise description of what went wrong. -->
 
 ## Steps to reproduce
 
@@ -16,17 +16,19 @@ A clear and concise description of what went wrong.
 
 ## Expected behavior
 
-What should have happened.
+<!-- What should have happened. -->
 
 ## Actual behavior
 
-What actually happened. Paste any relevant error messages or tracebacks here.
+<!-- What actually happened. Paste any relevant error messages or tracebacks here. -->
 
 ## Environment
 
+<!-- Use backticks for version strings, e.g. `macOS 12.7` or `3.13.1` -->
+
 - OS:
 - Python version:
-- Package version (or commit):
+- Package version (or commit): uw-ssec/open-ire@
 
 ## Logs / screenshots
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report something that isn't working correctly
+labels: bug
+---
+
+## Description
+
+A clear and concise description of what went wrong.
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+What should have happened.
+
+## Actual behavior
+
+What actually happened. Paste any relevant error messages or tracebacks here.
+
+## Environment
+
+- OS:
+- Python version:
+- Package version (or commit):
+
+## Logs / screenshots
+
+<!-- Paste relevant output or attach screenshots below. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,15 +6,22 @@ labels: enhancement
 
 ## Problem / motivation
 
-What problem are you trying to solve? ("I'm trying to…, but…")
+<!-- What problem are you trying to solve? ("I'm trying to…, but…") -->
 
 ## Proposed solution
 
-Describe your idea for how to address the problem.
+<!-- Describe your idea for how to address the problem. -->
 
 ## Alternatives considered
 
-Other approaches you thought of and why you ruled them out.
+<!-- Other approaches you thought of and why you ruled them out. -->
+
+## Success criteria / acceptance criteria
+
+<!-- Checklist of conditions that indicate this feature is done. Example:
+- [ ] Spider collects title, authors, DOI, and publication date
+- [ ] Articles without a DOI are skipped with a warning log entry
+-->
 
 ## Additional context
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest a new feature or enhancement
+labels: enhancement
+---
+
+## Problem / motivation
+
+What problem are you trying to solve? ("I'm trying to…, but…")
+
+## Proposed solution
+
+Describe your idea for how to address the problem.
+
+## Alternatives considered
+
+Other approaches you thought of and why you ruled them out.
+
+## Additional context
+
+<!-- Links, references, mockups, or anything else that might be helpful. -->


### PR DESCRIPTION
The issue submission is completely freeform. It would be beneficial to have a bit of structure when submitting most common issues (bugs and feature requests), and having templates reduces friction.
