### PR TITLE
feat(osti): recover missing-PDF articles with polite backoff retry

### DIFF
--- a/src/open_ire/middlewares.py
+++ b/src/open_ire/middlewares.py
@@ -1,0 +1,126 @@
+"""Downloader middlewares for the open_ire project."""
+
+import asyncio
+import logging
+import random
+from typing import Self
+
+from scrapy import Request
+from scrapy.crawler import Crawler
+from scrapy.downloadermiddlewares.retry import get_retry_request
+from scrapy.http import Response
+from twisted.internet.error import ConnectError, ConnectionDone, ConnectionLost
+from twisted.internet.error import TimeoutError as TxTimeoutError
+from twisted.web.client import ResponseFailed
+
+logger = logging.getLogger(__name__)
+
+
+class BackoffRetryMiddleware:
+    """Retry rate-limited or dropped downloads with exponential backoff.
+
+    Some servers (e.g. OSTI's ``/servlets/purl/`` fulltext endpoint) answer
+    request bursts with HTTP 503 or drop the connection instead of failing
+    permanently. Scrapy's built-in ``RetryMiddleware`` retries immediately,
+    which keeps hitting the same rate limit. This middleware instead waits
+    with exponential backoff (plus jitter) before each retry, and gives up
+    after ``OPEN_IRE_BACKOFF_RETRY_TIMES`` attempts so genuinely dead links
+    are skipped (and logged) rather than retried forever.
+
+    DNS lookup failures are deliberately not handled here: a host that no
+    longer resolves is dead, and the built-in ``RetryMiddleware`` already
+    gives those a couple of quick retries before the file is skipped.
+
+    Enable per spider via ``custom_settings``::
+
+        "DOWNLOADER_MIDDLEWARES": {
+            "open_ire.middlewares.BackoffRetryMiddleware": 560,
+        }
+
+    Settings (all optional):
+
+    - ``OPEN_IRE_BACKOFF_RETRY_TIMES``: max retries per request (default 5)
+    - ``OPEN_IRE_BACKOFF_BASE_DELAY``: first delay in seconds (default 5)
+    - ``OPEN_IRE_BACKOFF_MAX_DELAY``: delay cap in seconds (default 120)
+    """
+
+    RETRY_STATUSES = frozenset({429, 503})
+    RETRY_EXCEPTIONS = (
+        ConnectError,
+        ConnectionDone,
+        ConnectionLost,
+        ResponseFailed,
+        TxTimeoutError,
+    )
+
+    def __init__(
+        self,
+        max_retries: int,
+        base_delay: float,
+        max_delay: float,
+        crawler: Crawler | None = None,
+    ) -> None:
+        self.max_retries = max_retries
+        self.base_delay = base_delay
+        self.max_delay = max_delay
+        self.crawler = crawler
+
+    @classmethod
+    def from_crawler(cls, crawler: Crawler) -> Self:
+        settings = crawler.settings
+        return cls(
+            max_retries=settings.getint("OPEN_IRE_BACKOFF_RETRY_TIMES", 5),
+            base_delay=settings.getfloat("OPEN_IRE_BACKOFF_BASE_DELAY", 5.0),
+            max_delay=settings.getfloat("OPEN_IRE_BACKOFF_MAX_DELAY", 120.0),
+            crawler=crawler,
+        )
+
+    def _delay(self, retry_times: int) -> float:
+        delay = min(self.base_delay * (2.0**retry_times), self.max_delay)
+        return delay * random.uniform(0.75, 1.25)
+
+    async def _retry(self, request: Request, reason: str) -> Request | None:
+        if self.crawler is None or self.crawler.spider is None:
+            msg = "BackoffRetryMiddleware requires a crawler with a running spider."
+            raise RuntimeError(msg)
+
+        retry_times: int = request.meta.get("retry_times", 0)
+        new_request = get_retry_request(
+            request,
+            spider=self.crawler.spider,
+            reason=reason,
+            max_retry_times=self.max_retries,
+        )
+        if new_request is None:
+            logger.warning(
+                "Giving up on %s after %d backoff retries (%s); skipping.",
+                request.url,
+                retry_times,
+                reason,
+            )
+            return None
+
+        delay = self._delay(retry_times)
+        logger.info(
+            "Backing off %.1fs before retry %d/%d for %s (%s)",
+            delay,
+            retry_times + 1,
+            self.max_retries,
+            request.url,
+            reason,
+        )
+        await asyncio.sleep(delay)
+        return new_request
+
+    async def process_response(self, request: Request, response: Response) -> Request | Response:
+        if response.status not in self.RETRY_STATUSES:
+            return response
+
+        retried = await self._retry(request, f"HTTP {response.status}")
+        return response if retried is None else retried
+
+    async def process_exception(self, request: Request, exception: Exception) -> Request | None:
+        if not isinstance(exception, self.RETRY_EXCEPTIONS):
+            return None
+
+        return await self._retry(request, type(exception).__name__)

--- a/src/open_ire/pipelines/doi_duplicates_pipeline.py
+++ b/src/open_ire/pipelines/doi_duplicates_pipeline.py
@@ -58,9 +58,15 @@ class DOIDuplicatesPipeline(BaseSQLModelPipeline):
         if doi not in self._doi_to_article:
             return item
 
+        cached = self._doi_to_article[doi]
+        if cached.repository == item.repository and cached.reference == item.reference:
+            # The DOI belongs to this very article (re-crawl), not to a
+            # duplicate; let it through so downstream pipelines can update
+            # it and re-attempt any missing file downloads.
+            return item
+
         assert self.engine is not None
         with Session(self.engine) as session:
-            cached = self._doi_to_article[doi]
             existing_article = session.exec(
                 select(Article).where(
                     Article.repository == cached.repository,

--- a/src/open_ire/pipelines/skip_existing_pipeline.py
+++ b/src/open_ire/pipelines/skip_existing_pipeline.py
@@ -3,9 +3,10 @@ from typing import Any
 
 from scrapy.crawler import Crawler
 from scrapy.exceptions import DropItem
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from open_ire.items import ArticleItem
+from open_ire.models import Article, ArticleFile
 from open_ire.pipelines.base_sql_model_pipeline import BaseSQLModelPipeline
 
 logger = logging.getLogger(__name__)
@@ -16,11 +17,24 @@ class SkipExistingPipeline(BaseSQLModelPipeline):
     Skips items that already exist in the database.
 
     Intended to short-circuit file downloads and downstream pipelines when OPEN_IRE_SKIP_EXISTING is enabled.
+
+    When OPEN_IRE_SKIP_EXISTING_REQUIRES_FILES is also enabled (opt-in, per
+    spider), existing articles without any stored file are NOT skipped, so
+    previously failed file downloads get re-attempted on each run.
     """
 
     @staticmethod
     def _should_skip_existing(crawler: Crawler) -> bool:
         return bool(crawler.settings.getbool("OPEN_IRE_SKIP_EXISTING", False))
+
+    @staticmethod
+    def _skip_requires_files(crawler: Crawler) -> bool:
+        return crawler.settings.getbool("OPEN_IRE_SKIP_EXISTING_REQUIRES_FILES", False)
+
+    @staticmethod
+    def _has_stored_files(session: Session, article: Article) -> bool:
+        statement = select(ArticleFile).where(ArticleFile.article_id == article.id)
+        return session.exec(statement).first() is not None
 
     def open_spider(self) -> None:
         if self.crawler is None or not self._should_skip_existing(self.crawler):
@@ -36,7 +50,17 @@ class SkipExistingPipeline(BaseSQLModelPipeline):
             return item
 
         with Session(self.engine) as session:
-            if self.find_existing_article(session, item) is not None:
+            existing_article = self.find_existing_article(session, item)
+            if (
+                existing_article is not None
+                and self._skip_requires_files(self.crawler)
+                and not self._has_stored_files(session, existing_article)
+            ):
+                # Article is known but its file download previously failed;
+                # let it through so the file is re-attempted.
+                existing_article = None
+
+            if existing_article is not None:
                 if self.crawler.spider:
                     self.crawler.spider.logger.info(
                         "Skipping existing article '%s' from repository '%s'.",

--- a/src/open_ire/spiders/osti.py
+++ b/src/open_ire/spiders/osti.py
@@ -51,6 +51,17 @@ class OstiSpider(TermSearchSpider):
         # ROBOTSTXT_OBEY=True was incorrectly applying Googlebot rules as a
         # fallback and blocking PDF downloads that OSTI explicitly allows.
         "ROBOTSTXT_OBEY": False,
+        # OSTI rate-limits bursts of fulltext PDF downloads with HTTP 503 or
+        # dropped connections; waiting and retrying recovers them (verified
+        # on 75/75 sampled failures). Retry those politely with exponential
+        # backoff instead of the built-in immediate retries.
+        "DOWNLOADER_MIDDLEWARES": {
+            "open_ire.middlewares.BackoffRetryMiddleware": 560,
+        },
+        # When OPEN_IRE_SKIP_EXISTING is enabled, still re-process articles
+        # whose PDF download previously failed so their files get another
+        # attempt on each run.
+        "OPEN_IRE_SKIP_EXISTING_REQUIRES_FILES": True,
     }
 
     def build_search_request(self, term: str) -> Request:

--- a/tests/pipelines/test_doi_duplicates_pipeline.py
+++ b/tests/pipelines/test_doi_duplicates_pipeline.py
@@ -108,6 +108,31 @@ class TestDOIDuplicatesPipeline:
                 {"repository": "wos", "reference": "WOS:000123", "title": "Same Article from WoS"}
             ]
 
+    def test_passes_through_same_article_on_recrawl(
+        self,
+        pipeline_with_existing: DOIDuplicatesPipeline,
+    ) -> None:
+        """Re-crawling the article that owns the DOI must not drop it as its own duplicate."""
+        pipeline = pipeline_with_existing
+        assert pipeline.engine is not None
+        same_item = ArticleItem(
+            title="Existing Article",
+            authors="Author One",
+            publication_date=date(2024, 1, 15),
+            repository="openalex",
+            reference="OA123",
+            url="https://doi.org/10.1234/test",
+            doi="10.1234/test",
+        )
+
+        result = pipeline.process_item(same_item)
+
+        assert result is same_item
+        with Session(pipeline.engine) as session:
+            article = session.exec(select(Article).where(Article.doi == "10.1234/test")).first()
+            assert article is not None
+            assert "duplicate_sources" not in article.extra
+
     @pytest.mark.parametrize(
         ("pipeline_with_existing", "incoming_doi"),
         [

--- a/tests/pipelines/test_skip_existing_pipeline.py
+++ b/tests/pipelines/test_skip_existing_pipeline.py
@@ -8,7 +8,7 @@ from scrapy.exceptions import DropItem
 from sqlmodel import Session
 
 from open_ire.items import ArticleItem
-from open_ire.models import Article
+from open_ire.models import Article, ArticleFile
 from open_ire.pipelines import SkipExistingPipeline
 
 
@@ -76,6 +76,58 @@ class TestSkipExistingPipeline:
                 url=item.url,
             )
             session.add(article)
+            session.commit()
+
+        with pytest.raises(DropItem):
+            pipeline_enabled.process_item(item)
+
+    @staticmethod
+    def _save_article(pipeline: SkipExistingPipeline, item: ArticleItem) -> Article:
+        assert pipeline.engine is not None
+        with Session(pipeline.engine) as session:
+            article = Article(
+                title=item.title,
+                authors=item.authors,
+                publication_date=item.publication_date,
+                repository=item.repository,
+                reference=item.reference,
+                url=item.url,
+            )
+            session.add(article)
+            session.commit()
+            session.refresh(article)
+
+        return article
+
+    def test_requires_files_passes_existing_article_without_files(
+        self, pipeline_enabled: SkipExistingPipeline, item: ArticleItem
+    ) -> None:
+        """With the opt-in flag, a known article whose file download failed is re-processed."""
+        assert pipeline_enabled.crawler is not None
+        pipeline_enabled.crawler.settings.set("OPEN_IRE_SKIP_EXISTING_REQUIRES_FILES", True)
+        self._save_article(pipeline_enabled, item)
+
+        result = pipeline_enabled.process_item(item)
+
+        assert result is item
+
+    def test_requires_files_skips_existing_article_with_files(
+        self, pipeline_enabled: SkipExistingPipeline, item: ArticleItem
+    ) -> None:
+        assert pipeline_enabled.crawler is not None
+        pipeline_enabled.crawler.settings.set("OPEN_IRE_SKIP_EXISTING_REQUIRES_FILES", True)
+        article = self._save_article(pipeline_enabled, item)
+
+        assert pipeline_enabled.engine is not None
+        with Session(pipeline_enabled.engine) as session:
+            session.add(
+                ArticleFile(
+                    article_id=article.id,
+                    url="https://example.com/article/001.pdf",
+                    path="test_repo/001.pdf",
+                    checksum="abcde12345",
+                )
+            )
             session.commit()
 
         with pytest.raises(DropItem):

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -1,0 +1,136 @@
+import asyncio
+from collections.abc import Callable, Coroutine, Generator
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+from scrapy import Request, Spider
+from scrapy.crawler import Crawler
+from scrapy.http import Response
+from scrapy.settings import Settings
+from scrapy.statscollectors import MemoryStatsCollector
+from twisted.internet.error import ConnectionLost, DNSLookupError
+
+from open_ire.middlewares import BackoffRetryMiddleware
+
+RunCoroutine = Callable[[Coroutine[Any, Any, Any]], Any]
+
+
+class TestBackoffRetryMiddleware:
+    """Tests the BackoffRetryMiddleware backoff, give-up, and pass-through behavior."""
+
+    @pytest.fixture
+    def run(self) -> Generator[RunCoroutine, None, None]:
+        """Run a coroutine on a private event loop, without touching global loop state."""
+        loop = asyncio.new_event_loop()
+        yield loop.run_until_complete
+        loop.close()
+
+    @pytest.fixture
+    def crawler(self) -> Crawler:
+        mock_crawler = MagicMock(spec=Crawler)
+        mock_crawler.settings = Settings(
+            {
+                "OPEN_IRE_BACKOFF_RETRY_TIMES": 3,
+                "OPEN_IRE_BACKOFF_BASE_DELAY": 0.001,
+                "OPEN_IRE_BACKOFF_MAX_DELAY": 0.002,
+            }
+        )
+        mock_crawler.stats = MemoryStatsCollector(mock_crawler)
+
+        spider = Spider(name="test_spider")
+        spider.crawler = mock_crawler
+        mock_crawler.spider = spider
+
+        return cast(Crawler, mock_crawler)
+
+    @pytest.fixture
+    def middleware(self, crawler: Crawler) -> BackoffRetryMiddleware:
+        return BackoffRetryMiddleware.from_crawler(crawler)
+
+    @pytest.fixture
+    def request_(self) -> Request:
+        return Request("https://www.osti.gov/servlets/purl/1016225")
+
+    def test_from_crawler_reads_settings(self, middleware: BackoffRetryMiddleware) -> None:
+        assert middleware.max_retries == 3
+        assert middleware.base_delay == 0.001
+        assert middleware.max_delay == 0.002
+
+    def test_passes_through_ok_response(
+        self, middleware: BackoffRetryMiddleware, request_: Request, run: RunCoroutine
+    ) -> None:
+        response = Response(request_.url, status=200, request=request_)
+
+        result = run(middleware.process_response(request_, response))
+
+        assert result is response
+
+    def test_passes_through_non_retryable_error_status(
+        self, middleware: BackoffRetryMiddleware, request_: Request, run: RunCoroutine
+    ) -> None:
+        """403/404 are permanent failures and must not be retried."""
+        for status in (403, 404):
+            response = Response(request_.url, status=status, request=request_)
+
+            result = run(middleware.process_response(request_, response))
+
+            assert result is response
+
+    def test_retries_rate_limited_response(
+        self, middleware: BackoffRetryMiddleware, request_: Request, run: RunCoroutine
+    ) -> None:
+        response = Response(request_.url, status=503, request=request_)
+
+        result = run(middleware.process_response(request_, response))
+
+        assert isinstance(result, Request)
+        assert result.meta["retry_times"] == 1
+        assert result.dont_filter is True
+
+    def test_gives_up_on_rate_limit_after_max_retries(
+        self, middleware: BackoffRetryMiddleware, request_: Request, run: RunCoroutine
+    ) -> None:
+        exhausted = request_.replace(meta={"retry_times": middleware.max_retries})
+        response = Response(exhausted.url, status=503, request=exhausted)
+
+        result = run(middleware.process_response(exhausted, response))
+
+        assert result is response
+
+    def test_retries_dropped_connection(
+        self, middleware: BackoffRetryMiddleware, request_: Request, run: RunCoroutine
+    ) -> None:
+        result = run(middleware.process_exception(request_, ConnectionLost("dropped")))
+
+        assert isinstance(result, Request)
+        assert result.meta["retry_times"] == 1
+
+    def test_gives_up_on_dropped_connection_after_max_retries(
+        self, middleware: BackoffRetryMiddleware, request_: Request, run: RunCoroutine
+    ) -> None:
+        exhausted = request_.replace(meta={"retry_times": middleware.max_retries})
+
+        result = run(middleware.process_exception(exhausted, ConnectionLost("dropped")))
+
+        assert result is None
+
+    def test_ignores_dns_failure(
+        self, middleware: BackoffRetryMiddleware, request_: Request, run: RunCoroutine
+    ) -> None:
+        """Dead hosts (DNS gone) are left to the built-in RetryMiddleware."""
+        result = run(middleware.process_exception(request_, DNSLookupError("no such host")))
+
+        assert result is None
+
+    def test_delay_backs_off_exponentially_within_jitter(self) -> None:
+        middleware = BackoffRetryMiddleware(max_retries=5, base_delay=4.0, max_delay=1000.0)
+
+        for retry_times, base in ((0, 4.0), (1, 8.0), (3, 32.0)):
+            delay = middleware._delay(retry_times)
+            assert base * 0.75 <= delay <= base * 1.25
+
+    def test_delay_is_capped(self) -> None:
+        middleware = BackoffRetryMiddleware(max_retries=5, base_delay=4.0, max_delay=10.0)
+
+        assert middleware._delay(10) <= 10.0 * 1.25


### PR DESCRIPTION
Recovers fulltext PDFs for OSTI articles that previously failed to download, using polite retry within the normal spider run — no identity spoofing or WAF evasion.

## Background

A prior OSTI crawl left ~6,800 articles without a stored PDF. Investigation showed most failures were **HTTP 503 / dropped connections** from OSTI's `/servlets/purl/` endpoint rate-limiting bursts of downloads — not missing files. A sampled re-fetch after a pause recovered 75/75 of them as real PDFs served directly by OSTI. The remainder are genuine dead hosts (e.g. `efw.bpa.gov` no longer resolves) or deliberate WAF blocks (403), which are correctly skipped rather than retried.

## Changes

**1. `BackoffRetryMiddleware`** (new, enabled only in OSTI `custom_settings`)
- Retries `503`/`429` responses and dropped connections with exponential backoff + jitter, instead of Scrapy's immediate retries that keep hitting the same rate limit.
- Gives up after a configurable number of attempts (default 5) so dead links are skipped and logged, never retried forever.
- `403` (WAF) and `404` pass straight through — no retries. DNS-dead hosts are left to the built-in `RetryMiddleware` so they fail fast.
- Non-blocking: the backoff wait happens after the download slot is freed, so other downloads continue.

**2. Opt-in `OPEN_IRE_SKIP_EXISTING_REQUIRES_FILES`** (enabled for OSTI only)
- With `OPEN_IRE_SKIP_EXISTING`, articles already in the DB **that have a stored file** are skipped, but file-less ones are re-processed so their PDF gets another attempt — without re-downloading the complete ones.

**3. Fix: don't drop an article as its own DOI duplicate on re-crawl** (`DOIDuplicatesPipeline`)
- On a re-crawl, an already-collected article's own DOI was in the dedup cache, so the pipeline dropped it as a duplicate of itself before it could reach the file-download step — which blocked missing-PDF recovery entirely.
- Now skips duplicate handling when the cached DOI owner is the same `(repository, reference)` as the incoming item. Cross-repository dedup is unchanged. This is a general correctness fix; first-time crawls and cross-repo duplicates behave exactly as before.
- Fixes #113

## Scope / safety

- The middleware and the skip-existing modifier are wired **only** in OSTI's `custom_settings`; no other spider's behavior changes.
- The `DOIDuplicatesPipeline` fix touches a shared pipeline but only affects the previously-broken self-duplicate case; a second reviewer on that file is welcome.

## Testing

- Deterministic end-to-end harness through the real media pipeline: 503-recovers-after-pause, perpetual-503 gives up and skips, 403 skipped immediately with zero retries, healthy PDF downloads first try.
- Live OSTI crawl (fresh DB): downloads PDFs, dead hosts quick-fail on DNS.
- Live OSTI crawl against a copy of the prior run's DB with `--skip-existing`: complete articles skipped, file-less articles pass through to re-attempt, dead-host links skipped.
- Full suite: 295 tests pass; ruff and mypy clean.

## Usage

Recovery run (against the DB holding the prior articles):

```
ENVIRONMENT=production pixi run resume osti --skip-existing
```