### PR TITLE
refactor(models): Use snake_case in table names

### DIFF
--- a/src/open_ire/migrations/versions/473c9757ac3f_snake_case_table_names.py
+++ b/src/open_ire/migrations/versions/473c9757ac3f_snake_case_table_names.py
@@ -1,0 +1,154 @@
+"""Make table names use snake_case
+
+Revision ID: 473c9757ac3f
+Revises: de4a71ae327c
+Create Date: 2026-07-29 15:10:32.483572
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "473c9757ac3f"
+down_revision: str | None = "de4a71ae327c"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.rename_table("articledepositstatustransition", "article_deposit_status_transition")
+    op.rename_table("articlefile", "article_file")
+    op.rename_table("articlefilereference", "article_file_reference")
+    op.rename_table("articleoaevidence", "article_oa_evidence")
+    op.rename_table("authoraffiliation", "author_affiliation")
+    op.rename_table("authoridentifier", "author_identifier")
+
+    with op.batch_alter_table("article_deposit_status_transition", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_articledepositstatustransition_article_id"))
+        batch_op.drop_index(batch_op.f("ix_articledepositstatustransition_changed_at"))
+        batch_op.drop_index(batch_op.f("ix_articledepositstatustransition_from_status"))
+        batch_op.drop_index(batch_op.f("ix_articledepositstatustransition_to_status"))
+        batch_op.create_index(
+            batch_op.f("ix_article_deposit_status_transition_article_id"),
+            ["article_id"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_article_deposit_status_transition_changed_at"),
+            ["changed_at"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_article_deposit_status_transition_from_status"),
+            ["from_status"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_article_deposit_status_transition_to_status"),
+            ["to_status"],
+            unique=False,
+        )
+
+    with op.batch_alter_table("article_file", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_articlefile_created_at"))
+        batch_op.create_index(
+            batch_op.f("ix_article_file_created_at"), ["created_at"], unique=False
+        )
+
+    with op.batch_alter_table("article_file_reference", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_articlefilereference_created_at"))
+        batch_op.create_index(
+            batch_op.f("ix_article_file_reference_created_at"), ["created_at"], unique=False
+        )
+
+    with op.batch_alter_table("article_oa_evidence", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_articleoaevidence_article_id"))
+        batch_op.drop_index(batch_op.f("ix_articleoaevidence_created_at"))
+        batch_op.drop_index(batch_op.f("ix_articleoaevidence_kind"))
+        batch_op.create_index(
+            batch_op.f("ix_article_oa_evidence_article_id"), ["article_id"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_article_oa_evidence_created_at"), ["created_at"], unique=False
+        )
+        batch_op.create_index(batch_op.f("ix_article_oa_evidence_kind"), ["kind"], unique=False)
+
+    with op.batch_alter_table("author_affiliation", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_authoraffiliation_year"))
+        batch_op.create_index(batch_op.f("ix_author_affiliation_year"), ["year"], unique=False)
+
+    with op.batch_alter_table("author_identifier", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_authoridentifier_authority"))
+        batch_op.drop_index(batch_op.f("ix_authoridentifier_identifier"))
+        batch_op.create_index(
+            batch_op.f("ix_author_identifier_authority"), ["authority"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_author_identifier_identifier"), ["identifier"], unique=False
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("author_identifier", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_author_identifier_identifier"))
+        batch_op.drop_index(batch_op.f("ix_author_identifier_authority"))
+        batch_op.create_index(
+            batch_op.f("ix_authoridentifier_identifier"), ["identifier"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_authoridentifier_authority"), ["authority"], unique=False
+        )
+
+    with op.batch_alter_table("author_affiliation", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_author_affiliation_year"))
+        batch_op.create_index(batch_op.f("ix_authoraffiliation_year"), ["year"], unique=False)
+
+    with op.batch_alter_table("article_oa_evidence", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_article_oa_evidence_kind"))
+        batch_op.drop_index(batch_op.f("ix_article_oa_evidence_created_at"))
+        batch_op.drop_index(batch_op.f("ix_article_oa_evidence_article_id"))
+        batch_op.create_index(batch_op.f("ix_articleoaevidence_kind"), ["kind"], unique=False)
+        batch_op.create_index(
+            batch_op.f("ix_articleoaevidence_created_at"), ["created_at"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_articleoaevidence_article_id"), ["article_id"], unique=False
+        )
+
+    with op.batch_alter_table("article_file_reference", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_article_file_reference_created_at"))
+        batch_op.create_index(
+            batch_op.f("ix_articlefilereference_created_at"), ["created_at"], unique=False
+        )
+
+    with op.batch_alter_table("article_file", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_article_file_created_at"))
+        batch_op.create_index(batch_op.f("ix_articlefile_created_at"), ["created_at"], unique=False)
+
+    with op.batch_alter_table("article_deposit_status_transition", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_article_deposit_status_transition_to_status"))
+        batch_op.drop_index(batch_op.f("ix_article_deposit_status_transition_from_status"))
+        batch_op.drop_index(batch_op.f("ix_article_deposit_status_transition_changed_at"))
+        batch_op.drop_index(batch_op.f("ix_article_deposit_status_transition_article_id"))
+        batch_op.create_index(
+            batch_op.f("ix_articledepositstatustransition_to_status"), ["to_status"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_articledepositstatustransition_from_status"),
+            ["from_status"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_articledepositstatustransition_changed_at"), ["changed_at"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_articledepositstatustransition_article_id"), ["article_id"], unique=False
+        )
+
+    op.rename_table("author_identifier", "authoridentifier")
+    op.rename_table("author_affiliation", "authoraffiliation")
+    op.rename_table("article_oa_evidence", "articleoaevidence")
+    op.rename_table("article_file_reference", "articlefilereference")
+    op.rename_table("article_file", "articlefile")
+    op.rename_table("article_deposit_status_transition", "articledepositstatustransition")

--- a/src/open_ire/models.py
+++ b/src/open_ire/models.py
@@ -50,6 +50,8 @@ class ArticleBase(SQLModel):
 class Article(ArticleBase, table=True):
     """SQLModel to store article metadata."""
 
+    __tablename__ = "article"
+
     model_config = {"ignored_types": (hybrid_property,)}
 
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
@@ -131,6 +133,8 @@ class ArticleFile(ArticleFileBase, table=True):
     store_url: URL to the remote backup location (e.g., SharePoint).
     """
 
+    __tablename__ = "article_file"
+
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
 
     checksum: str = Field()
@@ -152,6 +156,8 @@ class ArticleFileReference(ArticleFileBase, table=True):
     source_url: URL of the website where the file `url` was found.
     """
 
+    __tablename__ = "article_file_reference"
+
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
 
     source_url: str | None = None
@@ -172,6 +178,8 @@ class ArticleOAEvidence(SQLModel, table=True):
     source: Origin of the evidence (e.g., "crossref", "openalex", "manual").
     data: Source-specific payload for evidence details.
     """
+
+    __tablename__ = "article_oa_evidence"
 
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
     article_id: uuid.UUID = Field(foreign_key="article.id", index=True)
@@ -200,6 +208,8 @@ class ArticleDepositStatusTransition(SQLModel, table=True):
     changed_at: Datetime when the status transition was recorded.
     reasons: Rule or factor identifiers applied in the decision.
     """
+
+    __tablename__ = "article_deposit_status_transition"
 
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
     article_id: uuid.UUID = Field(foreign_key="article.id", index=True)
@@ -242,6 +252,8 @@ class AuthorBase(SQLModel):
 class Author(AuthorBase, table=True):
     """SQLModel to store author information."""
 
+    __tablename__ = "author"
+
     id: int = Field(primary_key=True)
 
     # Relationships
@@ -271,6 +283,8 @@ class AuthorAffiliationBase(SQLModel):
 
 class AuthorAffiliation(AuthorAffiliationBase, table=True):
     """SQLModel to store author affiliations."""
+
+    __tablename__ = "author_affiliation"
 
     id: int = Field(primary_key=True)
 
@@ -310,6 +324,8 @@ class AuthorIdentifierBase(SQLModel):
 class AuthorIdentifier(AuthorIdentifierBase, table=True):
     """SQLModel to store external identifiers for authors."""
 
+    __tablename__ = "author_identifier"
+
     id: int = Field(primary_key=True)
 
     author_id: int = Field(
@@ -344,6 +360,8 @@ class AuthorshipBase(SQLModel):
 
 class Authorship(AuthorshipBase, table=True):
     """SQLModel to store many-to-many relationships between authors and articles."""
+
+    __tablename__ = "authorship"
 
     article_id: uuid.UUID = Field(
         sa_column=Column(


### PR DESCRIPTION
SQLModel (by default?) simply lowercases the class names when it translates them into table names, which ends up with such abominations as `articledepositstatustransition` that is nigh unreadable.

This PR updates `models.py` to manually assign snake_cased table names for each table model and creates a new Alembic migration script to migrate existing databases.

Alembic migration will automatically run the next time the Open-IRE database is written to. To do the migration manually, execute `pixi run alembic upgrade head`.