### PR TITLE
feat: add PubMed Central (PMC) spider for open-access articles

### DIFF
--- a/src/open_ire/spiders/pmc.py
+++ b/src/open_ire/spiders/pmc.py
@@ -1,0 +1,374 @@
+"""Spider to collect open-access articles from PubMed Central (PMC).
+
+This spider queries the NCBI E-utilities API for PMC records matching
+configurable search terms and yields one :class:`~open_ire.items.ArticleItem`
+per open-access record found.
+
+The crawl uses a three-step flow:
+
+1. ``esearch.fcgi`` returns the list of PMC UIDs matching a query, paginated
+   via ``retstart``/``retmax``.
+2. ``esummary.fcgi`` returns document summaries (title, authors, journal, IDs,
+   publication date) for a batch of UIDs.
+3. The PMC Open Access Subset on AWS (the ``pmc-oa-opendata`` S3 bucket) is
+   queried to locate the full-text PDF for each record.
+
+Searches are restricted to the open-access subset (``open access[filter]``) so
+that a record is available in the OA Subset bucket. Two NCBI download routes are
+intentionally *not* used: the web ``/articles/PMC.../pdf/`` endpoint is served
+behind a bot-verification interstitial (returns HTML, not the PDF), and the
+legacy ``oa.fcgi`` service only hands back ``ftp://`` links that no longer
+resolve. The AWS Open Data bucket serves the same OA content over plain HTTPS;
+each article lives under ``PMC<id>.<version>/`` with the main PDF named
+``PMC<id>.<version>.pdf``. The version is discovered with an S3 list request.
+
+API documentation:
+
+* E-utilities: https://www.ncbi.nlm.nih.gov/books/NBK25501/
+* PMC OA Subset on AWS: https://www.ncbi.nlm.nih.gov/pmc/tools/openftlist/
+
+Usage::
+
+    pixi run scrapy crawl pmc
+    pixi run scrapy crawl pmc -a terms="university of washington"
+
+An optional ``NCBI_API_KEY`` environment variable raises the per-IP rate limit
+from 3 to 10 requests/second; it is included automatically when present.
+"""
+
+import json
+import os
+import re
+from collections.abc import Generator
+from typing import Any, cast
+from urllib.parse import urlencode
+
+from scrapy.http import Request, Response, TextResponse
+
+from open_ire.author import ParsedAuthor
+from open_ire.items import ArticleItem
+from open_ire.settings import OPEN_IRE_CONTACT_EMAIL
+from open_ire.spiders.search import TermSearchSpider
+from open_ire.utils import parse_date
+
+
+class PMCSpider(TermSearchSpider):
+    """Collect open-access articles from PubMed Central via NCBI E-utilities.
+
+    For each search term, queries ``esearch`` for matching PMC UIDs and follows
+    up with ``esummary`` to build an :class:`ArticleItem` per open-access record.
+    """
+
+    name = "pmc"
+    eutils_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
+    oa_bucket_url = "https://pmc-oa-opendata.s3.amazonaws.com"
+    article_base_url = "https://pmc.ncbi.nlm.nih.gov/articles"
+    db = "pmc"
+    tool = "open_ire"
+    page_size = 100
+
+    custom_settings = {  # noqa: RUF012
+        # NCBI permits 3 requests/second per IP without an API key (10 with one).
+        # A 1-second delay with no concurrency keeps us comfortably within the
+        # unauthenticated limit across the esearch -> esummary chain.
+        "DOWNLOAD_DELAY": 1,
+        "CONCURRENT_REQUESTS_PER_DOMAIN": 1,
+        # E-utilities is the sanctioned programmatic interface; NCBI's robots.txt
+        # targets crawlers of the HTML site, not the API or the OA Subset bucket.
+        "ROBOTSTXT_OBEY": False,
+    }
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.api_key = os.getenv("NCBI_API_KEY") or None
+
+    # === REQUEST BUILDING ===
+
+    def build_search_request(self, term: str) -> Request:
+        """Build the first-page esearch request for *term*."""
+        self.logger.info("Searching PMC for %r (page_size=%d)", term, self.page_size)
+        return self._build_esearch_request(term, retstart=0)
+
+    def _eutils_params(self, extra: dict[str, str]) -> dict[str, str]:
+        """Return the common E-utilities query parameters merged with *extra*.
+
+        Includes the NCBI-recommended ``tool`` and ``email`` identifiers and the
+        optional ``api_key`` when configured.
+        """
+        params = {
+            "db": self.db,
+            "retmode": "json",
+            "tool": self.tool,
+            "email": OPEN_IRE_CONTACT_EMAIL,
+        }
+        if self.api_key:
+            params["api_key"] = self.api_key
+        params.update(extra)
+        return params
+
+    def _build_esearch_request(self, term: str, retstart: int) -> Request:
+        """Build an esearch request for *term* starting at *retstart*."""
+        params = self._eutils_params(
+            {
+                "term": self._build_query(term),
+                "retmax": str(self.page_size),
+                "retstart": str(retstart),
+            }
+        )
+        url = f"{self.eutils_url}/esearch.fcgi?{urlencode(params)}"
+        return Request(
+            url,
+            callback=self.parse,
+            headers={"Accept": "application/json"},
+            meta={"search_term": term, "retstart": retstart},
+        )
+
+    def _build_esummary_request(self, term: str, uids: list[str]) -> Request:
+        """Build an esummary request for a batch of *uids*."""
+        params = self._eutils_params({"id": ",".join(uids)})
+        url = f"{self.eutils_url}/esummary.fcgi?{urlencode(params)}"
+        return Request(
+            url,
+            callback=self.parse_summary,
+            headers={"Accept": "application/json"},
+            meta={"search_term": term},
+        )
+
+    @staticmethod
+    def _build_query(term: str) -> str:
+        """Build the PMC query string for *term*.
+
+        Restricts results to UW-affiliated records in the open-access subset so
+        a downloadable full-text PDF is available for every match.
+        """
+        return f'"{term}"[Affiliation] AND open access[filter]'
+
+    # === RESPONSE PARSING ===
+
+    def parse(self, response: Response, **kwargs: Any) -> Generator[Request]:  # noqa: ARG002
+        """Parse an esearch page, fetch summaries, and follow pagination."""
+        search_term: str = response.meta["search_term"]
+        retstart: int = response.meta["retstart"]
+
+        try:
+            payload = json.loads(response.text or "{}")
+        except json.JSONDecodeError:
+            self.logger.warning("PMC returned invalid JSON for esearch %r", search_term)
+            return
+
+        result = payload.get("esearchresult", {})
+        uids = [str(uid) for uid in result.get("idlist", []) if uid]
+        try:
+            count = int(result.get("count", 0))
+        except (TypeError, ValueError):
+            count = 0
+
+        self.logger.info(
+            "PMC esearch returned %d UID(s) for %r (retstart=%d, total=%d)",
+            len(uids),
+            search_term,
+            retstart,
+            count,
+        )
+
+        if not uids:
+            return
+
+        yield self._build_esummary_request(search_term, uids)
+
+        next_retstart = retstart + self.page_size
+        if next_retstart < count:
+            self.logger.debug(
+                "Requesting next PMC page (retstart=%d) for %r", next_retstart, search_term
+            )
+            yield self._build_esearch_request(search_term, next_retstart)
+
+    def parse_summary(self, response: Response, **kwargs: Any) -> Generator[Request]:  # noqa: ARG002
+        """Parse an esummary response and request the OA link for each record."""
+        search_term: str = response.meta["search_term"]
+
+        try:
+            payload = json.loads(response.text or "{}")
+        except json.JSONDecodeError:
+            self.logger.warning("PMC returned invalid JSON for esummary %r", search_term)
+            return
+
+        result = payload.get("result", {})
+        uids: list[str] = [str(uid) for uid in result.get("uids", []) if uid]
+
+        yielded = 0
+        for uid in uids:
+            record = result.get(uid)
+            if not isinstance(record, dict):
+                continue
+            item = self._parse_record(record)
+            if item is not None:
+                yielded += 1
+                yield self._build_oa_lookup_request(item)
+
+        if yielded < len(uids):
+            self.logger.info(
+                "Skipped %d PMC record(s) for %r (missing title or PMCID)",
+                len(uids) - yielded,
+                search_term,
+            )
+
+    def _build_oa_lookup_request(self, item: ArticleItem) -> Request:
+        """Build an S3 list request to locate the full-text PDF for *item*.
+
+        The OA Subset bucket stores each article under ``PMC<id>.<version>/``;
+        listing by the bare PMCID prefix reveals the available object keys
+        (and the version, which is not exposed by esummary).
+        """
+        params = {"list-type": "2", "prefix": item.reference}
+        url = f"{self.oa_bucket_url}/?{urlencode(params)}"
+        return Request(
+            url,
+            callback=self.parse_oa_listing,
+            errback=self.handle_oa_error,
+            cb_kwargs={"item": item},
+            dont_filter=True,
+        )
+
+    def parse_oa_listing(self, response: Response, item: ArticleItem) -> Generator[ArticleItem]:
+        """Attach the OA full-text PDF link to *item* (if any), then yield it.
+
+        The bucket may hold supplementary PDFs and figures alongside the main
+        article PDF, so only the ``PMC<id>.<version>/PMC<id>.<version>.pdf`` key
+        is selected. When no such key exists the item is yielded without a file.
+        """
+        selector = cast(TextResponse, response).selector
+        selector.remove_namespaces()
+        keys = selector.xpath("//Contents/Key/text()").getall()
+
+        pdf_key = self._select_pdf_key(item.reference, keys)
+        if pdf_key:
+            item.file_urls = [f"{self.oa_bucket_url}/{pdf_key}"]
+        else:
+            self.logger.debug("No OA Subset PDF found for %s", item.reference)
+
+        yield item
+
+    @staticmethod
+    def _select_pdf_key(pmcid: str, keys: list[str]) -> str | None:
+        """Return the main-article PDF key for *pmcid* from S3 *keys*.
+
+        Matches ``PMC<id>.<version>/PMC<id>.<version>.pdf`` exactly (the prefix
+        query can also return neighbouring IDs, e.g. ``PMC123`` matches
+        ``PMC1230``), preferring the highest version when several exist.
+        """
+        pattern = re.compile(rf"^{re.escape(pmcid)}\.(\d+)/{re.escape(pmcid)}\.\1\.pdf$")
+        matches = [(int(m.group(1)), key) for key in keys if (m := pattern.match(key))]
+        if not matches:
+            return None
+        return max(matches)[1]
+
+    def handle_oa_error(self, failure: Any) -> Generator[ArticleItem]:
+        """Yield the item without a file link when the OA lookup fails."""
+        item: ArticleItem = failure.request.cb_kwargs["item"]
+        self.logger.debug("OA lookup failed for %s (%s)", item.reference, failure.value)
+        yield item
+
+    # === RECORD PARSING ===
+
+    def _parse_record(self, record: dict[str, Any]) -> ArticleItem | None:
+        """Convert a single esummary record dict into an :class:`ArticleItem`."""
+        title = (record.get("title") or "").strip()
+        pmcid = self._extract_pmcid(record)
+
+        if not title or not pmcid:
+            self.logger.debug(
+                "Skipping record with missing title or PMCID: %s",
+                record.get("uid", "<unknown>"),
+            )
+            return None
+
+        # ``file_urls`` is populated later from the OA Web Service (see parse_oa);
+        # the esummary payload does not include a downloadable full-text link.
+        return ArticleItem(
+            authors=self._extract_authors(record),
+            doi=self._extract_article_id(record, "doi"),
+            extra=self._build_extra(record),
+            publication_date=parse_date(
+                record.get("sortdate")
+                or record.get("epubdate")
+                or record.get("pubdate")
+                or record.get("printpubdate")
+            ),
+            reference=pmcid,
+            repository=self.name,
+            title=title,
+            url=f"{self.article_base_url}/{pmcid}/",
+        )
+
+    # === FIELD EXTRACTION HELPERS ===
+
+    @staticmethod
+    def _extract_article_id(record: dict[str, Any], idtype: str) -> str | None:
+        """Return the value of the ``articleids`` entry matching *idtype*."""
+        for entry in record.get("articleids") or []:
+            if isinstance(entry, dict) and entry.get("idtype") == idtype:
+                value = str(entry.get("value") or "").strip()
+                if value:
+                    return value
+        return None
+
+    @classmethod
+    def _extract_pmcid(cls, record: dict[str, Any]) -> str | None:
+        """Return the PMCID (e.g. ``PMC123456``) for a record.
+
+        Prefers the explicit ``pmcid`` article id and falls back to deriving it
+        from the record's numeric UID.
+        """
+        pmcid = cls._extract_article_id(record, "pmcid")
+        if pmcid:
+            # esummary may return "PMC123456" or "PMC123456.1"; keep the bare ID.
+            return pmcid.split(".", 1)[0].strip()
+
+        uid = str(record.get("uid") or "").strip()
+        return f"PMC{uid}" if uid else None
+
+    @staticmethod
+    def _format_author_name(raw: str) -> str:
+        """Convert an NCBI ``"Surname Initials"`` name to ``"Surname, Initials"``.
+
+        NCBI returns author names as ``"Habell-Pallán M"`` or ``"Smith JA"``.
+        Reformatting to ``Last, First`` lets :class:`ParsedAuthor` parse the
+        surname and initials correctly.
+        """
+        raw = raw.strip()
+        surname, _, initials = raw.rpartition(" ")
+        if surname and initials:
+            return f"{surname}, {initials}"
+        return raw
+
+    @classmethod
+    def _extract_authors(cls, record: dict[str, Any]) -> str | None:
+        """Encode the author list from an esummary record."""
+        cleaned: list[ParsedAuthor] = []
+        for entry in record.get("authors") or []:
+            if not isinstance(entry, dict):
+                continue
+            name = (entry.get("name") or "").strip()
+            if name:
+                cleaned.append(ParsedAuthor(cls._format_author_name(name)))
+
+        return ParsedAuthor.encode_author_string(cleaned) if cleaned else None
+
+    @classmethod
+    def _build_extra(cls, record: dict[str, Any]) -> dict[str, Any]:
+        """Collect supplementary metadata into the ``extra`` dict."""
+        extra: dict[str, Any] = {}
+
+        journal_name = (record.get("fulljournalname") or record.get("source") or "").strip()
+        if journal_name:
+            extra["journal_name"] = journal_name
+
+        for key in ("volume", "issue", "pages"):
+            if value := (record.get(key) or "").strip():
+                extra[key] = value
+
+        if pmid := cls._extract_article_id(record, "pmid"):
+            extra["pmid"] = pmid
+
+        return extra

--- a/src/open_ire/spiders/pmc.py
+++ b/src/open_ire/spiders/pmc.py
@@ -283,8 +283,8 @@ class PMCSpider(TermSearchSpider):
             )
             return None
 
-        # ``file_urls`` is populated later from the OA Web Service (see parse_oa);
-        # the esummary payload does not include a downloadable full-text link.
+        # ``file_urls`` is populated later from the OA Subset bucket listing (see
+        # parse_oa_listing); esummary does not include a downloadable full-text link.
         return ArticleItem(
             authors=self._extract_authors(record),
             doi=self._extract_article_id(record, "doi"),
@@ -344,16 +344,34 @@ class PMCSpider(TermSearchSpider):
 
     @classmethod
     def _extract_authors(cls, record: dict[str, Any]) -> str | None:
-        """Encode the author list from an esummary record."""
+        """Encode the personal-author list from an esummary record.
+
+        Organizational authors (``authtype == "CollectiveName"``) are excluded:
+        their multi-word names are not personal names and :class:`ParsedAuthor`
+        (backed by ``HumanName``) mangles them into bogus person rows. They are
+        preserved separately via :meth:`_extract_collective_authors`. Properly
+        modelling consortium authors is tracked in issue #125.
+        """
         cleaned: list[ParsedAuthor] = []
         for entry in record.get("authors") or []:
-            if not isinstance(entry, dict):
+            if not isinstance(entry, dict) or entry.get("authtype") == "CollectiveName":
                 continue
             name = (entry.get("name") or "").strip()
             if name:
                 cleaned.append(ParsedAuthor(cls._format_author_name(name)))
 
         return ParsedAuthor.encode_author_string(cleaned) if cleaned else None
+
+    @staticmethod
+    def _extract_collective_authors(record: dict[str, Any]) -> list[str]:
+        """Return the verbatim names of organizational/consortium authors."""
+        return [
+            name
+            for entry in record.get("authors") or []
+            if isinstance(entry, dict)
+            and entry.get("authtype") == "CollectiveName"
+            and (name := (entry.get("name") or "").strip())
+        ]
 
     @classmethod
     def _build_extra(cls, record: dict[str, Any]) -> dict[str, Any]:
@@ -370,5 +388,8 @@ class PMCSpider(TermSearchSpider):
 
         if pmid := cls._extract_article_id(record, "pmid"):
             extra["pmid"] = pmid
+
+        if collective_authors := cls._extract_collective_authors(record):
+            extra["collective_authors"] = collective_authors
 
         return extra

--- a/tests/spiders/test_pmc.py
+++ b/tests/spiders/test_pmc.py
@@ -1,0 +1,344 @@
+import json
+from collections.abc import Generator
+from datetime import date
+from typing import Any
+from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from scrapy.http import Request, TextResponse, XmlResponse
+
+from open_ire.items import ArticleItem
+from open_ire.settings import OPEN_IRE_SEARCH_TERMS
+from open_ire.spiders.pmc import PMCSpider
+
+
+@pytest.fixture
+def spider() -> Generator[PMCSpider, None, None]:
+    with patch.object(PMCSpider, "logger", new_callable=MagicMock):
+        yield PMCSpider(terms="university of washington")
+
+
+def _json_response(url: str, payload: dict[str, Any], meta: dict[str, Any]) -> TextResponse:
+    request = Request(url, meta=meta)
+    return TextResponse(
+        url=url,
+        body=json.dumps(payload).encode("utf-8"),
+        encoding="utf-8",
+        request=request,
+    )
+
+
+def _s3_response(body: str, item: ArticleItem) -> XmlResponse:
+    request = Request(
+        "https://pmc-oa-opendata.s3.amazonaws.com/?list-type=2&prefix=" + item.reference,
+        cb_kwargs={"item": item},
+    )
+    return XmlResponse(
+        url=request.url, body=body.encode("utf-8"), encoding="utf-8", request=request
+    )
+
+
+def _s3_listing(keys: list[str]) -> str:
+    """Build an S3 ListBucketResult XML body (with the S3 default namespace)."""
+    contents = "".join(f"<Contents><Key>{key}</Key></Contents>" for key in keys)
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+        f"<Name>pmc-oa-opendata</Name>{contents}</ListBucketResult>"
+    )
+
+
+# Field names and shapes mirror a live NCBI PMC esummary (JSON, version 2.0)
+# record: no issn/essn, dates exposed as sortdate/epubdate/pubdate.
+SAMPLE_RECORD: dict[str, Any] = {
+    "uid": "9876543",
+    "title": "Ocean Acidification in the Salish Sea",
+    "sortdate": "2024/03/15 00:00",
+    "epubdate": "2024 Mar 15",
+    "pubdate": "2024 Mar",
+    "source": "Mar Biol",
+    "fulljournalname": "Marine Biology",
+    "volume": "12",
+    "issue": "3",
+    "pages": "100-110",
+    "authors": [
+        {"name": "Habell-Pallán M", "authtype": "Author"},
+        {"name": "Smith JA", "authtype": "Author"},
+    ],
+    "articleids": [
+        {"idtype": "pmid", "value": "33445566"},
+        {"idtype": "pmcid", "value": "PMC9876543"},
+        {"idtype": "doi", "value": "10.1234/marbio.2024.99"},
+    ],
+}
+
+
+class TestInit:
+    def test_default_terms(self) -> None:
+        spider = PMCSpider()
+        assert spider.name == "pmc"
+        assert spider.search_phrases == list(OPEN_IRE_SEARCH_TERMS)
+
+    def test_custom_terms(self) -> None:
+        spider = PMCSpider(terms="coral bleaching, kelp forests")
+        assert spider.search_phrases == ["coral bleaching", "kelp forests"]
+
+    def test_api_key_absent_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NCBI_API_KEY", raising=False)
+        assert PMCSpider().api_key is None
+
+    def test_api_key_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NCBI_API_KEY", "secret-key")
+        assert PMCSpider().api_key == "secret-key"
+
+
+class TestRequestBuilding:
+    def test_build_search_request_targets_esearch(self, spider: PMCSpider) -> None:
+        request = spider.build_search_request("university of washington")
+        parsed = urlparse(request.url)
+        query = parse_qs(parsed.query)
+
+        assert parsed.path.endswith("/esearch.fcgi")
+        assert request.meta == {"search_term": "university of washington", "retstart": 0}
+        assert query["db"] == ["pmc"]
+        assert query["retmode"] == ["json"]
+        assert query["retmax"] == ["100"]
+        assert query["retstart"] == ["0"]
+        assert query["email"][0]
+        assert query["tool"] == ["open_ire"]
+
+    def test_query_restricts_to_oa_affiliation(self, spider: PMCSpider) -> None:
+        request = spider.build_search_request("university of washington")
+        term = parse_qs(urlparse(request.url).query)["term"][0]
+        assert term == '"university of washington"[Affiliation] AND open access[filter]'
+
+    def test_api_key_included_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NCBI_API_KEY", "secret-key")
+        spider = PMCSpider(terms="x")
+        request = spider.build_search_request("x")
+        assert parse_qs(urlparse(request.url).query)["api_key"] == ["secret-key"]
+
+    def test_esummary_request_batches_uids(self, spider: PMCSpider) -> None:
+        request = spider._build_esummary_request("term", ["111", "222", "333"])
+        parsed = urlparse(request.url)
+        query = parse_qs(parsed.query)
+
+        assert parsed.path.endswith("/esummary.fcgi")
+        assert query["id"] == ["111,222,333"]
+        assert request.callback == spider.parse_summary
+        assert request.meta == {"search_term": "term"}
+
+
+class TestParseEsearch:
+    def test_yields_summary_request_and_pagination(self, spider: PMCSpider) -> None:
+        payload = {"esearchresult": {"count": "250", "idlist": ["1", "2", "3"]}}
+        response = _json_response(
+            "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
+            payload,
+            meta={"search_term": "uw", "retstart": 0},
+        )
+
+        outputs = list(spider.parse(response))
+
+        assert len(outputs) == 2
+        summary_request, next_page = outputs
+        assert summary_request.callback == spider.parse_summary
+        assert parse_qs(urlparse(summary_request.url).query)["id"] == ["1,2,3"]
+        assert next_page.callback == spider.parse
+        assert next_page.meta["retstart"] == 100
+
+    def test_stops_pagination_on_last_page(self, spider: PMCSpider) -> None:
+        payload = {"esearchresult": {"count": "2", "idlist": ["1", "2"]}}
+        response = _json_response(
+            "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
+            payload,
+            meta={"search_term": "uw", "retstart": 0},
+        )
+
+        outputs = list(spider.parse(response))
+
+        assert len(outputs) == 1
+        assert outputs[0].callback == spider.parse_summary
+
+    def test_no_results(self, spider: PMCSpider) -> None:
+        payload = {"esearchresult": {"count": "0", "idlist": []}}
+        response = _json_response(
+            "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
+            payload,
+            meta={"search_term": "uw", "retstart": 0},
+        )
+
+        assert list(spider.parse(response)) == []
+
+    def test_invalid_json(self, spider: PMCSpider) -> None:
+        request = Request(
+            "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
+            meta={"search_term": "uw", "retstart": 0},
+        )
+        response = TextResponse(
+            url=request.url, body=b"<not json>", encoding="utf-8", request=request
+        )
+        assert list(spider.parse(response)) == []
+
+
+class TestParseSummary:
+    def _summary_response(self, records: dict[str, Any]) -> TextResponse:
+        payload = {"result": {"uids": list(records.keys()), **records}}
+        return _json_response(
+            "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi",
+            payload,
+            meta={"search_term": "uw"},
+        )
+
+    def _single_item(self, spider: PMCSpider, record: dict[str, Any], uid: str) -> ArticleItem:
+        requests = list(spider.parse_summary(self._summary_response({uid: record})))
+        item: ArticleItem = next(iter(requests)).cb_kwargs["item"]
+        return item
+
+    def test_yields_oa_request_carrying_item(self, spider: PMCSpider) -> None:
+        response = self._summary_response({"9876543": SAMPLE_RECORD})
+
+        outputs = list(spider.parse_summary(response))
+
+        assert len(outputs) == 1
+        request = outputs[0]
+        assert request.callback == spider.parse_oa_listing
+        assert request.errback == spider.handle_oa_error
+        query = parse_qs(urlparse(request.url).query)
+        assert "s3.amazonaws.com" in request.url
+        assert query["prefix"] == ["PMC9876543"]
+
+        item = request.cb_kwargs["item"]
+        assert isinstance(item, ArticleItem)
+        assert item.title == "Ocean Acidification in the Salish Sea"
+        assert item.reference == "PMC9876543"
+        assert item.repository == "pmc"
+        assert item.url == "https://pmc.ncbi.nlm.nih.gov/articles/PMC9876543/"
+        assert item.file_urls == []
+        assert item.doi == "10.1234/marbio.2024.99"
+        assert item.publication_date == date(2024, 3, 15)
+        assert item.authors == "Habell-Pallán, M; Smith, JA"
+        assert item.extra == {
+            "journal_name": "Marine Biology",
+            "volume": "12",
+            "issue": "3",
+            "pages": "100-110",
+            "pmid": "33445566",
+        }
+
+    def test_falls_back_to_pubdate(self, spider: PMCSpider) -> None:
+        record = {**SAMPLE_RECORD}
+        del record["sortdate"]
+        record["epubdate"] = ""
+        record["pubdate"] = "2022 Jul 04"
+        item = self._single_item(spider, record, "9876543")
+        assert item.publication_date == date(2022, 7, 4)
+
+    def test_skips_record_missing_title(self, spider: PMCSpider) -> None:
+        record = {**SAMPLE_RECORD, "title": ""}
+        assert list(spider.parse_summary(self._summary_response({"9876543": record}))) == []
+
+    def test_derives_pmcid_from_uid(self, spider: PMCSpider) -> None:
+        record = {"uid": "55555", "title": "No articleids here", "articleids": []}
+        item = self._single_item(spider, record, "55555")
+        assert item.reference == "PMC55555"
+
+    def test_skips_non_dict_entries(self, spider: PMCSpider) -> None:
+        payload = {"result": {"uids": ["1"], "1": "not-a-dict"}}
+        response = _json_response(
+            "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi",
+            payload,
+            meta={"search_term": "uw"},
+        )
+        assert list(spider.parse_summary(response)) == []
+
+
+class TestParseOAListing:
+    def _item(self, reference: str = "PMC9876543") -> ArticleItem:
+        return ArticleItem(
+            reference=reference,
+            repository="pmc",
+            title="Ocean Acidification in the Salish Sea",
+            url=f"https://pmc.ncbi.nlm.nih.gov/articles/{reference}/",
+        )
+
+    def test_attaches_main_pdf_link(self, spider: PMCSpider) -> None:
+        item = self._item()
+        listing = _s3_listing(
+            [
+                "PMC9876543.1/PMC9876543.1.json",
+                "PMC9876543.1/PMC9876543.1.pdf",
+                "PMC9876543.1/supplement.pdf",
+                "PMC9876543.1/fig01.jpg",
+            ]
+        )
+        outputs = list(spider.parse_oa_listing(_s3_response(listing, item), item=item))
+
+        assert outputs == [item]
+        assert item.file_urls == [
+            "https://pmc-oa-opendata.s3.amazonaws.com/PMC9876543.1/PMC9876543.1.pdf"
+        ]
+
+    def test_prefers_highest_version(self, spider: PMCSpider) -> None:
+        item = self._item()
+        listing = _s3_listing(["PMC9876543.1/PMC9876543.1.pdf", "PMC9876543.2/PMC9876543.2.pdf"])
+        list(spider.parse_oa_listing(_s3_response(listing, item), item=item))
+        assert item.file_urls == [
+            "https://pmc-oa-opendata.s3.amazonaws.com/PMC9876543.2/PMC9876543.2.pdf"
+        ]
+
+    def test_ignores_neighbouring_pmcid_prefix(self, spider: PMCSpider) -> None:
+        item = self._item(reference="PMC123")
+        # A prefix query for "PMC123" also returns "PMC1230"; only the exact id wins.
+        listing = _s3_listing(["PMC1230.1/PMC1230.1.pdf", "PMC123.1/PMC123.1.pdf"])
+        list(spider.parse_oa_listing(_s3_response(listing, item), item=item))
+        assert item.file_urls == ["https://pmc-oa-opendata.s3.amazonaws.com/PMC123.1/PMC123.1.pdf"]
+
+    def test_no_pdf_yields_item_without_file(self, spider: PMCSpider) -> None:
+        item = self._item()
+        listing = _s3_listing(["PMC9876543.1/PMC9876543.1.xml"])
+        outputs = list(spider.parse_oa_listing(_s3_response(listing, item), item=item))
+
+        assert outputs == [item]
+        assert item.file_urls == []
+
+    def test_empty_listing_yields_item_without_file(self, spider: PMCSpider) -> None:
+        item = self._item()
+        outputs = list(spider.parse_oa_listing(_s3_response(_s3_listing([]), item), item=item))
+
+        assert outputs == [item]
+        assert item.file_urls == []
+
+    def test_oa_lookup_request_url(self, spider: PMCSpider) -> None:
+        request = spider._build_oa_lookup_request(self._item())
+        query = parse_qs(urlparse(request.url).query)
+        assert request.url.startswith("https://pmc-oa-opendata.s3.amazonaws.com/?")
+        assert query["prefix"] == ["PMC9876543"]
+        assert query["list-type"] == ["2"]
+
+    def test_select_pdf_key_returns_none_without_match(self) -> None:
+        assert PMCSpider._select_pdf_key("PMC9876543", []) is None
+        assert PMCSpider._select_pdf_key("PMC9876543", ["PMC9876543.1/other.pdf"]) is None
+
+    def test_handle_oa_error_yields_item(self, spider: PMCSpider) -> None:
+        item = self._item()
+        failure = MagicMock()
+        failure.request.cb_kwargs = {"item": item}
+        assert list(spider.handle_oa_error(failure)) == [item]
+        assert item.file_urls == []
+
+
+class TestHelpers:
+    def test_extract_pmcid_strips_version(self) -> None:
+        record = {"articleids": [{"idtype": "pmcid", "value": "PMC123.1"}]}
+        assert PMCSpider._extract_pmcid(record) == "PMC123"
+
+    def test_format_author_name(self) -> None:
+        assert PMCSpider._format_author_name("Smith JA") == "Smith, JA"
+        assert PMCSpider._format_author_name("van der Berg J") == "van der Berg, J"
+        assert PMCSpider._format_author_name("Madonna") == "Madonna"
+
+    def test_extract_authors_empty(self) -> None:
+        assert PMCSpider._extract_authors({"authors": []}) is None
+        assert PMCSpider._extract_authors({}) is None

--- a/tests/spiders/test_pmc.py
+++ b/tests/spiders/test_pmc.py
@@ -119,18 +119,26 @@ class TestRequestBuilding:
         request = spider.build_search_request("x")
         assert parse_qs(urlparse(request.url).query)["api_key"] == ["secret-key"]
 
-    def test_esummary_request_batches_uids(self, spider: PMCSpider) -> None:
-        request = spider._build_esummary_request("term", ["111", "222", "333"])
-        parsed = urlparse(request.url)
-        query = parse_qs(parsed.query)
-
-        assert parsed.path.endswith("/esummary.fcgi")
-        assert query["id"] == ["111,222,333"]
-        assert request.callback == spider.parse_summary
-        assert request.meta == {"search_term": "term"}
-
 
 class TestParseEsearch:
+    def test_one_esummary_request_per_esearch_page(self, spider: PMCSpider) -> None:
+        # A whole page of UIDs must collapse into a single esummary request;
+        # one-request-per-UID would blow the NCBI rate limit. That decision lives
+        # in ``parse``, so drive it there rather than calling the helper directly.
+        esearch = _json_response(
+            "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
+            {"esearchresult": {"count": "3", "idlist": ["111", "222", "333"]}},
+            meta={"search_term": "term", "retstart": 0},
+        )
+
+        requests = list(spider.parse(esearch))
+
+        summary_requests = [r for r in requests if r.callback == spider.parse_summary]
+        assert len(summary_requests) == 1
+        parsed = urlparse(summary_requests[0].url)
+        assert parsed.path.endswith("/esummary.fcgi")
+        assert parse_qs(parsed.query)["id"] == ["111,222,333"]
+
     def test_yields_summary_request_and_pagination(self, spider: PMCSpider) -> None:
         payload = {"esearchresult": {"count": "250", "idlist": ["1", "2", "3"]}}
         response = _json_response(
@@ -252,6 +260,35 @@ class TestParseSummary:
             meta={"search_term": "uw"},
         )
         assert list(spider.parse_summary(response)) == []
+
+    def test_collective_authors_routed_to_extra(self, spider: PMCSpider) -> None:
+        # Organizational authors must not leak into the personal-author string
+        # (HumanName would mangle "GeKeR Study Group" into a bogus person row);
+        # they are preserved verbatim under extra instead. See issue #125.
+        record = {
+            **SAMPLE_RECORD,
+            "authors": [
+                {"name": "Smith JA", "authtype": "Author"},
+                {"name": "GeKeR Study Group", "authtype": "CollectiveName"},
+            ],
+        }
+        item = self._single_item(spider, record, "9876543")
+
+        assert item.authors == "Smith, JA"
+        assert "GeKeR" not in (item.authors or "")
+        assert item.extra["collective_authors"] == ["GeKeR Study Group"]
+
+    @pytest.mark.xfail(reason="#125: consortium authors not yet first-class")
+    def test_collective_authors_are_preserved(self, spider: PMCSpider) -> None:
+        record = {
+            **SAMPLE_RECORD,
+            "authors": [
+                {"name": "Smith JA", "authtype": "Author"},
+                {"name": "GeKeR Study Group", "authtype": "CollectiveName"},
+            ],
+        }
+        item = self._single_item(spider, record, "9876543")
+        assert "GeKeR Study Group" in (item.authors or "")
 
 
 class TestParseOAListing:


### PR DESCRIPTION
## Summary

Adds a `pmc` spider that collects open-access articles (metadata + full-text PDFs) from **PubMed Central** using NCBI's public services. It follows the existing `TermSearchSpider` pattern (same family as the OSTI spider).

### Crawl flow
1. **esearch.fcgi** — finds PMC UIDs for each search term, restricted to the open-access subset and UW affiliation (`"<term>"[Affiliation] AND open access[filter]`), paginated via `retstart`/`retmax`.
2. **esummary.fcgi** — provides article metadata (title, authors, journal, DOI/PMID, publication date) for a batch of UIDs.
3. **PMC OA Subset on AWS** (`pmc-oa-opendata` S3 bucket) — listed per article to locate and download the full-text PDF over HTTPS.

### Why the AWS OA Subset bucket for downloads
Two more obvious NCBI routes were tried and rejected because they don't actually work for programmatic download:
- The web `…/articles/PMC<id>/pdf/` endpoint is served behind a **bot-verification interstitial** (returns HTML, not the PDF).
- The legacy **`oa.fcgi`** OA Web Service only returns `ftp://` links that **no longer resolve** (`550 file-not-found`).

NCBI's [PMC Open Access Subset on AWS](https://www.ncbi.nlm.nih.gov/pmc/tools/openftlist/) serves the same OA content reliably over HTTPS. Each article lives under `PMC<id>.<version>/` with the main PDF at `PMC<id>.<version>.pdf`; the version (not exposed by esummary) is discovered with a single S3 list request.

### Notes
- Author names are reformatted from NCBI's `"Surname Initials"` form so `ParsedAuthor` parses surname/initials correctly.
- Records with no PDF in the OA Subset still yield metadata (no file).
- An optional `NCBI_API_KEY` env var is included when present (raises the rate limit from 3→10 req/s); `DOWNLOAD_DELAY=1` keeps the unauthenticated crawl within limits.